### PR TITLE
Add new list of infectious agents.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
 
             - name: Run po4a
               shell: bash
-              run: po4a --master-charset utf8 --localized-charset utf8 --verbose po4a.cfg
+              run: |
+                po4a --verbose po4a.cfg
+                po4a --verbose metadata/common/pathogens/po4a.cfg
 
             - name: Build
               shell: pwsh

--- a/metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml
+++ b/metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml
@@ -1,0 +1,25394 @@
+UrlTemplates:
+  ICTV: https://ictv.global/taxonomy/taxondetails?taxnode_id={0}
+  LPSN: https://lpsn.dsmz.de/{0}
+  MycoBank: http://www.mycobank.org/page/Name%20details%20page/field/Mycobank%20%23/{0}
+  NeoIPC: 'TODO: Create URIs for NeoIPC-owned pathogen concepts'
+Hierarchies:
+- Name: Not listed
+  ConceptType: Unknown
+  ConceptId: 1
+  ConceptSource: NeoIPC
+  Id: 0
+  MRSA: true
+  VRE: true
+  3GCR: true
+  Carbapenems: true
+  Colistin: true
+- Name: Viruses
+  ConceptSource: NeoIPC
+  Children:
+  - Name: Duplodnaviria
+    ConceptType: Realm
+    ConceptId: 202407117
+    ConceptSource: ICTV
+    IctvId: 201907117
+    Children:
+    - Name: Heunggongvirae
+      ConceptType: Kingdom
+      ConceptId: 202407118
+      ConceptSource: ICTV
+      IctvId: 201907118
+      Children:
+      - Name: Peploviricota
+        ConceptType: Phylum
+        ConceptId: 202407121
+        ConceptSource: ICTV
+        IctvId: 201907121
+        Children:
+        - Name: Herviviricetes
+          ConceptType: Class
+          ConceptId: 202407122
+          ConceptSource: ICTV
+          IctvId: 201907122
+          Children:
+          - Name: Herpesvirales
+            ConceptType: Order
+            ConceptId: 202401392
+            ConceptSource: ICTV
+            IctvId: 20080002
+            Children:
+            - Name: Orthoherpesviridae
+              ConceptType: Family
+              ConceptId: 202401411
+              ConceptSource: ICTV
+              Id: 3504
+              IctvId: 19750007
+              Children:
+              - Name: Alphaherpesvirinae
+                ConceptType: Subfamily
+                ConceptId: 202401412
+                ConceptSource: ICTV
+                IctvId: 19780034
+                Children:
+                - Name: Simplexvirus
+                  ConceptType: Genus
+                  ConceptId: 202401424
+                  ConceptSource: ICTV
+                  IctvId: 19790066
+                  Children:
+                  - Name: Human herpes simplex virus
+                    ConceptType: Group
+                    ConceptId: 12
+                    ConceptSource: NeoIPC
+                    Id: 2621
+                    Children:
+                    - Name: Simplexvirus humanalpha1
+                      ConceptType: Species
+                      ConceptId: 202401428
+                      ConceptSource: ICTV
+                      Id: 3505
+                      IctvId: 19710176
+                      Synonyms:
+                      - Name: Herpes simplex virus type 1
+                        ConceptId: "88"
+                        ConceptSource: NeoIPC
+                        Id: 2617
+                      - Name: Human alphaherpesvirus 1
+                        ConceptId: 202101428
+                        ConceptSource: ICTV
+                        Id: 2616
+                        IctvId: 19710176
+                    - Name: Simplexvirus humanalpha2
+                      ConceptType: Species
+                      ConceptId: 202401429
+                      ConceptSource: ICTV
+                      Id: 3506
+                      IctvId: 19760237
+                      Synonyms:
+                      - Name: Herpes simplex virus type 2
+                        ConceptId: "89"
+                        ConceptSource: NeoIPC
+                        Id: 2619
+                      - Name: Human alphaherpesvirus 2
+                        ConceptId: 202101429
+                        ConceptSource: ICTV
+                        Id: 2618
+                        IctvId: 19760237
+                - Name: Varicellovirus
+                  ConceptType: Genus
+                  ConceptId: 202401439
+                  ConceptSource: ICTV
+                  Id: 31
+                  IctvId: 19790067
+                  Children:
+                  - Name: Varicellovirus humanalpha3
+                    ConceptType: Species
+                    ConceptId: 202401454
+                    ConceptSource: ICTV
+                    Id: 3507
+                    IctvId: 19840518
+                    Synonyms:
+                    - Name: Human alphaherpesvirus 3
+                      ConceptId: 202101454
+                      ConceptSource: ICTV
+                      Id: 2620
+                      IctvId: 19840518
+                    - Name: Varicella zoster virus
+                      ConceptId: "92"
+                      ConceptSource: NeoIPC
+                      Id: 876
+              - Name: Betaherpesvirinae
+                ConceptType: Subfamily
+                ConceptId: 202401457
+                ConceptSource: ICTV
+                IctvId: 19790035
+                Children:
+                - Name: Cytomegalovirus
+                  ConceptType: Genus
+                  ConceptId: 202401458
+                  ConceptSource: ICTV
+                  IctvId: 19790068
+                  Children:
+                  - Name: Cytomegalovirus humanbeta5
+                    ConceptType: Species
+                    ConceptId: 202401462
+                    ConceptSource: ICTV
+                    Id: 3508
+                    IctvId: 19790333
+                    Synonyms:
+                    - Name: Human betaherpesvirus 5
+                      ConceptId: 202101462
+                      ConceptSource: ICTV
+                      Id: 2604
+                      IctvId: 19790333
+                    - Name: Human cytomegalovirus
+                      ConceptId: "5"
+                      ConceptSource: NeoIPC
+                      Id: 2605
+                - Name: Roseolovirus
+                  ConceptType: Genus
+                  ConceptId: 202401473
+                  ConceptSource: ICTV
+                  IctvId: 19930156
+                  Children:
+                  - Name: Human herpesvirus 6
+                    ConceptType: Group
+                    ConceptId: 24
+                    ConceptSource: NeoIPC
+                    Id: 2674
+                    Children:
+                    - Name: Roseolovirus humanbeta6a
+                      ConceptType: Species
+                      ConceptId: 202401475
+                      ConceptSource: ICTV
+                      Id: 3509
+                      IctvId: 20115682
+                      Synonyms:
+                      - Name: Human betaherpesvirus 6A
+                        ConceptId: 202101475
+                        ConceptSource: ICTV
+                        Id: 2670
+                        IctvId: 20115682
+                      - Name: Human herpesvirus 6A
+                        ConceptId: 20115682
+                        ConceptSource: ICTV
+                        Id: 2671
+                        IctvId: 20115682
+                    - Name: Roseolovirus humanbeta6b
+                      ConceptType: Species
+                      ConceptId: 202401476
+                      ConceptSource: ICTV
+                      Id: 3510
+                      IctvId: 20115683
+                      Synonyms:
+                      - Name: Human betaherpesvirus 6B
+                        ConceptId: 202101476
+                        ConceptSource: ICTV
+                        Id: 2672
+                        IctvId: 20115683
+                      - Name: Human herpesvirus 6B
+                        ConceptId: 20115683
+                        ConceptSource: ICTV
+                        Id: 2673
+                        IctvId: 20115683
+              - Name: Gammaherpesvirinae
+                ConceptType: Subfamily
+                ConceptId: 202401481
+                ConceptSource: ICTV
+                IctvId: 19780035
+                Children:
+                - Name: Lymphocryptovirus
+                  ConceptType: Genus
+                  ConceptId: 202401482
+                  ConceptSource: ICTV
+                  IctvId: 19790070
+                  Children:
+                  - Name: Lymphocryptovirus humangamma4
+                    ConceptType: Species
+                    ConceptId: 202401486
+                    ConceptSource: ICTV
+                    Id: 3511
+                    IctvId: 19710173
+                    Synonyms:
+                    - Name: Epstein-Barr virus
+                      ConceptId: 19710173
+                      ConceptSource: ICTV
+                      Id: 2116
+                      IctvId: 19710173
+                    - Name: Human gammaherpesvirus 4
+                      ConceptId: 202101486
+                      ConceptSource: ICTV
+                      Id: 3344
+                      IctvId: 19710173
+                - Name: Rhadinovirus
+                  ConceptType: Genus
+                  ConceptId: 202401505
+                  ConceptSource: ICTV
+                  IctvId: 19840098
+                  Children:
+                  - Name: Rhadinovirus humangamma8
+                    ConceptType: Species
+                    ConceptId: 202401510
+                    ConceptSource: ICTV
+                    Id: 3512
+                    IctvId: 19991019
+                    Synonyms:
+                    - Name: Human gammaherpesvirus 8
+                      ConceptId: 202101510
+                      ConceptSource: ICTV
+                      Id: 2629
+                      IctvId: 19991019
+                    - Name: Human herpesvirus 8
+                      ConceptId: 20083108
+                      ConceptSource: ICTV
+                      Id: 2631
+                      IctvId: 19991019
+                    - Name: Kaposi's sarcoma-associated herpesvirus
+                      ConceptId: "91"
+                      ConceptSource: NeoIPC
+                      Id: 2630
+              Synonyms:
+              - Name: Herpesviridae
+                ConceptId: 202101411
+                ConceptSource: ICTV
+                Id: 473
+                IctvId: 19750007
+  - Name: Monodnaviria
+    ConceptType: Realm
+    ConceptId: 202407161
+    ConceptSource: ICTV
+    IctvId: 201907161
+    Children:
+    - Name: Shotokuvirae
+      ConceptType: Kingdom
+      ConceptId: 202407170
+      ConceptSource: ICTV
+      IctvId: 201907170
+      Children:
+      - Name: Cossaviricota
+        ConceptType: Phylum
+        ConceptId: 202407171
+        ConceptSource: ICTV
+        IctvId: 201907171
+        Children:
+        - Name: Papovaviricetes
+          ConceptType: Class
+          ConceptId: 202407178
+          ConceptSource: ICTV
+          IctvId: 201907178
+          Children:
+          - Name: Sepolyvirales
+            ConceptType: Order
+            ConceptId: 202407179
+            ConceptSource: ICTV
+            IctvId: 201907179
+            Children:
+            - Name: Polyomaviridae
+              ConceptType: Family
+              ConceptId: 202404409
+              ConceptSource: ICTV
+              Id: 2644
+              IctvId: 19990055
+              Children:
+              - Name: Betapolyomavirus
+                ConceptType: Genus
+                ConceptId: 202404449
+                ConceptSource: ICTV
+                IctvId: 20153677
+                Children:
+                - Name: Betapolyomavirus hominis
+                  ConceptType: Species
+                  ConceptId: 202404459
+                  ConceptSource: ICTV
+                  Id: 2642
+                  IctvId: 19760276
+                  Synonyms:
+                  - Name: BK polyomavirus
+                    ConceptId: 19991317
+                    ConceptSource: ICTV
+                    Id: 2470
+                    IctvId: 19760276
+                  - Name: Human polyomavirus 1
+                    ConceptId: 20153664
+                    ConceptSource: ICTV
+                    Id: 2643
+                    IctvId: 19760276
+                - Name: Betapolyomavirus macacae
+                  ConceptType: Species
+                  ConceptId: 202404464
+                  ConceptSource: ICTV
+                  Id: 3335
+                  IctvId: 19710060
+                  Synonyms:
+                  - Name: Simian virus 40
+                    ConceptId: 19951416
+                    ConceptSource: ICTV
+                    Id: 1979
+                    IctvId: 19710060
+                - Name: Betapolyomavirus secuhominis
+                  ConceptType: Species
+                  ConceptId: 202404460
+                  ConceptSource: ICTV
+                  Id: 2682
+                  IctvId: 19760277
+                  Synonyms:
+                  - Name: Human polyomavirus 2
+                    ConceptId: 20153670
+                    ConceptSource: ICTV
+                    Id: 2683
+                    IctvId: 19760277
+                  - Name: JC polyomavirus
+                    ConceptId: 19991321
+                    ConceptSource: ICTV
+                    Id: 2684
+                    IctvId: 19760277
+                  - Name: JC virus
+                    ConceptId: 19760277
+                    ConceptSource: ICTV
+                    Id: 2685
+                    IctvId: 19760277
+          - Name: Zurhausenvirales
+            ConceptType: Order
+            ConceptId: 202407180
+            ConceptSource: ICTV
+            IctvId: 201907180
+            Children:
+            - Name: Papillomaviridae
+              ConceptType: Family
+              ConceptId: 202403971
+              ConceptSource: ICTV
+              IctvId: 19990048
+              Children:
+              - Name: Firstpapillomavirinae
+                ConceptType: Subfamily
+                ConceptId: 202405883
+                ConceptSource: ICTV
+                IctvId: 20175883
+                Children:
+                - Name: Human papillomavirus
+                  ConceptType: Group
+                  ConceptId: Human papillomavirus
+                  ConceptSource: NeoIPC
+                  Id: 2611
+        - Name: Quintoviricetes
+          ConceptType: Class
+          ConceptId: 202407172
+          ConceptSource: ICTV
+          IctvId: 201907172
+          Children:
+          - Name: Piccovirales
+            ConceptType: Order
+            ConceptId: 202407173
+            ConceptSource: ICTV
+            IctvId: 201907173
+            Children:
+            - Name: Parvoviridae
+              ConceptType: Family
+              ConceptId: 202404206
+              ConceptSource: ICTV
+              IctvId: 19750012
+              Children:
+              - Name: Parvovirinae
+                ConceptType: Subfamily
+                ConceptId: 202404235
+                ConceptSource: ICTV
+                IctvId: 19930089
+                Children:
+                - Name: Bocaparvovirus
+                  ConceptType: Genus
+                  ConceptId: 202404241
+                  ConceptSource: ICTV
+                  Id: 2690
+                  IctvId: 20040344
+                  Children:
+                  - Name: Human bocavirus
+                    ConceptType: Group
+                    ConceptId: 16
+                    ConceptSource: NeoIPC
+                    Id: 2626
+                  Synonyms:
+                  - Name: Bocavirus
+                    ConceptId: 20040344
+                    ConceptSource: ICTV
+                    Id: 2691
+                    IctvId: 20040344
+                - Name: Erythroparvovirus
+                  ConceptType: Genus
+                  ConceptId: 202404265
+                  ConceptSource: ICTV
+                  IctvId: 19930188
+                  Children:
+                  - Name: Erythroparvovirus primate1
+                    ConceptType: Species
+                    ConceptId: 202404266
+                    ConceptSource: ICTV
+                    Id: 3538
+                    IctvId: 20132595
+                    Synonyms:
+                    - Name: B19 virus
+                      ConceptId: "10"
+                      ConceptSource: NeoIPC
+                      Id: 2614
+                    - Name: Erythrovirus B19
+                      ConceptId: "11"
+                      ConceptSource: NeoIPC
+                      Id: 2615
+                    - Name: Primate erythroparvovirus 1
+                      ConceptId: 202104266
+                      ConceptSource: ICTV
+                      Id: 2612
+                      IctvId: 20132595
+  - Name: Riboviria
+    ConceptType: Realm
+    ConceptId: 202407095
+    ConceptSource: ICTV
+    IctvId: 201857095
+    Children:
+    - Name: Orthornavirae
+      ConceptType: Kingdom
+      ConceptId: 202407198
+      ConceptSource: ICTV
+      IctvId: 201907198
+      Children:
+      - Name: Duplornaviricota
+        ConceptType: Phylum
+        ConceptId: 202407229
+        ConceptSource: ICTV
+        IctvId: 201907229
+        Children:
+        - Name: Resentoviricetes
+          ConceptType: Class
+          ConceptId: 202407234
+          ConceptSource: ICTV
+          IctvId: 201907234
+          Children:
+          - Name: Reovirales
+            ConceptType: Order
+            ConceptId: 202407235
+            ConceptSource: ICTV
+            IctvId: 201907235
+            Children:
+            - Name: Sedoreoviridae
+              ConceptType: Family
+              ConceptId: 202404872
+              ConceptSource: ICTV
+              IctvId: 20090683
+              Children:
+              - Name: Orbivirus
+                ConceptType: Genus
+                ConceptId: 202404877
+                ConceptSource: ICTV
+                Id: 198
+                IctvId: 19740026
+              - Name: Rotavirus
+                ConceptType: Genus
+                ConceptId: 202404904
+                ConceptSource: ICTV
+                Id: 2155
+                IctvId: 19780099
+            - Name: Spinareoviridae
+              ConceptType: Family
+              ConceptId: 202404918
+              ConceptSource: ICTV
+              IctvId: 20090684
+              Children:
+              - Name: Coltivirus
+                ConceptType: Genus
+                ConceptId: 202404927
+                ConceptSource: ICTV
+                IctvId: 20071237
+                Children:
+                - Name: Coltivirus dermacentoris
+                  ConceptType: Species
+                  ConceptId: 202404928
+                  ConceptSource: ICTV
+                  Id: 3489
+                  IctvId: 19991541
+                  Synonyms:
+                  - Name: Colorado tick fever coltivirus
+                    ConceptId: 202104928
+                    ConceptSource: ICTV
+                    Id: 3339
+                    IctvId: 19991541
+                  - Name: Colorado tick fever virus
+                    ConceptId: 19991541
+                    ConceptSource: ICTV
+                    Id: 1725
+                    IctvId: 19991541
+              - Name: Orthoreovirus
+                ConceptType: Genus
+                ConceptId: 202404969
+                ConceptSource: ICTV
+                Id: 793
+                IctvId: 19710041
+      - Name: Kitrinoviricota
+        ConceptType: Phylum
+        ConceptId: 202407217
+        ConceptSource: ICTV
+        IctvId: 201907217
+        Children:
+        - Name: Alsuviricetes
+          ConceptType: Class
+          ConceptId: 202407225
+          ConceptSource: ICTV
+          IctvId: 201907225
+          Children:
+          - Name: Hepelivirales
+            ConceptType: Order
+            ConceptId: 202407228
+            ConceptSource: ICTV
+            IctvId: 201907228
+            Children:
+            - Name: Hepeviridae
+              ConceptType: Family
+              ConceptId: 202403662
+              ConceptSource: ICTV
+              IctvId: 20090337
+              Children:
+              - Name: Orthohepevirinae
+                ConceptType: Subfamily
+                ConceptId: 202413883
+                ConceptSource: ICTV
+                IctvId: 202113883
+                Children:
+                - Name: Paslahepevirus
+                  ConceptType: Genus
+                  ConceptId: 202413884
+                  ConceptSource: ICTV
+                  IctvId: 202113884
+                  Children:
+                  - Name: Paslahepevirus balayani
+                    ConceptType: Species
+                    ConceptId: 202403665
+                    ConceptSource: ICTV
+                    Id: 2649
+                    IctvId: 19950816
+                    Synonyms:
+                    - Name: Hepatitis E virus
+                      ConceptId: 19950816
+                      ConceptSource: ICTV
+                      Id: 2650
+                      IctvId: 19950816
+            - Name: Matonaviridae
+              ConceptType: Family
+              ConceptId: 202406488
+              ConceptSource: ICTV
+              IctvId: 201856488
+              Children:
+              - Name: Rubivirus
+                ConceptType: Genus
+                ConceptId: 202405114
+                ConceptSource: ICTV
+                Id: 778
+                IctvId: 19750076
+                Children:
+                - Name: Rubivirus rubellae
+                  ConceptType: Species
+                  ConceptId: 202405115
+                  ConceptSource: ICTV
+                  Id: 3342
+                  IctvId: 19750326
+                  Synonyms:
+                  - Name: Rubella virus
+                    ConceptId: 19750326
+                    ConceptSource: ICTV
+                    Id: 223
+                    IctvId: 19750326
+          - Name: Martellivirales
+            ConceptType: Order
+            ConceptId: 202407226
+            ConceptSource: ICTV
+            IctvId: 201907226
+            Children:
+            - Name: Togaviridae
+              ConceptType: Family
+              ConceptId: 202405080
+              ConceptSource: ICTV
+              Id: 1563
+              IctvId: 19740006
+              Children:
+              - Name: Alphavirus
+                ConceptType: Genus
+                ConceptId: 202405082
+                ConceptSource: ICTV
+                IctvId: 19710015
+                Children:
+                - Name: Alphavirus chikungunya
+                  ConceptType: Species
+                  ConceptId: 202405087
+                  ConceptSource: ICTV
+                  Id: 3485
+                  IctvId: 19710074
+                  Synonyms:
+                  - Name: Chikungunya virus
+                    ConceptId: 202105087
+                    ConceptSource: ICTV
+                    Id: 916
+                    IctvId: 19710074
+                - Name: Alphavirus eastern
+                  ConceptType: Species
+                  ConceptId: 202405088
+                  ConceptSource: ICTV
+                  Id: 3494
+                  IctvId: 19710075
+                  Synonyms:
+                  - Name: Eastern equine encephalitis virus
+                    ConceptId: 202105088
+                    ConceptSource: ICTV
+                    Id: 905
+                    IctvId: 19710075
+                  - Name: North American eastern equine encephalitis virus
+                    ConceptId: "86"
+                    ConceptSource: NeoIPC
+                    Id: 2646
+                - Name: Alphavirus madariaga
+                  ConceptType: Species
+                  ConceptId: 202405094
+                  ConceptSource: ICTV
+                  Id: 3525
+                  IctvId: 20125921
+                  Synonyms:
+                  - Name: Madariaga virus
+                    ConceptId: 202105094
+                    ConceptSource: ICTV
+                    Id: 2647
+                    IctvId: 20125921
+                  - Name: South American eastern equine encephalitis virus
+                    ConceptId: "87"
+                    ConceptSource: NeoIPC
+                    Id: 2648
+                - Name: Alphavirus venezuelan
+                  ConceptType: Species
+                  ConceptId: 202405111
+                  ConceptSource: ICTV
+                  Id: 3556
+                  IctvId: 19710086
+                  Synonyms:
+                  - Name: Venezuelan equine encephalitis virus
+                    ConceptId: 202105111
+                    ConceptSource: ICTV
+                    Id: 2688
+                    IctvId: 19710086
+                - Name: Alphavirus western
+                  ConceptType: Species
+                  ConceptId: 202405112
+                  ConceptSource: ICTV
+                  Id: 3559
+                  IctvId: 19710087
+                  Synonyms:
+                  - Name: Western equine encephalitis virus
+                    ConceptId: 202105112
+                    ConceptSource: ICTV
+                    Id: 2645
+                    IctvId: 19710087
+        - Name: Flasuviricetes
+          ConceptType: Class
+          ConceptId: 202407218
+          ConceptSource: ICTV
+          IctvId: 201907218
+          Children:
+          - Name: Amarillovirales
+            ConceptType: Order
+            ConceptId: 202407219
+            ConceptSource: ICTV
+            IctvId: 201907219
+            Children:
+            - Name: Flaviviridae
+              ConceptType: Family
+              ConceptId: 202403068
+              ConceptSource: ICTV
+              IctvId: 19840011
+              Children:
+              - Name: Hepacivirus
+                ConceptType: Genus
+                ConceptId: 202403124
+                ConceptSource: ICTV
+                IctvId: 19910116
+                Children:
+                - Name: Hepacivirus hominis
+                  ConceptType: Species
+                  ConceptId: 202403127
+                  ConceptSource: ICTV
+                  Id: 3501
+                  IctvId: 19910774
+                  Synonyms:
+                  - Name: Hepacivirus C
+                    ConceptId: 202103127
+                    ConceptSource: ICTV
+                    Id: 2640
+                    IctvId: 19910774
+                  - Name: Hepatitis C virus
+                    ConceptId: 19950941
+                    ConceptSource: ICTV
+                    Id: 2641
+                    IctvId: 19910774
+              - Name: Orthoflavivirus
+                ConceptType: Genus
+                ConceptId: 202403070
+                ConceptSource: ICTV
+                IctvId: 19710016
+                Children:
+                - Name: Orthoflavivirus denguei
+                  ConceptType: Species
+                  ConceptId: 202403081
+                  ConceptSource: ICTV
+                  Id: 3492
+                  IctvId: 19990820
+                  Synonyms:
+                  - Name: Dengue virus
+                    ConceptId: 202103081
+                    ConceptSource: ICTV
+                    Id: 1791
+                    IctvId: 19990820
+                - Name: Orthoflavivirus encephalitidis
+                  ConceptType: Species
+                  ConceptId: 202403114
+                  ConceptSource: ICTV
+                  Id: 3553
+                  IctvId: 19790934
+                  Synonyms:
+                  - Name: Tick-borne encephalitis virus
+                    ConceptId: 202103114
+                    ConceptSource: ICTV
+                    Id: 2389
+                    IctvId: 19790934
+                - Name: Orthoflavivirus flavi
+                  ConceptType: Species
+                  ConceptId: 202403121
+                  ConceptSource: ICTV
+                  Id: 3560
+                  IctvId: 19710125
+                  Synonyms:
+                  - Name: Yellow fever virus
+                    ConceptId: 202103121
+                    ConceptSource: ICTV
+                    Id: 1757
+                    IctvId: 19710125
+                - Name: Orthoflavivirus louisense
+                  ConceptType: Species
+                  ConceptId: 202403112
+                  ConceptSource: ICTV
+                  Id: 3546
+                  IctvId: 19710117
+                  Synonyms:
+                  - Name: Saint Louis encephalitis virus
+                    ConceptId: 202103112
+                    ConceptSource: ICTV
+                    Id: 2686
+                    IctvId: 19710117
+                  - Name: St. Louis encephalitis virus
+                    ConceptId: 19710117
+                    ConceptSource: ICTV
+                    Id: 2687
+                    IctvId: 19710117
+                - Name: Orthoflavivirus nilense
+                  ConceptType: Species
+                  ConceptId: 202403119
+                  ConceptSource: ICTV
+                  Id: 3558
+                  IctvId: 19990858
+                  Synonyms:
+                  - Name: West Nile virus
+                    ConceptId: 202103119
+                    ConceptSource: ICTV
+                    Id: 1143
+                    IctvId: 19990858
+                - Name: Orthoflavivirus zikaense
+                  ConceptType: Species
+                  ConceptId: 202403123
+                  ConceptSource: ICTV
+                  Id: 3415
+                  IctvId: 19990862
+                  Synonyms:
+                  - Name: Zika virus
+                    ConceptId: 202103123
+                    ConceptSource: ICTV
+                    Id: 1140
+                    IctvId: 19990862
+                Id: 3499
+                Synonyms:
+                - Name: Flavivirus
+                  ConceptId: 202103070
+                  ConceptSource: ICTV
+                  Id: 1194
+                  IctvId: 19710016
+              - Name: Pegivirus
+                ConceptType: Genus
+                ConceptId: 202403139
+                ConceptSource: ICTV
+                IctvId: 20125923
+                Children:
+                - Name: Human pegivirus
+                  ConceptType: Group
+                  ConceptId: Human pegivirus
+                  ConceptSource: NeoIPC
+                  Id: 2652
+                - Name: Pegivirus hominis
+                  ConceptType: Species
+                  ConceptId: 202403142
+                  ConceptSource: ICTV
+                  Id: 3536
+                  IctvId: 20165296
+                  Synonyms:
+                  - Name: Hepatitis G virus
+                    ConceptId: "21"
+                    ConceptSource: NeoIPC
+                    Id: 2653
+                  - Name: Pegivirus C
+                    ConceptId: 202103142
+                    ConceptSource: ICTV
+                    Id: 2651
+                    IctvId: 20165296
+      - Name: Negarnaviricota
+        ConceptType: Phylum
+        ConceptId: 202406016
+        ConceptSource: ICTV
+        IctvId: 20186016
+        Children:
+        - Name: Haploviricotina
+          ConceptType: Subphylum
+          ConceptId: 202406019
+          ConceptSource: ICTV
+          IctvId: 20186019
+          Children:
+          - Name: Monjiviricetes
+            ConceptType: Class
+            ConceptId: 202406020
+            ConceptSource: ICTV
+            IctvId: 20186020
+            Children:
+            - Name: Mononegavirales
+              ConceptType: Order
+              ConceptId: 202401548
+              ConceptSource: ICTV
+              IctvId: 19900001
+              Children:
+              - Name: Filoviridae
+                ConceptType: Family
+                ConceptId: 202401560
+                ConceptSource: ICTV
+                IctvId: 19870011
+                Children:
+                - Name: Orthoebolavirus
+                  ConceptType: Genus
+                  ConceptId: 202401564
+                  ConceptSource: ICTV
+                  Id: 3495
+                  IctvId: 19980158
+                  Synonyms:
+                  - Name: Ebolavirus
+                    ConceptId: 202101564
+                    ConceptSource: ICTV
+                    Id: 1684
+                    IctvId: 19980158
+                - Name: Orthomarburgvirus
+                  ConceptType: Genus
+                  ConceptId: 202401570
+                  ConceptSource: ICTV
+                  Id: 3527
+                  IctvId: 19980159
+                  Synonyms:
+                  - Name: Marburgvirus
+                    ConceptId: 202101570
+                    ConceptSource: ICTV
+                    Id: 2170
+                    IctvId: 19980159
+              - Name: Paramyxoviridae
+                ConceptType: Family
+                ConceptId: 202401586
+                ConceptSource: ICTV
+                IctvId: 19750011
+                Children:
+                - Name: Human parainfluenza virus
+                  ConceptType: Group
+                  ConceptId: Human parainfluenza virus
+                  ConceptSource: NeoIPC
+                  Id: 2660
+                - Name: Feraresvirinae
+                  ConceptType: Subfamily
+                  ConceptId: 202415191
+                  ConceptSource: ICTV
+                  IctvId: 202315191
+                  Children:
+                  - Name: Respirovirus
+                    ConceptType: Genus
+                    ConceptId: 202401620
+                    ConceptSource: ICTV
+                    Id: 536
+                    IctvId: 19710034
+                    Children:
+                    - Name: Respirovirus laryngotracheitidis
+                      ConceptType: Species
+                      ConceptId: 202401622
+                      ConceptSource: ICTV
+                      Id: 3519
+                      IctvId: 19710229
+                      Synonyms:
+                      - Name: Human parainfluenza virus 1
+                        ConceptId: 19950297
+                        ConceptSource: ICTV
+                        Id: 2662
+                        IctvId: 19710229
+                      - Name: Human respirovirus 1
+                        ConceptId: 202101622
+                        ConceptSource: ICTV
+                        Id: 2661
+                        IctvId: 19710229
+                    - Name: Respirovirus pneumoniae
+                      ConceptType: Species
+                      ConceptId: 202401623
+                      ConceptSource: ICTV
+                      Id: 3520
+                      IctvId: 19710231
+                      Synonyms:
+                      - Name: Human parainfluenza virus 3
+                        ConceptId: 19950298
+                        ConceptSource: ICTV
+                        Id: 2666
+                        IctvId: 19710231
+                      - Name: Human respirovirus 3
+                        ConceptId: 202101623
+                        ConceptSource: ICTV
+                        Id: 2665
+                        IctvId: 19710231
+                - Name: Orthoparamyxovirinae
+                  ConceptType: Subfamily
+                  ConceptId: 202406451
+                  ConceptSource: ICTV
+                  IctvId: 201856451
+                  Children:
+                  - Name: Morbillivirus
+                    ConceptType: Genus
+                    ConceptId: 202401612
+                    ConceptSource: ICTV
+                    Id: 2369
+                    IctvId: 19750049
+                    Children:
+                    - Name: Morbillivirus hominis
+                      ConceptType: Species
+                      ConceptId: 202401616
+                      ConceptSource: ICTV
+                      Id: 3529
+                      IctvId: 19750163
+                      Synonyms:
+                      - Name: Measles morbillivirus
+                        ConceptId: 202101616
+                        ConceptSource: ICTV
+                        Id: 3333
+                        IctvId: 19750163
+                      - Name: Measles virus
+                        ConceptId: 19750163
+                        ConceptSource: ICTV
+                        Id: 607
+                        IctvId: 19750163
+                - Name: Rubulavirinae
+                  ConceptType: Subfamily
+                  ConceptId: 202406467
+                  ConceptSource: ICTV
+                  IctvId: 201856467
+                  Children:
+                  - Name: Orthorubulavirus
+                    ConceptType: Genus
+                    ConceptId: 202406468
+                    ConceptSource: ICTV
+                    IctvId: 201856468
+                    Children:
+                    - Name: Orthorubulavirus hominis
+                      ConceptType: Species
+                      ConceptId: 202401631
+                      ConceptSource: ICTV
+                      Id: 3518
+                      IctvId: 19990434
+                      Synonyms:
+                      - Name: Human orthorubulavirus 4
+                        ConceptId: 202101631
+                        ConceptSource: ICTV
+                        Id: 2667
+                        IctvId: 19990434
+                      - Name: Human parainfluenza virus 4
+                        ConceptId: 19990434
+                        ConceptSource: ICTV
+                        Id: 2668
+                        IctvId: 19990434
+                    - Name: Orthorubulavirus laryngotracheitidis
+                      ConceptType: Species
+                      ConceptId: 202401630
+                      ConceptSource: ICTV
+                      Id: 3517
+                      IctvId: 19950309
+                      Synonyms:
+                      - Name: Human orthorubulavirus 2
+                        ConceptId: 202101630
+                        ConceptSource: ICTV
+                        Id: 2663
+                        IctvId: 19950309
+                      - Name: Human parainfluenza virus 2
+                        ConceptId: 19950309
+                        ConceptSource: ICTV
+                        Id: 2664
+                        IctvId: 19950309
+                    - Name: Orthorubulavirus parotitidis
+                      ConceptType: Species
+                      ConceptId: 202401635
+                      ConceptSource: ICTV
+                      Id: 3533
+                      IctvId: 19710227
+                      Synonyms:
+                      - Name: Mumps orthorubulavirus
+                        ConceptId: 202101635
+                        ConceptSource: ICTV
+                        Id: 3337
+                        IctvId: 19710227
+                      - Name: Mumps virus
+                        ConceptId: 19710227
+                        ConceptSource: ICTV
+                        Id: 1059
+                        IctvId: 19710227
+              - Name: Pneumoviridae
+                ConceptType: Family
+                ConceptId: 202401644
+                ConceptSource: ICTV
+                IctvId: 19900046
+                Children:
+                - Name: Metapneumovirus
+                  ConceptType: Genus
+                  ConceptId: 202401646
+                  ConceptSource: ICTV
+                  IctvId: 19960123
+                  Children:
+                  - Name: Metapneumovirus hominis
+                    ConceptType: Species
+                    ConceptId: 202401648
+                    ConceptSource: ICTV
+                    Id: 3515
+                    IctvId: 20073072
+                    Synonyms:
+                    - Name: Human metapneumovirus
+                      ConceptId: 202101648
+                      ConceptSource: ICTV
+                      Id: 2462
+                      IctvId: 20073072
+                - Name: Orthopneumovirus
+                  ConceptType: Genus
+                  ConceptId: 202401649
+                  ConceptSource: ICTV
+                  IctvId: 19750051
+                  Children:
+                  - Name: Orthopneumovirus hominis
+                    ConceptType: Species
+                    ConceptId: 202401651
+                    ConceptSource: ICTV
+                    Id: 3516
+                    IctvId: 19750170
+                    Synonyms:
+                    - Name: Human orthopneumovirus
+                      ConceptId: 202101651
+                      ConceptSource: ICTV
+                      Id: 2603
+                      IctvId: 19750170
+                    - Name: Human respiratory syncytial virus
+                      ConceptId: 19950318
+                      ConceptSource: ICTV
+                      Id: 376
+                      IctvId: 19750170
+              - Name: Rhabdoviridae
+                ConceptType: Family
+                ConceptId: 202401653
+                ConceptSource: ICTV
+                Id: 2689
+                IctvId: 19750017
+                Children:
+                - Name: Alpharhabdovirinae
+                  ConceptType: Subfamily
+                  ConceptId: 202408748
+                  ConceptSource: ICTV
+                  IctvId: 202008748
+                  Children:
+                  - Name: Lyssavirus
+                    ConceptType: Genus
+                    ConceptId: 202401721
+                    ConceptSource: ICTV
+                    IctvId: 19750071
+                    Children:
+                    - Name: Lyssavirus rabies
+                      ConceptType: Species
+                      ConceptId: 202401733
+                      ConceptSource: ICTV
+                      Id: 3336
+                      IctvId: 19710311
+                      Synonyms:
+                      - Name: Rabies virus
+                        ConceptId: 19710311
+                        ConceptSource: ICTV
+                        Id: 2404
+                        IctvId: 19710311
+        - Name: Polyploviricotina
+          ConceptType: Subphylum
+          ConceptId: 202406017
+          ConceptSource: ICTV
+          IctvId: 20186017
+          Children:
+          - Name: Bunyaviricetes
+            ConceptType: Class
+            ConceptId: 202406018
+            ConceptSource: ICTV
+            IctvId: 20186018
+            Children:
+            - Name: Elliovirales
+              ConceptType: Order
+              ConceptId: 202400001
+              ConceptSource: ICTV
+              IctvId: 20164603
+              Children:
+              - Name: Peribunyaviridae
+                ConceptType: Family
+                ConceptId: 202400081
+                ConceptSource: ICTV
+                IctvId: 19750005
+                Children:
+                - Name: Orthobunyavirus
+                  ConceptType: Genus
+                  ConceptId: 202400088
+                  ConceptSource: ICTV
+                  IctvId: 19750042
+                  Children:
+                  - Name: Orthobunyavirus encephalitidis
+                    ConceptType: Species
+                    ConceptId: 202400103
+                    ConceptSource: ICTV
+                    Id: 3483
+                    IctvId: 19990625
+                    Synonyms:
+                    - Name: California encephalitis orthobunyavirus
+                      ConceptId: 202100103
+                      ConceptSource: ICTV
+                      Id: 3334
+                      IctvId: 19990625
+                    - Name: California encephalitis virus
+                      ConceptId: 19990625
+                      ConceptSource: ICTV
+                      Id: 1636
+                      IctvId: 19990625
+            - Name: Hareavirales
+              ConceptType: Order
+              ConceptId: 202415134
+              ConceptSource: ICTV
+              IctvId: 202315134
+              Children:
+              - Name: Arenaviridae
+                ConceptType: Family
+                ConceptId: 202402567
+                ConceptSource: ICTV
+                IctvId: 19750003
+                Children:
+                - Name: Mammarenavirus
+                  ConceptType: Genus
+                  ConceptId: 202402569
+                  ConceptSource: ICTV
+                  IctvId: 19710017
+                  Children:
+                  - Name: Mammarenavirus choriomeningitidis
+                    ConceptType: Species
+                    ConceptId: 202402586
+                    ConceptSource: ICTV
+                    Id: 3524
+                    IctvId: 19710131
+                    Synonyms:
+                    - Name: Lymphocytic choriomeningitis mammarenavirus
+                      ConceptId: 202102586
+                      ConceptSource: ICTV
+                      Id: 3343
+                      IctvId: 19710131
+                    - Name: Lymphocytic choriomeningitis virus
+                      ConceptId: 19710131
+                      ConceptSource: ICTV
+                      Id: 2070
+                      IctvId: 19710131
+                  - Name: Mammarenavirus lassaense
+                    ConceptType: Species
+                    ConceptId: 202402580
+                    ConceptSource: ICTV
+                    Id: 3521
+                    IctvId: 19790162
+                    Synonyms:
+                    - Name: Lassa mammarenavirus
+                      ConceptId: 202102580
+                      ConceptSource: ICTV
+                      Id: 2669
+                      IctvId: 19790162
+                    - Name: Lassa virus
+                      ConceptId: 19790162
+                      ConceptSource: ICTV
+                      Id: 981
+                      IctvId: 19790162
+              - Name: Nairoviridae
+                ConceptType: Family
+                ConceptId: 202400066
+                ConceptSource: ICTV
+                IctvId: 20164609
+                Children:
+                - Name: Orthonairovirus
+                  ConceptType: Genus
+                  ConceptId: 202400068
+                  ConceptSource: ICTV
+                  IctvId: 19810072
+                  Children:
+                  - Name: Orthonairovirus haemorrhagiae
+                    ConceptType: Species
+                    ConceptId: 202400070
+                    ConceptSource: ICTV
+                    Id: 3490
+                    IctvId: 19990680
+                    Synonyms:
+                    - Name: Crimean-Congo hemorrhagic fever orthonairovirus
+                      ConceptId: 202100070
+                      ConceptSource: ICTV
+                      Id: 3340
+                      IctvId: 19990680
+                    - Name: Crimean-Congo hemorrhagic fever virus
+                      ConceptId: 19990680
+                      ConceptSource: ICTV
+                      Id: 632
+                      IctvId: 19990680
+              - Name: Phenuiviridae
+                ConceptType: Family
+                ConceptId: 202400146
+                ConceptSource: ICTV
+                IctvId: 20164611
+                Children:
+                - Name: Phlebovirus
+                  ConceptType: Genus
+                  ConceptId: 202400157
+                  ConceptSource: ICTV
+                  IctvId: 19910109
+                  Children:
+                  - Name: Phlebovirus riftense
+                    ConceptType: Species
+                    ConceptId: 202400163
+                    ConceptSource: ICTV
+                    Id: 3544
+                    IctvId: 19990693
+                    Synonyms:
+                    - Name: Rift Valley fever phlebovirus
+                      ConceptId: 202100163
+                      ConceptSource: ICTV
+                      Id: 3341
+                      IctvId: 19990693
+                    - Name: Rift Valley fever virus
+                      ConceptId: 19990693
+                      ConceptSource: ICTV
+                      Id: 2021
+                      IctvId: 19990693
+          - Name: Insthoviricetes
+            ConceptType: Class
+            ConceptId: 202406023
+            ConceptSource: ICTV
+            IctvId: 20186023
+            Children:
+            - Name: Articulavirales
+              ConceptType: Order
+              ConceptId: 202406024
+              ConceptSource: ICTV
+              IctvId: 20186024
+              Children:
+              - Name: Orthomyxoviridae
+                ConceptType: Family
+                ConceptId: 202403953
+                ConceptSource: ICTV
+                IctvId: 19750009
+                Children:
+                - Name: Influenza virus
+                  ConceptType: Group
+                  ConceptId: 22
+                  ConceptSource: NeoIPC
+                  Id: 2659
+                  Children:
+                  - Name: Alphainfluenzavirus
+                    ConceptType: Genus
+                    ConceptId: 202403955
+                    ConceptSource: ICTV
+                    IctvId: 19960203
+                    Children:
+                    - Name: Alphainfluenzavirus influenzae
+                      ConceptType: Species
+                      ConceptId: 202403956
+                      ConceptSource: ICTV
+                      Id: 2654
+                      IctvId: 19710226
+                      Synonyms:
+                      - Name: Influenza A virus
+                        ConceptId: 19951376
+                        ConceptSource: ICTV
+                        Id: 2526
+                        IctvId: 19710226
+                  - Name: Betainfluenzavirus
+                    ConceptType: Genus
+                    ConceptId: 202403957
+                    ConceptSource: ICTV
+                    IctvId: 19960204
+                    Children:
+                    - Name: Betainfluenzavirus influenzae
+                      ConceptType: Species
+                      ConceptId: 202403958
+                      ConceptSource: ICTV
+                      Id: 2655
+                      IctvId: 19710224
+                      Synonyms:
+                      - Name: Influenza B virus
+                        ConceptId: 19951377
+                        ConceptSource: ICTV
+                        Id: 710
+                        IctvId: 19710224
+                  - Name: Gammainfluenzavirus
+                    ConceptType: Genus
+                    ConceptId: 202403959
+                    ConceptSource: ICTV
+                    IctvId: 19870116
+                    Children:
+                    - Name: Gammainfluenzavirus influenzae
+                      ConceptType: Species
+                      ConceptId: 202403960
+                      ConceptSource: ICTV
+                      Id: 2658
+                      IctvId: 19870699
+                      Synonyms:
+                      - Name: Influenza C virus
+                        ConceptId: 19951378
+                        ConceptSource: ICTV
+                        Id: 1420
+                        IctvId: 19870699
+                  - Name: Deltainfluenzavirus
+                    ConceptType: Genus
+                    ConceptId: 202403961
+                    ConceptSource: ICTV
+                    IctvId: 20164753
+                    Children:
+                    - Name: Deltainfluenzavirus influenzae
+                      ConceptType: Species
+                      ConceptId: 202403962
+                      ConceptSource: ICTV
+                      Id: 2656
+                      IctvId: 20165406
+                      Synonyms:
+                      - Name: Influenza D virus
+                        ConceptId: 20165406
+                        ConceptSource: ICTV
+                        Id: 2657
+                        IctvId: 20165406
+      - Name: Pisuviricota
+        ConceptType: Phylum
+        ConceptId: 202407209
+        ConceptSource: ICTV
+        IctvId: 201907209
+        Children:
+        - Name: Pisoniviricetes
+          ConceptType: Class
+          ConceptId: 202407210
+          ConceptSource: ICTV
+          IctvId: 201907210
+          Children:
+          - Name: Nidovirales
+            ConceptType: Order
+            ConceptId: 202401821
+            ConceptSource: ICTV
+            IctvId: 19960002
+            Children:
+            - Name: Cornidovirineae
+              ConceptType: Suborder
+              ConceptId: 202406105
+              ConceptSource: ICTV
+              IctvId: 20186105
+              Children:
+              - Name: Coronaviridae
+                ConceptType: Family
+                ConceptId: 202401846
+                ConceptSource: ICTV
+                IctvId: 19750006
+                Children:
+                - Name: Orthocoronavirinae
+                  ConceptType: Subfamily
+                  ConceptId: 202401847
+                  ConceptSource: ICTV
+                  IctvId: 20090624
+                  Synonyms:
+                  - Name: Human coronavirus
+                    ConceptId: 7
+                    ConceptSource: NeoIPC
+                    Id: 2609
+                  Children:
+                  - Name: Betacoronavirus
+                    ConceptType: Genus
+                    ConceptId: 202401860
+                    ConceptSource: ICTV
+                    IctvId: 20091082
+                    Children:
+                    - Name: Sarbecovirus
+                      ConceptType: Subgenus
+                      ConceptId: 202406129
+                      ConceptSource: ICTV
+                      IctvId: 20186129
+                      Children:
+                      - Name: Betacoronavirus pandemicum
+                        ConceptType: Species
+                        ConceptId: 202401868
+                        ConceptSource: ICTV
+                        IctvId: 20040588
+                        Children:
+                        - Name: Severe acute respiratory syndrome coronavirus 2
+                          ConceptType: Serotype
+                          ConceptId: Severe acute respiratory syndrome coronavirus 2
+                          ConceptSource: NeoIPC
+                          Id: 2607
+                          Synonyms:
+                          - Name: SARS-CoV-2
+                            ConceptId: "6"
+                            ConceptSource: NeoIPC
+                            Id: 2608
+                        Id: 3549
+                        Synonyms:
+                        - Name: Severe acute respiratory syndrome-related coronavirus
+                          ConceptId: 202101868
+                          ConceptSource: ICTV
+                          Id: 2606
+                          IctvId: 20040588
+          - Name: Picornavirales
+            ConceptType: Order
+            ConceptId: 202401910
+            ConceptSource: ICTV
+            IctvId: 20080005
+            Children:
+            - Name: Caliciviridae
+              ConceptType: Family
+              ConceptId: 202402798
+              ConceptSource: ICTV
+              Id: 2680
+              IctvId: 19810006
+              Children:
+              - Name: Norovirus
+                ConceptType: Genus
+                ConceptId: 202402805
+                ConceptSource: ICTV
+                Id: 578
+                IctvId: 19980200
+                Children:
+                - Name: Norovirus norwalkense
+                  ConceptType: Species
+                  ConceptId: 202402806
+                  ConceptSource: ICTV
+                  Id: 3534
+                  IctvId: 19950817
+                  Synonyms:
+                  - Name: Norwalk virus
+                    ConceptId: 202102806
+                    ConceptSource: ICTV
+                    Id: 647
+                    IctvId: 19950817
+            - Name: Picornaviridae
+              ConceptType: Family
+              ConceptId: 202401953
+              ConceptSource: ICTV
+              Id: 2627
+              IctvId: 19710003
+              Children:
+              - Name: Echovirus
+                ConceptType: Group
+                ConceptId: 27
+                ConceptSource: NeoIPC
+                Id: 2681
+              - Name: Ensavirinae
+                ConceptType: Subfamily
+                ConceptId: 202412925
+                ConceptSource: ICTV
+                IctvId: 202112925
+                Children:
+                - Name: Enterovirus
+                  ConceptType: Genus
+                  ConceptId: 202401982
+                  ConceptSource: ICTV
+                  Id: 502
+                  IctvId: 20081066
+                  Children:
+                  - Name: Human coxsackievirus
+                    ConceptType: Group
+                    ConceptId: 13
+                    ConceptSource: NeoIPC
+                    Id: 2623
+                  - Name: Human coxsackievirus A
+                    ConceptType: Group
+                    ConceptId: 14
+                    ConceptSource: NeoIPC
+                    Id: 2624
+                  - Name: Human coxsackievirus B
+                    ConceptType: Group
+                    ConceptId: 15
+                    ConceptSource: NeoIPC
+                    Id: 2625
+                  - Name: Human rhinovirus
+                    ConceptType: Group
+                    ConceptId: Human rhinovirus
+                    ConceptSource: NeoIPC
+                    Id: 2610
+                  - Name: Enterovirus betacoxsackie
+                    ConceptType: Species
+                    ConceptId: 202401984
+                    ConceptSource: ICTV
+                    Id: 3496
+                    IctvId: 19991248
+                    Synonyms:
+                    - Name: Enterovirus B
+                      ConceptId: 202101984
+                      ConceptSource: ICTV
+                      Id: 2622
+                      IctvId: 19991248
+                  - Name: Enterovirus coxsackiepol
+                    ConceptType: Species
+                    ConceptId: 202401985
+                    ConceptSource: ICTV
+                    Id: 3497
+                    IctvId: 20083305
+                    Children:
+                    - Name: Poliovirus
+                      ConceptType: Serotype
+                      ConceptId: 87
+                      ConceptSource: NeoIPC
+                      Id: 2635
+                    - Name: Poliovirus 1
+                      ConceptType: Serotype
+                      ConceptId: 88
+                      ConceptSource: NeoIPC
+                      Id: 2637
+                    - Name: Poliovirus 2
+                      ConceptType: Serotype
+                      ConceptId: 89
+                      ConceptSource: NeoIPC
+                      Id: 2638
+                    - Name: Poliovirus 3
+                      ConceptType: Serotype
+                      ConceptId: 90
+                      ConceptSource: NeoIPC
+                      Id: 2639
+                    Synonyms:
+                    - Name: Enterovirus C
+                      ConceptId: 202101985
+                      ConceptSource: ICTV
+                      Id: 2636
+                      IctvId: 20083305
+              - Name: Heptrevirinae
+                ConceptType: Subfamily
+                ConceptId: 202412927
+                ConceptSource: ICTV
+                IctvId: 202112927
+                Children:
+                - Name: Hepatovirus
+                  ConceptType: Genus
+                  ConceptId: 202402002
+                  ConceptSource: ICTV
+                  IctvId: 19910153
+                  Children:
+                  - Name: Hepatovirus ahepa
+                    ConceptType: Species
+                    ConceptId: 202402003
+                    ConceptSource: ICTV
+                    Id: 3503
+                    IctvId: 19991254
+                    Synonyms:
+                    - Name: Hepatitis A virus
+                      ConceptId: 19991254
+                      ConceptSource: ICTV
+                      Id: 1568
+                      IctvId: 19991254
+                    - Name: Hepatovirus A
+                      ConceptId: 202102003
+                      ConceptSource: ICTV
+                      Id: 3338
+                      IctvId: 19991254
+        - Name: Stelpaviricetes
+          ConceptType: Class
+          ConceptId: 202407212
+          ConceptSource: ICTV
+          IctvId: 201907212
+          Children:
+          - Name: Stellavirales
+            ConceptType: Order
+            ConceptId: 202407214
+            ConceptSource: ICTV
+            IctvId: 201907214
+            Children:
+            - Name: Astroviridae
+              ConceptType: Family
+              ConceptId: 202402619
+              ConceptSource: ICTV
+              Id: 539
+              IctvId: 19950008
+    - Name: Pararnavirae
+      ConceptType: Kingdom
+      ConceptId: 202407236
+      ConceptSource: ICTV
+      IctvId: 201907236
+      Children:
+      - Name: Artverviricota
+        ConceptType: Phylum
+        ConceptId: 202407237
+        ConceptSource: ICTV
+        IctvId: 201907237
+        Children:
+        - Name: Revtraviricetes
+          ConceptType: Class
+          ConceptId: 202407238
+          ConceptSource: ICTV
+          IctvId: 201907238
+          Children:
+          - Name: Blubervirales
+            ConceptType: Order
+            ConceptId: 202407239
+            ConceptSource: ICTV
+            IctvId: 201907239
+            Children:
+            - Name: Hepadnaviridae
+              ConceptType: Family
+              ConceptId: 202403645
+              ConceptSource: ICTV
+              IctvId: 19900016
+              Children:
+              - Name: Orthohepadnavirus
+                ConceptType: Genus
+                ConceptId: 202403651
+                ConceptSource: ICTV
+                IctvId: 19910119
+                Children:
+                - Name: Orthohepadnavirus hominoidei
+                  ConceptType: Species
+                  ConceptId: 202403653
+                  ConceptSource: ICTV
+                  Id: 3502
+                  IctvId: 19910781
+                  Synonyms:
+                  - Name: Hepatitis B virus
+                    ConceptId: 202103653
+                    ConceptSource: ICTV
+                    Id: 1903
+                    IctvId: 19910781
+          - Name: Ortervirales
+            ConceptType: Order
+            ConceptId: 202405588
+            ConceptSource: ICTV
+            IctvId: 20175588
+            Children:
+            - Name: Retroviridae
+              ConceptType: Family
+              ConceptId: 202404979
+              ConceptSource: ICTV
+              IctvId: 19750016
+              Children:
+              - Name: Orthoretrovirinae
+                ConceptType: Subfamily
+                ConceptId: 202404980
+                ConceptSource: ICTV
+                IctvId: 20025143
+                Children:
+                - Name: Deltaretrovirus
+                  ConceptType: Genus
+                  ConceptId: 202404997
+                  ConceptSource: ICTV
+                  IctvId: 19900174
+                  Children:
+                  - Name: Deltaretrovirus priTlym1
+                    ConceptType: Species
+                    ConceptId: 202404999
+                    ConceptSource: ICTV
+                    Id: 3539
+                    IctvId: 19911434
+                    Synonyms:
+                    - Name: Human T-lymphotropic virus 1
+                      ConceptId: "25"
+                      ConceptSource: NeoIPC
+                      Id: 2676
+                    - Name: Primate T-lymphotropic virus 1
+                      ConceptId: 202104999
+                      ConceptSource: ICTV
+                      Id: 2675
+                      IctvId: 19911434
+                  - Name: Deltaretrovirus priTlym2
+                    ConceptType: Species
+                    ConceptId: 202405000
+                    ConceptSource: ICTV
+                    Id: 3540
+                    IctvId: 19911435
+                    Synonyms:
+                    - Name: Human T-lymphotropic virus 2
+                      ConceptId: "26"
+                      ConceptSource: NeoIPC
+                      Id: 2678
+                    - Name: Primate T-lymphotropic virus 2
+                      ConceptId: 202105000
+                      ConceptSource: ICTV
+                      Id: 2677
+                      IctvId: 19911435
+                  - Name: Deltaretrovirus priTlym3
+                    ConceptType: Species
+                    ConceptId: 202405001
+                    ConceptSource: ICTV
+                    Id: 3541
+                    IctvId: 19991616
+                    Synonyms:
+                    - Name: Primate T-lymphotropic virus 3
+                      ConceptId: 202105001
+                      ConceptSource: ICTV
+                      Id: 2679
+                      IctvId: 19991616
+                - Name: Lentivirus
+                  ConceptType: Genus
+                  ConceptId: 202405025
+                  ConceptSource: ICTV
+                  IctvId: 19900175
+                  Children:
+                  - Name: Human immunodeficiency virus
+                    ConceptType: Group
+                    ConceptId: 19
+                    ConceptSource: NeoIPC
+                    Id: 2634
+                    Children:
+                    - Name: Lentivirus humimdef1
+                      ConceptType: Species
+                      ConceptId: 202405030
+                      ConceptSource: ICTV
+                      Id: 3513
+                      IctvId: 19911441
+                      Synonyms:
+                      - Name: Human immunodeficiency virus 1
+                        ConceptId: 202105030
+                        ConceptSource: ICTV
+                        Id: 2632
+                        IctvId: 19911441
+                    - Name: Lentivirus humimdef2
+                      ConceptType: Species
+                      ConceptId: 202405031
+                      ConceptSource: ICTV
+                      Id: 3514
+                      IctvId: 19911442
+                      Synonyms:
+                      - Name: Human immunodeficiency virus 2
+                        ConceptId: 202105031
+                        ConceptSource: ICTV
+                        Id: 2633
+                        IctvId: 19911442
+  - Name: Ribozyviria
+    ConceptType: Realm
+    ConceptId: 202409292
+    ConceptSource: ICTV
+    IctvId: 202009292
+    Children:
+    - Name: Kolmioviridae
+      ConceptType: Family
+      ConceptId: 202409293
+      ConceptSource: ICTV
+      IctvId: 202009293
+      Children:
+      - Name: Deltavirus
+        ConceptType: Genus
+        ConceptId: 202405347
+        ConceptSource: ICTV
+        Id: 3480
+        IctvId: 19930250
+        Synonyms:
+        - Name: Hepatitis D virus
+          ConceptId: "17"
+          ConceptSource: NeoIPC
+          Id: 2628
+  - Name: Varidnaviria
+    ConceptType: Realm
+    ConceptId: 202408702
+    ConceptSource: ICTV
+    IctvId: 201908702
+    Children:
+    - Name: Bamfordvirae
+      ConceptType: Kingdom
+      ConceptId: 202408707
+      ConceptSource: ICTV
+      IctvId: 201908707
+      Children:
+      - Name: Nucleocytoviricota
+        ConceptType: Phylum
+        ConceptId: 202408716
+        ConceptSource: ICTV
+        IctvId: 201908716
+        Children:
+        - Name: Pokkesviricetes
+          ConceptType: Class
+          ConceptId: 202407100
+          ConceptSource: ICTV
+          IctvId: 201907100
+          Children:
+          - Name: Chitovirales
+            ConceptType: Order
+            ConceptId: 202407102
+            ConceptSource: ICTV
+            IctvId: 201907102
+            Children:
+            - Name: Poxviridae
+              ConceptType: Family
+              ConceptId: 202404737
+              ConceptSource: ICTV
+              Id: 480
+              IctvId: 19740004
+              Children:
+              - Name: Chordopoxvirinae
+                ConceptType: Subfamily
+                ConceptId: 202404738
+                ConceptSource: ICTV
+                IctvId: 19780046
+                Children:
+                - Name: Molluscipoxvirus
+                  ConceptType: Genus
+                  ConceptId: 202404765
+                  ConceptSource: ICTV
+                  IctvId: 19900158
+                  Children:
+                  - Name: Molluscipoxvirus molluscum
+                    ConceptType: Species
+                    ConceptId: 202404766
+                    ConceptSource: ICTV
+                    Id: 3531
+                    IctvId: 19710278
+                    Synonyms:
+                    - Name: Molluscum contagiosum virus
+                      ConceptId: 202104766
+                      ConceptSource: ICTV
+                      Id: 1289
+                      IctvId: 19710278
+                - Name: Orthopoxvirus
+                  ConceptType: Genus
+                  ConceptId: 202404767
+                  ConceptSource: ICTV
+                  IctvId: 19740023
+                  Children:
+                  - Name: Orthopoxvirus monkeypox
+                    ConceptType: Species
+                    ConceptId: 202404771
+                    ConceptSource: ICTV
+                    Id: 3532
+                    IctvId: 19710279
+                    Synonyms:
+                    - Name: Monkeypox virus
+                      ConceptId: 202104771
+                      ConceptSource: ICTV
+                      Id: 1084
+                      IctvId: 19710279
+                  - Name: Orthopoxvirus vaccinia
+                    ConceptType: Species
+                    ConceptId: 202404775
+                    ConceptSource: ICTV
+                    Id: 3554
+                    IctvId: 19911346
+                    Synonyms:
+                    - Name: Vaccinia virus
+                      ConceptId: 202104775
+                      ConceptSource: ICTV
+                      Id: 210
+                      IctvId: 19911346
+                  - Name: Orthopoxvirus variola
+                    ConceptType: Species
+                    ConceptId: 202404776
+                    ConceptSource: ICTV
+                    Id: 3555
+                    IctvId: 19710294
+                    Synonyms:
+                    - Name: Variola virus
+                      ConceptId: 202104776
+                      ConceptSource: ICTV
+                      Id: 2339
+                      IctvId: 19710294
+                - Name: Parapoxvirus
+                  ConceptType: Genus
+                  ConceptId: 202404778
+                  ConceptSource: ICTV
+                  IctvId: 19740024
+                  Children:
+                  - Name: Parapoxvirus orf
+                    ConceptType: Species
+                    ConceptId: 202404780
+                    ConceptSource: ICTV
+                    Id: 3535
+                    IctvId: 19710281
+                    Synonyms:
+                    - Name: Orf virus
+                      ConceptId: 202104780
+                      ConceptSource: ICTV
+                      Id: 1510
+                      IctvId: 19710281
+                - Name: Yatapoxvirus
+                  ConceptType: Genus
+                  ConceptId: 202404788
+                  ConceptSource: ICTV
+                  IctvId: 19900163
+                  Children:
+                  - Name: Yatapoxvirus tanapox
+                    ConceptType: Species
+                    ConceptId: 202404789
+                    ConceptSource: ICTV
+                    Id: 3552
+                    IctvId: 19710291
+                    Synonyms:
+                    - Name: Tanapox virus
+                      ConceptId: 202104789
+                      ConceptSource: ICTV
+                      Id: 1836
+                      IctvId: 19710291
+      - Name: Preplasmiviricota
+        ConceptType: Phylum
+        ConceptId: 202408708
+        ConceptSource: ICTV
+        IctvId: 201908708
+        Children:
+        - Name: Polisuviricotina
+          ConceptType: Subphylum
+          ConceptId: 202419582
+          ConceptSource: ICTV
+          IctvId: 202419582
+          Children:
+          - Name: Pharingeaviricetes
+            ConceptType: Class
+            ConceptId: 202419586
+            ConceptSource: ICTV
+            IctvId: 202419586
+            Children:
+            - Name: Rowavirales
+              ConceptType: Order
+              ConceptId: 202408711
+              ConceptSource: ICTV
+              IctvId: 201908711
+              Children:
+              - Name: Adenoviridae
+                ConceptType: Family
+                ConceptId: 202402387
+                ConceptSource: ICTV
+                IctvId: 19750002
+                Children:
+                - Name: Mastadenovirus
+                  ConceptType: Genus
+                  ConceptId: 202402412
+                  ConceptSource: ICTV
+                  Id: 387
+                  IctvId: 19710013
+                  Children:
+                  - Name: Human adenovirus
+                    ConceptType: Group
+                    ConceptId: 28
+                    ConceptSource: NeoIPC
+                    Id: 2692
+- Name: Bacteria
+  ConceptType: Domain
+  ConceptId: domain/bacteria
+  ConceptSource: LPSN
+  LpsnRecordNumber: 43123
+  Children:
+  - Name: Bacillati
+    ConceptType: Kingdom
+    ConceptId: kingdom/bacillati
+    ConceptSource: LPSN
+    LpsnRecordNumber: 43129
+    Children:
+    - Name: Actinomycetota
+      ConceptType: Phylum
+      ConceptId: phylum/actinomycetota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 51272
+      Children:
+      - Name: Actinomycetes
+        ConceptType: Class
+        ConceptId: class/actinomycetes
+        ConceptSource: LPSN
+        LpsnRecordNumber: 3
+        Children:
+        - Name: Actinomycetales
+          ConceptType: Order
+          ConceptId: order/actinomycetales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5010
+          Children:
+          - Name: Actinomycetaceae
+            ConceptType: Family
+            ConceptId: family/actinomycetaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 45
+            Children:
+            - Name: Actinobaculum
+              ConceptType: Genus
+              ConceptId: genus/actinobaculum
+              ConceptSource: LPSN
+              Id: 890
+              LpsnRecordNumber: 515030
+              Children:
+              - Name: Actinobaculum massiliense
+                ConceptType: Species
+                ConceptId: species/actinobaculum-massiliense
+                ConceptSource: LPSN
+                Id: 2930
+                LpsnRecordNumber: 785464
+            - Name: Actinomyces
+              ConceptType: Genus
+              ConceptId: genus/actinomyces
+              ConceptSource: LPSN
+              Id: 743
+              LpsnRecordNumber: 515038
+              CommonCommensal: true
+              Children:
+              - Name: Actinomyces bovis
+                ConceptType: Species
+                ConceptId: species/actinomyces-bovis
+                ConceptSource: LPSN
+                Id: 1833
+                LpsnRecordNumber: 772765
+                CommonCommensal: true
+              - Name: Actinomyces dentalis
+                ConceptType: Species
+                ConceptId: species/actinomyces-dentalis
+                ConceptSource: LPSN
+                Id: 702
+                LpsnRecordNumber: 783300
+                CommonCommensal: true
+              - Name: Actinomyces gerencseriae
+                ConceptType: Species
+                ConceptId: species/actinomyces-gerencseriae
+                ConceptSource: LPSN
+                Id: 1677
+                LpsnRecordNumber: 772780
+                CommonCommensal: true
+              - Name: Actinomyces graevenitzii
+                ConceptType: Species
+                ConceptId: species/actinomyces-graevenitzii
+                ConceptSource: LPSN
+                Id: 2434
+                LpsnRecordNumber: 772784
+                CommonCommensal: true
+              - Name: Actinomyces israelii
+                ConceptType: Species
+                ConceptId: species/actinomyces-israelii
+                ConceptSource: LPSN
+                Id: 1341
+                LpsnRecordNumber: 772789
+                CommonCommensal: true
+              - Name: Actinomyces naeslundii
+                ConceptType: Species
+                ConceptId: species/actinomyces-naeslundii
+                ConceptSource: LPSN
+                Id: 1152
+                LpsnRecordNumber: 772795
+                CommonCommensal: true
+              - Name: Actinomyces oricola
+                ConceptType: Species
+                ConceptId: species/actinomyces-oricola
+                ConceptSource: LPSN
+                Id: 639
+                LpsnRecordNumber: 772799
+                CommonCommensal: true
+              - Name: Actinomyces oris
+                ConceptType: Species
+                ConceptId: species/actinomyces-oris
+                ConceptSource: LPSN
+                Id: 2519
+                LpsnRecordNumber: 787742
+                CommonCommensal: true
+              - Name: Actinomyces radicidentis
+                ConceptType: Species
+                ConceptId: species/actinomyces-radicidentis
+                ConceptSource: LPSN
+                Id: 538
+                LpsnRecordNumber: 772802
+                CommonCommensal: true
+              - Name: Actinomyces urogenitalis
+                ConceptType: Species
+                ConceptId: species/actinomyces-urogenitalis
+                ConceptSource: LPSN
+                Id: 67
+                LpsnRecordNumber: 772811
+                CommonCommensal: true
+              - Name: Actinomyces viscosus
+                ConceptType: Species
+                ConceptId: species/actinomyces-viscosus
+                ConceptSource: LPSN
+                Id: 1104
+                LpsnRecordNumber: 772815
+                CommonCommensal: true
+            - Name: Actinotignum
+              ConceptType: Genus
+              ConceptId: genus/actinotignum
+              ConceptSource: LPSN
+              Id: 2442
+              LpsnRecordNumber: 518671
+              Children:
+              - Name: Actinotignum schaalii
+                ConceptType: Species
+                ConceptId: species/actinotignum-schaalii
+                ConceptSource: LPSN
+                Id: 2313
+                LpsnRecordNumber: 792534
+                Synonyms:
+                - Name: Actinobaculum schaalii
+                  ConceptId: species/actinobaculum-schaalii
+                  ConceptSource: LPSN
+                  Id: 2207
+                  LpsnRecordNumber: 772663
+              - Name: Actinotignum urinale
+                ConceptType: Species
+                ConceptId: species/actinotignum-urinale
+                ConceptSource: LPSN
+                Id: 239
+                LpsnRecordNumber: 792535
+                Synonyms:
+                - Name: Actinobaculum urinale
+                  ConceptId: species/actinobaculum-urinale
+                  ConceptSource: LPSN
+                  Id: 839
+                  LpsnRecordNumber: 772665
+            - Name: Arcanobacterium
+              ConceptType: Genus
+              ConceptId: genus/arcanobacterium
+              ConceptSource: LPSN
+              Id: 439
+              LpsnRecordNumber: 515165
+              CommonCommensal: true
+              Children:
+              - Name: Arcanobacterium haemolyticum
+                ConceptType: Species
+                ConceptId: species/arcanobacterium-haemolyticum
+                ConceptSource: LPSN
+                Id: 1418
+                LpsnRecordNumber: 773354
+                CommonCommensal: true
+              - Name: Arcanobacterium pluranimalium
+                ConceptType: Species
+                ConceptId: species/arcanobacterium-pluranimalium
+                ConceptSource: LPSN
+                Id: 90
+                LpsnRecordNumber: 773357
+                CommonCommensal: true
+            - Name: Bowdeniella
+              ConceptType: Genus
+              ConceptId: genus/bowdeniella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520428
+              Children:
+              - Name: Bowdeniella nasicola
+                ConceptType: Species
+                ConceptId: species/bowdeniella-nasicola
+                ConceptSource: LPSN
+                Id: 3038
+                LpsnRecordNumber: 798118
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces nasicola
+                  ConceptId: species/actinomyces-nasicola
+                  ConceptSource: LPSN
+                  Id: 759
+                  LpsnRecordNumber: 783309
+            - Name: Gleimia
+              ConceptType: Genus
+              ConceptId: genus/gleimia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520433
+              Children:
+              - Name: Gleimia europaea
+                ConceptType: Species
+                ConceptId: species/gleimia-europaea
+                ConceptSource: LPSN
+                Id: 3189
+                LpsnRecordNumber: 798107
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces europaeus
+                  ConceptId: species/actinomyces-europaeus
+                  ConceptSource: LPSN
+                  Id: 1676
+                  LpsnRecordNumber: 772773
+            - Name: Mobiluncus
+              ConceptType: Genus
+              ConceptId: genus/mobiluncus
+              ConceptSource: LPSN
+              Id: 1306
+              LpsnRecordNumber: 516109
+              Children:
+              - Name: Mobiluncus curtisii
+                ConceptType: Species
+                ConceptId: species/mobiluncus-curtisii
+                ConceptSource: LPSN
+                Id: 2297
+                LpsnRecordNumber: 778275
+              - Name: Mobiluncus holmesii
+                ConceptType: Species
+                ConceptId: species/mobiluncus-holmesii
+                ConceptSource: LPSN
+                Id: 3322
+                LpsnRecordNumber: 798129
+                Synonyms:
+                - Name: Falcivibrio vaginalis
+                  ConceptId: species/falcivibrio-vaginalis
+                  ConceptSource: LPSN
+                  Id: 25
+                  LpsnRecordNumber: 776175
+              - Name: Mobiluncus mulieris
+                ConceptType: Species
+                ConceptId: species/mobiluncus-mulieris
+                ConceptSource: LPSN
+                Id: 1819
+                LpsnRecordNumber: 778276
+                Synonyms:
+                - Name: Falcivibrio grandis
+                  ConceptId: species/falcivibrio-grandis
+                  ConceptSource: LPSN
+                  Id: 1381
+                  LpsnRecordNumber: 776174
+            - Name: Pauljensenia
+              ConceptType: Genus
+              ConceptId: genus/pauljensenia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520443
+              Children:
+              - Name: Pauljensenia hongkongensis
+                ConceptType: Species
+                ConceptId: species/pauljensenia-hongkongensis
+                ConceptSource: LPSN
+                Id: 3084
+                LpsnRecordNumber: 798111
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces hongkongensis
+                  ConceptId: species/actinomyces-hongkongensis
+                  ConceptSource: LPSN
+                  Id: 1214
+                  LpsnRecordNumber: 772785
+            - Name: Schaalia
+              ConceptType: Genus
+              ConceptId: genus/schaalia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520445
+              Children:
+              - Name: Schaalia cardiffensis
+                ConceptType: Species
+                ConceptId: species/schaalia-cardiffensis
+                ConceptSource: LPSN
+                Id: 3241
+                LpsnRecordNumber: 798105
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces cardiffensis
+                  ConceptId: species/actinomyces-cardiffensis
+                  ConceptSource: LPSN
+                  Id: 2162
+                  LpsnRecordNumber: 772768
+              - Name: Schaalia funkei
+                ConceptType: Species
+                ConceptId: species/schaalia-funkei
+                ConceptSource: LPSN
+                Id: 3251
+                LpsnRecordNumber: 798108
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces funkei
+                  ConceptId: species/actinomyces-funkei
+                  ConceptSource: LPSN
+                  Id: 2229
+                  LpsnRecordNumber: 772778
+              - Name: Schaalia georgiae
+                ConceptType: Species
+                ConceptId: species/schaalia-georgiae
+                ConceptSource: LPSN
+                Id: 3208
+                LpsnRecordNumber: 798109
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces georgiae
+                  ConceptId: species/actinomyces-georgiae
+                  ConceptSource: LPSN
+                  Id: 988
+                  LpsnRecordNumber: 772779
+              - Name: Schaalia meyeri
+                ConceptType: Species
+                ConceptId: species/schaalia-meyeri
+                ConceptSource: LPSN
+                Id: 3267
+                LpsnRecordNumber: 798116
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces meyeri
+                  ConceptId: species/actinomyces-meyeri
+                  ConceptSource: LPSN
+                  Id: 2211
+                  LpsnRecordNumber: 772794
+              - Name: Schaalia odontolytica
+                ConceptType: Species
+                ConceptId: species/schaalia-odontolytica
+                ConceptSource: LPSN
+                Id: 3298
+                LpsnRecordNumber: 798123
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces odontolyticus
+                  ConceptId: species/actinomyces-odontolyticus
+                  ConceptSource: LPSN
+                  Id: 2466
+                  LpsnRecordNumber: 772798
+              - Name: Schaalia radingae
+                ConceptType: Species
+                ConceptId: species/schaalia-radingae
+                ConceptSource: LPSN
+                Id: 3166
+                LpsnRecordNumber: 798124
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces radingae
+                  ConceptId: species/actinomyces-radingae
+                  ConceptSource: LPSN
+                  Id: 119
+                  LpsnRecordNumber: 772803
+              - Name: Schaalia turicensis
+                ConceptType: Species
+                ConceptId: species/schaalia-turicensis
+                ConceptSource: LPSN
+                Id: 3040
+                LpsnRecordNumber: 798126
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces turicensis
+                  ConceptId: species/actinomyces-turicensis
+                  ConceptSource: LPSN
+                  Id: 1558
+                  LpsnRecordNumber: 772810
+            - Name: Trueperella
+              ConceptType: Genus
+              ConceptId: genus/trueperella
+              ConceptSource: LPSN
+              Id: 2542
+              LpsnRecordNumber: 518094
+              CommonCommensal: true
+              Children:
+              - Name: Trueperella bernardiae
+                ConceptType: Species
+                ConceptId: species/trueperella-bernardiae
+                ConceptSource: LPSN
+                Id: 295
+                LpsnRecordNumber: 789265
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces bernardiae
+                  ConceptId: species/actinomyces-bernardiae
+                  ConceptSource: LPSN
+                  Id: 688
+                  LpsnRecordNumber: 772764
+                - Name: Arcanobacterium bernardiae
+                  ConceptId: species/arcanobacterium-bernardiae
+                  ConceptSource: LPSN
+                  Id: 2239
+                  LpsnRecordNumber: 773351
+              - Name: Trueperella pyogenes
+                ConceptType: Species
+                ConceptId: species/trueperella-pyogenes
+                ConceptSource: LPSN
+                Id: 2122
+                LpsnRecordNumber: 789262
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arcanobacterium pyogenes
+                  ConceptId: species/arcanobacterium-pyogenes
+                  ConceptSource: LPSN
+                  Id: 112
+                  LpsnRecordNumber: 773358
+                - Name: Corynebacterium pyogenes
+                  ConceptId: species/corynebacterium-pyogenes
+                  ConceptSource: LPSN
+                  Id: 754
+                  LpsnRecordNumber: 775241
+            - Name: Winkia
+              ConceptType: Genus
+              ConceptId: genus/winkia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520447
+              Children:
+              - Name: Winkia neuii
+                ConceptType: Species
+                ConceptId: species/winkia-neuii
+                ConceptSource: LPSN
+                Id: 3056
+                LpsnRecordNumber: 798121
+                CommonCommensal: true
+                Synonyms:
+                - Name: Actinomyces neuii
+                  ConceptId: species/actinomyces-neuii
+                  ConceptSource: LPSN
+                  Id: 2055
+                  LpsnRecordNumber: 798119
+        - Name: Bifidobacteriales
+          ConceptType: Order
+          ConceptId: order/bifidobacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5047
+          Children:
+          - Name: Bifidobacteriaceae
+            ConceptType: Family
+            ConceptId: family/bifidobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 213
+            Children:
+            - Name: Alloscardovia
+              ConceptType: Genus
+              ConceptId: genus/alloscardovia
+              ConceptSource: LPSN
+              Id: 786
+              LpsnRecordNumber: 517608
+              Children:
+              - Name: Alloscardovia omnicolens
+                ConceptType: Species
+                ConceptId: species/alloscardovia-omnicolens
+                ConceptSource: LPSN
+                Id: 2320
+                LpsnRecordNumber: 786483
+            - Name: Bifidobacterium
+              ConceptType: Genus
+              ConceptId: genus/bifidobacterium
+              ConceptSource: LPSN
+              Id: 8
+              LpsnRecordNumber: 515236
+              Children:
+              - Name: Bifidobacterium adolescentis
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-adolescentis
+                ConceptSource: LPSN
+                Id: 840
+                LpsnRecordNumber: 774020
+              - Name: Bifidobacterium angulatum
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-angulatum
+                ConceptSource: LPSN
+                Id: 1351
+                LpsnRecordNumber: 774021
+              - Name: Bifidobacterium bifidum
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-bifidum
+                ConceptSource: LPSN
+                Id: 419
+                LpsnRecordNumber: 774026
+              - Name: Bifidobacterium breve
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-breve
+                ConceptSource: LPSN
+                Id: 1041
+                LpsnRecordNumber: 774028
+              - Name: Bifidobacterium catenulatum
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-catenulatum
+                ConceptSource: LPSN
+                Id: 330
+                LpsnRecordNumber: 774029
+              - Name: Bifidobacterium dentium
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-dentium
+                ConceptSource: LPSN
+                Id: 1371
+                LpsnRecordNumber: 774034
+              - Name: Bifidobacterium gallicum
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-gallicum
+                ConceptSource: LPSN
+                Id: 1734
+                LpsnRecordNumber: 774035
+              - Name: Bifidobacterium longum
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-longum
+                ConceptSource: LPSN
+                Id: 1241
+                LpsnRecordNumber: 774044
+                Children:
+                - Name: Bifidobacterium longum subsp. infantis
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/bifidobacterium-longum-infantis
+                  ConceptSource: LPSN
+                  Id: 3043
+                  LpsnRecordNumber: 787283
+                  Synonyms:
+                  - Name: Bifidobacterium infantis
+                    ConceptId: species/bifidobacterium-infantis
+                    ConceptSource: LPSN
+                    Id: 354
+                    LpsnRecordNumber: 774039
+                - Name: Bifidobacterium longum subsp. suis
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/bifidobacterium-longum-suis
+                  ConceptSource: LPSN
+                  Id: 3065
+                  LpsnRecordNumber: 787284
+                  Synonyms:
+                  - Name: Bifidobacterium suis
+                    ConceptId: species/bifidobacterium-suis
+                    ConceptSource: LPSN
+                    Id: 1292
+                    LpsnRecordNumber: 774061
+              - Name: Bifidobacterium pseudocatenulatum
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-pseudocatenulatum
+                ConceptSource: LPSN
+                Id: 30
+                LpsnRecordNumber: 774050
+              - Name: Bifidobacterium scardovii
+                ConceptType: Species
+                ConceptId: species/bifidobacterium-scardovii
+                ConceptSource: LPSN
+                Id: 1173
+                LpsnRecordNumber: 774058
+            - Name: Gardnerella
+              ConceptType: Genus
+              ConceptId: genus/gardnerella
+              ConceptSource: LPSN
+              Id: 1181
+              LpsnRecordNumber: 515677
+              Children:
+              - Name: Gardnerella vaginalis
+                ConceptType: Species
+                ConceptId: species/gardnerella-vaginalis
+                ConceptSource: LPSN
+                Id: 1226
+                LpsnRecordNumber: 776427
+            - Name: Parascardovia
+              ConceptType: Genus
+              ConceptId: genus/parascardovia
+              ConceptSource: LPSN
+              Id: 749
+              LpsnRecordNumber: 516260
+              Children:
+              - Name: Parascardovia denticolens
+                ConceptType: Species
+                ConceptId: species/parascardovia-denticolens
+                ConceptSource: LPSN
+                Id: 711
+                LpsnRecordNumber: 779172
+                Synonyms:
+                - Name: Bifidobacterium denticolens
+                  ConceptId: species/bifidobacterium-denticolens
+                  ConceptSource: LPSN
+                  Id: 2829
+                  LpsnRecordNumber: 774033
+            - Name: Scardovia
+              ConceptType: Genus
+              ConceptId: genus/scardovia
+              ConceptSource: LPSN
+              Id: 1885
+              LpsnRecordNumber: 516559
+              Children:
+              - Name: Scardovia inopinata
+                ConceptType: Species
+                ConceptId: species/scardovia-inopinata
+                ConceptSource: LPSN
+                Id: 1652
+                LpsnRecordNumber: 780800
+                Synonyms:
+                - Name: Bifidobacterium inopinatum
+                  ConceptId: species/bifidobacterium-inopinatum
+                  ConceptSource: LPSN
+                  Id: 2830
+                  LpsnRecordNumber: 774040
+        - Name: Kitasatosporales
+          ConceptType: Order
+          ConceptId: order/kitasatosporales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 34886
+          Children:
+          - Name: Streptomycetaceae
+            ConceptType: Family
+            ConceptId: family/streptomycetaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1348
+            Children:
+            - Name: Streptomyces
+              ConceptType: Genus
+              ConceptId: genus/streptomyces
+              ConceptSource: LPSN
+              Id: 2507
+              LpsnRecordNumber: 517119
+              Children:
+              - Name: Streptomyces albus
+                ConceptType: Species
+                ConceptId: species/streptomyces-albus
+                ConceptSource: LPSN
+                Id: 1319
+                LpsnRecordNumber: 781439
+              - Name: Streptomyces bikiniensis
+                ConceptType: Species
+                ConceptId: species/streptomyces-bikiniensis
+                ConceptSource: LPSN
+                Id: 1176
+                LpsnRecordNumber: 781496
+              - Name: Streptomyces candidus
+                ConceptType: Species
+                ConceptId: species/streptomyces-candidus
+                ConceptSource: LPSN
+                Id: 2040
+                LpsnRecordNumber: 781515
+              - Name: Streptomyces clavuligerus
+                ConceptType: Species
+                ConceptId: species/streptomyces-clavuligerus
+                ConceptSource: LPSN
+                Id: 2501
+                LpsnRecordNumber: 781573
+              - Name: Streptomyces filamentosus
+                ConceptType: Species
+                ConceptId: species/streptomyces-filamentosus
+                ConceptSource: LPSN
+                Id: 2023
+                LpsnRecordNumber: 781642
+                Synonyms:
+                - Name: Streptomyces roseosporus
+                  ConceptId: species/streptomyces-roseosporus
+                  ConceptSource: LPSN
+                  Id: 255
+                  LpsnRecordNumber: 781998
+              - Name: Streptomyces griseus
+                ConceptType: Species
+                ConceptId: species/streptomyces-griseus
+                ConceptSource: LPSN
+                Id: 2445
+                LpsnRecordNumber: 781730
+                Synonyms:
+                - Name: Streptomyces caviscabies
+                  ConceptId: species/streptomyces-caviscabies
+                  ConceptSource: LPSN
+                  Id: 950
+                  LpsnRecordNumber: 781532
+                - Name: Streptomyces erumpens
+                  ConceptId: species/streptomyces-erumpens
+                  ConceptSource: LPSN
+                  Id: 383
+                  LpsnRecordNumber: 781627
+                - Name: Streptomyces setonii
+                  ConceptId: species/streptomyces-setonii
+                  ConceptSource: LPSN
+                  Id: 329
+                  LpsnRecordNumber: 782028
+              - Name: Streptomyces lincolnensis
+                ConceptType: Species
+                ConceptId: species/streptomyces-lincolnensis
+                ConceptSource: LPSN
+                Id: 638
+                LpsnRecordNumber: 781810
+              - Name: Streptomyces somaliensis
+                ConceptType: Species
+                ConceptId: species/streptomyces-somaliensis
+                ConceptSource: LPSN
+                Id: 773
+                LpsnRecordNumber: 782033
+              - Name: Streptomyces spectabilis
+                ConceptType: Species
+                ConceptId: species/streptomyces-spectabilis
+                ConceptSource: LPSN
+                Id: 2163
+                LpsnRecordNumber: 782038
+              - Name: Streptomyces thermovulgaris
+                ConceptType: Species
+                ConceptId: species/streptomyces-thermovulgaris
+                ConceptSource: LPSN
+                Id: 151
+                LpsnRecordNumber: 782081
+              - Name: Streptomyces venezuelae
+                ConceptType: Species
+                ConceptId: species/streptomyces-venezuelae
+                ConceptSource: LPSN
+                Id: 2456
+                LpsnRecordNumber: 782100
+        - Name: Micrococcales
+          ConceptType: Order
+          ConceptId: order/micrococcales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5022
+          Children:
+          - Name: Brevibacteriaceae
+            ConceptType: Family
+            ConceptId: family/brevibacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 238
+            Children:
+            - Name: Brevibacterium
+              ConceptType: Genus
+              ConceptId: genus/brevibacterium
+              ConceptSource: LPSN
+              Id: 1251
+              LpsnRecordNumber: 515270
+              CommonCommensal: true
+              Children:
+              - Name: Brevibacterium casei
+                ConceptType: Species
+                ConceptId: species/brevibacterium-casei
+                ConceptSource: LPSN
+                Id: 75
+                LpsnRecordNumber: 774200
+                CommonCommensal: true
+              - Name: Brevibacterium epidermidis
+                ConceptType: Species
+                ConceptId: species/brevibacterium-epidermidis
+                ConceptSource: LPSN
+                Id: 1643
+                LpsnRecordNumber: 774205
+                CommonCommensal: true
+              - Name: Brevibacterium linens
+                ConceptType: Species
+                ConceptId: species/brevibacterium-linens
+                ConceptSource: LPSN
+                Id: 721
+                LpsnRecordNumber: 774217
+                CommonCommensal: true
+              - Name: Brevibacterium luteolum
+                ConceptType: Species
+                ConceptId: species/brevibacterium-luteolum
+                ConceptSource: LPSN
+                Id: 531
+                LpsnRecordNumber: 774220
+                CommonCommensal: true
+              - Name: Brevibacterium mcbrellneri
+                ConceptType: Species
+                ConceptId: species/brevibacterium-mcbrellneri
+                ConceptSource: LPSN
+                Id: 2541
+                LpsnRecordNumber: 774224
+                CommonCommensal: true
+              - Name: Brevibacterium ravenspurgense
+                ConceptType: Species
+                ConceptId: species/brevibacterium-ravenspurgense
+                ConceptSource: LPSN
+                Id: 1673
+                LpsnRecordNumber: 787630
+                CommonCommensal: true
+              - Name: Brevibacterium sanguinis
+                ConceptType: Species
+                ConceptId: species/brevibacterium-sanguinis
+                ConceptSource: LPSN
+                Id: 692
+                LpsnRecordNumber: 774233
+                CommonCommensal: true
+          - Name: Cellulomonadaceae
+            ConceptType: Family
+            ConceptId: family/cellulomonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 292
+            Children:
+            - Name: Cellulomonas
+              ConceptType: Genus
+              ConceptId: genus/cellulomonas
+              ConceptSource: LPSN
+              Id: 392
+              LpsnRecordNumber: 515328
+              CommonCommensal: true
+              Children:
+              - Name: Cellulomonas hominis
+                ConceptType: Species
+                ConceptId: species/cellulomonas-hominis
+                ConceptSource: LPSN
+                Id: 2440
+                LpsnRecordNumber: 774554
+                CommonCommensal: true
+              - Name: Cellulomonas humilata
+                ConceptType: Species
+                ConceptId: species/cellulomonas-humilata
+                ConceptSource: LPSN
+                Id: 1662
+                LpsnRecordNumber: 774555
+                CommonCommensal: true
+          - Name: Dermabacteraceae
+            ConceptType: Family
+            ConceptId: family/dermabacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 390
+            Children:
+            - Name: Brachybacterium
+              ConceptType: Genus
+              ConceptId: genus/brachybacterium
+              ConceptSource: LPSN
+              Id: 1841
+              LpsnRecordNumber: 515261
+              Children:
+              - Name: Brachybacterium muris
+                ConceptType: Species
+                ConceptId: species/brachybacterium-muris
+                ConceptSource: LPSN
+                Id: 2595
+                LpsnRecordNumber: 774151
+            - Name: Dermabacter
+              ConceptType: Genus
+              ConceptId: genus/dermabacter
+              ConceptSource: LPSN
+              Id: 993
+              LpsnRecordNumber: 515491
+              CommonCommensal: true
+              Children:
+              - Name: Dermabacter hominis
+                ConceptType: Species
+                ConceptId: species/dermabacter-hominis
+                ConceptSource: LPSN
+                Id: 745
+                LpsnRecordNumber: 775505
+                CommonCommensal: true
+          - Name: Dermacoccaceae
+            ConceptType: Family
+            ConceptId: family/dermacoccaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 391
+            Children:
+            - Name: Dermacoccus
+              ConceptType: Genus
+              ConceptId: genus/dermacoccus
+              ConceptSource: LPSN
+              Id: 2552
+              LpsnRecordNumber: 515492
+              CommonCommensal: true
+              Children:
+              - Name: Dermacoccus nishinomiyaensis
+                ConceptType: Species
+                ConceptId: species/dermacoccus-nishinomiyaensis
+                ConceptSource: LPSN
+                Id: 545
+                LpsnRecordNumber: 775508
+                CommonCommensal: true
+                Synonyms:
+                - Name: Micrococcus nishinomiyaensis
+                  ConceptId: species/micrococcus-nishinomiyaensis
+                  ConceptSource: LPSN
+                  Id: 408
+                  LpsnRecordNumber: 778124
+          - Name: Dermatophilaceae
+            ConceptType: Family
+            ConceptId: family/dermatophilaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 393
+            Children:
+            - Name: Arsenicicoccus
+              ConceptType: Genus
+              ConceptId: genus/arsenicicoccus
+              ConceptSource: LPSN
+              Id: 2535
+              LpsnRecordNumber: 515174
+              Children:
+              - Name: Arsenicicoccus bolidensis
+                ConceptType: Species
+                ConceptId: species/arsenicicoccus-bolidensis
+                ConceptSource: LPSN
+                Id: 327
+                LpsnRecordNumber: 773381
+            - Name: Dermatophilus
+              ConceptType: Genus
+              ConceptId: genus/dermatophilus
+              ConceptSource: LPSN
+              Id: 776
+              LpsnRecordNumber: 515493
+              Children:
+              - Name: Dermatophilus congolensis
+                ConceptType: Species
+                ConceptId: species/dermatophilus-congolensis
+                ConceptSource: LPSN
+                Id: 1215
+                LpsnRecordNumber: 775511
+          - Name: Intrasporangiaceae
+            ConceptType: Family
+            ConceptId: family/intrasporangiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 682
+            Children:
+            - Name: Janibacter
+              ConceptType: Genus
+              ConceptId: genus/janibacter
+              ConceptSource: LPSN
+              Id: 1839
+              LpsnRecordNumber: 515865
+              CommonCommensal: true
+              Children:
+              - Name: Janibacter hoylei
+                ConceptType: Species
+                ConceptId: species/janibacter-hoylei
+                ConceptSource: LPSN
+                Id: 1367
+                LpsnRecordNumber: 788272
+                CommonCommensal: true
+          - Name: Jonesiaceae
+            ConceptType: Family
+            ConceptId: family/jonesiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 697
+            Children:
+            - Name: Jonesia
+              ConceptType: Genus
+              ConceptId: genus/jonesia
+              ConceptSource: LPSN
+              Id: 2591
+              LpsnRecordNumber: 515871
+              Children:
+              - Name: Jonesia denitrificans
+                ConceptType: Species
+                ConceptId: species/jonesia-denitrificans
+                ConceptSource: LPSN
+                Id: 1559
+                LpsnRecordNumber: 777069
+                Synonyms:
+                - Name: Listeria denitrificans
+                  ConceptId: species/listeria-denitrificans
+                  ConceptSource: LPSN
+                  Id: 1283
+                  LpsnRecordNumber: 777585
+          - Name: Kytococcaceae
+            ConceptType: Family
+            ConceptId: family/kytococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 4817
+            Children:
+            - Name: Kytococcus
+              ConceptType: Genus
+              ConceptId: genus/kytococcus
+              ConceptSource: LPSN
+              Id: 2035
+              LpsnRecordNumber: 515905
+              CommonCommensal: true
+              Children:
+              - Name: Kytococcus sedentarius
+                ConceptType: Species
+                ConceptId: species/kytococcus-sedentarius
+                ConceptSource: LPSN
+                Id: 28
+                LpsnRecordNumber: 777227
+                CommonCommensal: true
+                Synonyms:
+                - Name: Micrococcus sedentarius
+                  ConceptId: species/micrococcus-sedentarius
+                  ConceptSource: LPSN
+                  Id: 468
+                  LpsnRecordNumber: 778132
+          - Name: Microbacteriaceae
+            ConceptType: Family
+            ConceptId: family/microbacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 875
+            Children:
+            - Name: Agromyces
+              ConceptType: Genus
+              ConceptId: genus/agromyces
+              ConceptSource: LPSN
+              Id: 2432
+              LpsnRecordNumber: 515063
+            - Name: Curtobacterium
+              ConceptType: Genus
+              ConceptId: genus/curtobacterium
+              ConceptSource: LPSN
+              Id: 412
+              LpsnRecordNumber: 515449
+              Children:
+              - Name: Curtobacterium citreum
+                ConceptType: Species
+                ConceptId: species/curtobacterium-citreum
+                ConceptSource: LPSN
+                Id: 3491
+                LpsnRecordNumber: 775325
+                Synonyms:
+                - Name: Brevibacterium albidum
+                  ConceptId: species/brevibacterium-albidum
+                  ConceptSource: LPSN
+                  Id: 2283
+                  LpsnRecordNumber: 774197
+                - Name: Curtobacterium albidum
+                  ConceptId: species/curtobacterium-albidum
+                  ConceptSource: LPSN
+                  Id: 332
+                  LpsnRecordNumber: 775324
+            - Name: Leifsonia
+              ConceptType: Genus
+              ConceptId: genus/leifsonia
+              ConceptSource: LPSN
+              Id: 2244
+              LpsnRecordNumber: 515934
+              CommonCommensal: true
+              Children:
+              - Name: Leifsonia aquatica
+                ConceptType: Species
+                ConceptId: species/leifsonia-aquatica
+                ConceptSource: LPSN
+                Id: 2333
+                LpsnRecordNumber: 777460
+                CommonCommensal: true
+              - Name: Leifsonia xyli
+                ConceptType: Species
+                ConceptId: species/leifsonia-xyli
+                ConceptSource: LPSN
+                Id: 1637
+                LpsnRecordNumber: 784128
+                CommonCommensal: true
+            - Name: Microbacterium
+              ConceptType: Genus
+              ConceptId: genus/microbacterium
+              ConceptSource: LPSN
+              Id: 832
+              LpsnRecordNumber: 516080
+              CommonCommensal: true
+              Children:
+              - Name: Microbacterium arborescens
+                ConceptType: Species
+                ConceptId: species/microbacterium-arborescens
+                ConceptSource: LPSN
+                Id: 1830
+                LpsnRecordNumber: 778028
+                CommonCommensal: true
+              - Name: Microbacterium hydrocarbonoxydans
+                ConceptType: Species
+                ConceptId: species/microbacterium-hydrocarbonoxydans
+                ConceptSource: LPSN
+                Id: 881
+                LpsnRecordNumber: 778042
+                CommonCommensal: true
+              - Name: Microbacterium imperiale
+                ConceptType: Species
+                ConceptId: species/microbacterium-imperiale
+                ConceptSource: LPSN
+                Id: 2210
+                LpsnRecordNumber: 778043
+                CommonCommensal: true
+                Synonyms:
+                - Name: Brevibacterium imperiale
+                  ConceptId: species/brevibacterium-imperiale
+                  ConceptSource: LPSN
+                  Id: 247
+                  LpsnRecordNumber: 774212
+              - Name: Microbacterium lacticum
+                ConceptType: Species
+                ConceptId: species/microbacterium-lacticum
+                ConceptSource: LPSN
+                Id: 1741
+                LpsnRecordNumber: 778048
+                CommonCommensal: true
+              - Name: Microbacterium liquefaciens
+                ConceptType: Species
+                ConceptId: species/microbacterium-liquefaciens
+                ConceptSource: LPSN
+                Id: 1203
+                LpsnRecordNumber: 778050
+                CommonCommensal: true
+                Synonyms:
+                - Name: Aureobacterium liquefaciens
+                  ConceptId: species/aureobacterium-liquefaciens
+                  ConceptSource: LPSN
+                  Id: 2554
+                  LpsnRecordNumber: 773552
+              - Name: Microbacterium maritypicum
+                ConceptType: Species
+                ConceptId: species/microbacterium-maritypicum
+                ConceptSource: LPSN
+                Id: 2093
+                LpsnRecordNumber: 778052
+                CommonCommensal: true
+                Synonyms:
+                - Name: Flavobacterium marinotypicum
+                  ConceptId: species/flavobacterium-marinotypicum
+                  ConceptSource: LPSN
+                  Id: 1824
+                  LpsnRecordNumber: 776253
+              - Name: Microbacterium oxydans
+                ConceptType: Species
+                ConceptId: species/microbacterium-oxydans
+                ConceptSource: LPSN
+                Id: 180
+                LpsnRecordNumber: 778056
+                CommonCommensal: true
+                Synonyms:
+                - Name: Brevibacterium oxydans
+                  ConceptId: species/brevibacterium-oxydans
+                  ConceptSource: LPSN
+                  Id: 1829
+                  LpsnRecordNumber: 774226
+              - Name: Microbacterium paraoxydans
+                ConceptType: Species
+                ConceptId: species/microbacterium-paraoxydans
+                ConceptSource: LPSN
+                Id: 973
+                LpsnRecordNumber: 778059
+                CommonCommensal: true
+              - Name: Microbacterium resistens
+                ConceptType: Species
+                ConceptId: species/microbacterium-resistens
+                ConceptSource: LPSN
+                Id: 1138
+                LpsnRecordNumber: 778061
+                CommonCommensal: true
+            - Name: Pseudoclavibacter
+              ConceptType: Genus
+              ConceptId: genus/pseudoclavibacter
+              ConceptSource: LPSN
+              Id: 445
+              LpsnRecordNumber: 516415
+          - Name: Micrococcaceae
+            ConceptType: Family
+            ConceptId: family/micrococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 880
+            Children:
+            - Name: Arthrobacter
+              ConceptType: Genus
+              ConceptId: genus/arthrobacter
+              ConceptSource: LPSN
+              Id: 1003
+              LpsnRecordNumber: 515179
+              CommonCommensal: true
+              Children:
+              - Name: Arthrobacter agilis
+                ConceptType: Species
+                ConceptId: species/arthrobacter-agilis
+                ConceptSource: LPSN
+                Id: 1287
+                LpsnRecordNumber: 773387
+                CommonCommensal: true
+              - Name: Arthrobacter citreus
+                ConceptType: Species
+                ConceptId: species/arthrobacter-citreus
+                ConceptSource: LPSN
+                Id: 1115
+                LpsnRecordNumber: 773397
+                CommonCommensal: true
+              - Name: Arthrobacter crystallopoietes
+                ConceptType: Species
+                ConceptId: species/arthrobacter-crystallopoietes
+                ConceptSource: LPSN
+                Id: 1370
+                LpsnRecordNumber: 773400
+                CommonCommensal: true
+              - Name: Arthrobacter flavus
+                ConceptType: Species
+                ConceptId: species/arthrobacter-flavus
+                ConceptSource: LPSN
+                Id: 2343
+                LpsnRecordNumber: 773405
+                CommonCommensal: true
+              - Name: Arthrobacter gandavensis
+                ConceptType: Species
+                ConceptId: species/arthrobacter-gandavensis
+                ConceptSource: LPSN
+                Id: 1196
+                LpsnRecordNumber: 773407
+                CommonCommensal: true
+              - Name: Arthrobacter globiformis
+                ConceptType: Species
+                ConceptId: species/arthrobacter-globiformis
+                ConceptSource: LPSN
+                Id: 1477
+                LpsnRecordNumber: 773410
+                CommonCommensal: true
+              - Name: Arthrobacter koreensis
+                ConceptType: Species
+                ConceptId: species/arthrobacter-koreensis
+                ConceptSource: LPSN
+                Id: 1529
+                LpsnRecordNumber: 773414
+                CommonCommensal: true
+              - Name: Arthrobacter luteolus
+                ConceptType: Species
+                ConceptId: species/arthrobacter-luteolus
+                ConceptSource: LPSN
+                Id: 43
+                LpsnRecordNumber: 773415
+                CommonCommensal: true
+              - Name: Arthrobacter methylotrophus
+                ConceptType: Species
+                ConceptId: species/arthrobacter-methylotrophus
+                ConceptSource: LPSN
+                Id: 805
+                LpsnRecordNumber: 773418
+                CommonCommensal: true
+              - Name: Arthrobacter oryzae
+                ConceptType: Species
+                ConceptId: species/arthrobacter-oryzae
+                ConceptSource: LPSN
+                Id: 1085
+                LpsnRecordNumber: 787113
+                CommonCommensal: true
+              - Name: Arthrobacter pascens
+                ConceptType: Species
+                ConceptId: species/arthrobacter-pascens
+                ConceptSource: LPSN
+                Id: 2058
+                LpsnRecordNumber: 773428
+                CommonCommensal: true
+              - Name: Arthrobacter psychrolactophilus
+                ConceptType: Species
+                ConceptId: species/arthrobacter-psychrolactophilus
+                ConceptSource: LPSN
+                Id: 1587
+                LpsnRecordNumber: 773433
+                CommonCommensal: true
+              - Name: Arthrobacter ramosus
+                ConceptType: Species
+                ConceptId: species/arthrobacter-ramosus
+                ConceptSource: LPSN
+                Id: 1496
+                LpsnRecordNumber: 773436
+                CommonCommensal: true
+              - Name: Arthrobacter rhombi
+                ConceptType: Species
+                ConceptId: species/arthrobacter-rhombi
+                ConceptSource: LPSN
+                Id: 1111
+                LpsnRecordNumber: 773437
+                CommonCommensal: true
+              - Name: Arthrobacter roseus
+                ConceptType: Species
+                ConceptId: species/arthrobacter-roseus
+                ConceptSource: LPSN
+                Id: 1808
+                LpsnRecordNumber: 773438
+                CommonCommensal: true
+              - Name: Arthrobacter russicus
+                ConceptType: Species
+                ConceptId: species/arthrobacter-russicus
+                ConceptSource: LPSN
+                Id: 1638
+                LpsnRecordNumber: 773439
+                CommonCommensal: true
+              - Name: Arthrobacter woluwensis
+                ConceptType: Species
+                ConceptId: species/arthrobacter-woluwensis
+                ConceptSource: LPSN
+                Id: 1175
+                LpsnRecordNumber: 773457
+                CommonCommensal: true
+            - Name: Falsarthrobacter
+              ConceptType: Genus
+              ConceptId: genus/falsarthrobacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520367
+              Children:
+              - Name: Falsarthrobacter nasiphocae
+                ConceptType: Species
+                ConceptId: species/falsarthrobacter-nasiphocae
+                ConceptSource: LPSN
+                Id: 3245
+                LpsnRecordNumber: 798260
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter nasiphocae
+                  ConceptId: species/arthrobacter-nasiphocae
+                  ConceptSource: LPSN
+                  Id: 1174
+                  LpsnRecordNumber: 773421
+            - Name: Glutamicibacter
+              ConceptType: Genus
+              ConceptId: genus/glutamicibacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518961
+              Children:
+              - Name: Glutamicibacter arilaitensis
+                ConceptType: Species
+                ConceptId: species/glutamicibacter-arilaitensis
+                ConceptSource: LPSN
+                Id: 3203
+                LpsnRecordNumber: 794221
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter arilaitensis
+                  ConceptId: species/arthrobacter-arilaitensis
+                  ConceptSource: LPSN
+                  Id: 961
+                  LpsnRecordNumber: 773391
+              - Name: Glutamicibacter bergerei
+                ConceptType: Species
+                ConceptId: species/glutamicibacter-bergerei
+                ConceptSource: LPSN
+                Id: 3068
+                LpsnRecordNumber: 794222
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter bergerei
+                  ConceptId: species/arthrobacter-bergerei
+                  ConceptSource: LPSN
+                  Id: 894
+                  LpsnRecordNumber: 773394
+              - Name: Glutamicibacter creatinolyticus
+                ConceptType: Species
+                ConceptId: species/glutamicibacter-creatinolyticus
+                ConceptSource: LPSN
+                Id: 3169
+                LpsnRecordNumber: 794223
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter creatinolyticus
+                  ConceptId: species/arthrobacter-creatinolyticus
+                  ConceptSource: LPSN
+                  Id: 877
+                  LpsnRecordNumber: 773398
+              - Name: Glutamicibacter nicotianae
+                ConceptType: Species
+                ConceptId: species/glutamicibacter-nicotianae
+                ConceptSource: LPSN
+                Id: 3151
+                LpsnRecordNumber: 794225
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter mysorens
+                  ConceptId: species/arthrobacter-mysorens
+                  ConceptSource: LPSN
+                  Id: 211
+                  LpsnRecordNumber: 773420
+                - Name: Arthrobacter nicotianae
+                  ConceptId: species/arthrobacter-nicotianae
+                  ConceptSource: LPSN
+                  Id: 2287
+                  LpsnRecordNumber: 773422
+              - Name: Glutamicibacter protophormiae
+                ConceptType: Species
+                ConceptId: species/glutamicibacter-protophormiae
+                ConceptSource: LPSN
+                Id: 3114
+                LpsnRecordNumber: 794219
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter protophormiae
+                  ConceptId: species/arthrobacter-protophormiae
+                  ConceptSource: LPSN
+                  Id: 1728
+                  LpsnRecordNumber: 773432
+              - Name: Glutamicibacter uratoxydans
+                ConceptType: Species
+                ConceptId: species/glutamicibacter-uratoxydans
+                ConceptSource: LPSN
+                Id: 3255
+                LpsnRecordNumber: 775265
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter uratoxydans
+                  ConceptId: species/arthrobacter-uratoxydans
+                  ConceptSource: LPSN
+                  Id: 563
+                  LpsnRecordNumber: 773453
+            - Name: Kocuria
+              ConceptType: Genus
+              ConceptId: genus/kocuria
+              ConceptSource: LPSN
+              Id: 2005
+              LpsnRecordNumber: 515896
+              CommonCommensal: true
+              Children:
+              - Name: Kocuria rosea
+                ConceptType: Species
+                ConceptId: species/kocuria-rosea
+                ConceptSource: LPSN
+                Id: 2561
+                LpsnRecordNumber: 777198
+                CommonCommensal: true
+                Synonyms:
+                - Name: Kocuria erythromyxa
+                  ConceptId: species/kocuria-erythromyxa
+                  ConceptSource: LPSN
+                  Id: 2485
+                  LpsnRecordNumber: 777191
+                - Name: Micrococcus roseus
+                  ConceptId: species/micrococcus-roseus
+                  ConceptSource: LPSN
+                  Id: 1647
+                  LpsnRecordNumber: 778130
+              - Name: Kocuria varians
+                ConceptType: Species
+                ConceptId: species/kocuria-varians
+                ConceptSource: LPSN
+                Id: 442
+                LpsnRecordNumber: 777200
+                CommonCommensal: true
+            - Name: Micrococcus
+              ConceptType: Genus
+              ConceptId: genus/micrococcus
+              ConceptSource: LPSN
+              Id: 100
+              LpsnRecordNumber: 516085
+              CommonCommensal: true
+              Children:
+              - Name: Micrococcus antarcticus
+                ConceptType: Species
+                ConceptId: species/micrococcus-antarcticus
+                ConceptSource: LPSN
+                Id: 1056
+                LpsnRecordNumber: 778099
+                CommonCommensal: true
+              - Name: Micrococcus flavus
+                ConceptType: Species
+                ConceptId: species/micrococcus-flavus
+                ConceptSource: LPSN
+                Id: 2236
+                LpsnRecordNumber: 785844
+                CommonCommensal: true
+              - Name: Micrococcus luteus
+                ConceptType: Species
+                ConceptId: species/micrococcus-luteus
+                ConceptSource: LPSN
+                Id: 1606
+                LpsnRecordNumber: 778120
+                CommonCommensal: true
+              - Name: Micrococcus lylae
+                ConceptType: Species
+                ConceptId: species/micrococcus-lylae
+                ConceptSource: LPSN
+                Id: 1956
+                LpsnRecordNumber: 778121
+                CommonCommensal: true
+            - Name: Nesterenkonia
+              ConceptType: Genus
+              ConceptId: genus/nesterenkonia
+              ConceptSource: LPSN
+              Id: 585
+              LpsnRecordNumber: 516169
+              Children:
+              - Name: Nesterenkonia halobia
+                ConceptType: Species
+                ConceptId: species/nesterenkonia-halobia
+                ConceptSource: LPSN
+                Id: 106
+                LpsnRecordNumber: 778651
+                Synonyms:
+                - Name: Micrococcus halobius
+                  ConceptId: species/micrococcus-halobius
+                  ConceptSource: LPSN
+                  Id: 508
+                  LpsnRecordNumber: 778113
+            - Name: Paenarthrobacter
+              ConceptType: Genus
+              ConceptId: genus/paenarthrobacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518963
+              Children:
+              - Name: Paenarthrobacter aurescens
+                ConceptType: Species
+                ConceptId: species/paenarthrobacter-aurescens
+                ConceptSource: LPSN
+                Id: 3313
+                LpsnRecordNumber: 794229
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter aurescens
+                  ConceptId: species/arthrobacter-aurescens
+                  ConceptSource: LPSN
+                  Id: 1573
+                  LpsnRecordNumber: 773393
+              - Name: Paenarthrobacter histidinolovorans
+                ConceptType: Species
+                ConceptId: species/paenarthrobacter-histidinolovorans
+                ConceptSource: LPSN
+                Id: 3019
+                LpsnRecordNumber: 794230
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter histidinolovorans
+                  ConceptId: species/arthrobacter-histidinolovorans
+                  ConceptSource: LPSN
+                  Id: 199
+                  LpsnRecordNumber: 773411
+              - Name: Paenarthrobacter ilicis
+                ConceptType: Species
+                ConceptId: species/paenarthrobacter-ilicis
+                ConceptSource: LPSN
+                Id: 3210
+                LpsnRecordNumber: 794231
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter ilicis
+                  ConceptId: species/arthrobacter-ilicis
+                  ConceptSource: LPSN
+                  Id: 2258
+                  LpsnRecordNumber: 773412
+              - Name: Paenarthrobacter nicotinovorans
+                ConceptType: Species
+                ConceptId: species/paenarthrobacter-nicotinovorans
+                ConceptSource: LPSN
+                Id: 3132
+                LpsnRecordNumber: 794232
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter nicotinovorans
+                  ConceptId: species/arthrobacter-nicotinovorans
+                  ConceptSource: LPSN
+                  Id: 1344
+                  LpsnRecordNumber: 773423
+              - Name: Paenarthrobacter nitroguajacolicus
+                ConceptType: Species
+                ConceptId: species/paenarthrobacter-nitroguajacolicus
+                ConceptSource: LPSN
+                Id: 3162
+                LpsnRecordNumber: 794233
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter nitroguajacolicus
+                  ConceptId: species/arthrobacter-nitroguajacolicus
+                  ConceptSource: LPSN
+                  Id: 434
+                  LpsnRecordNumber: 773424
+              - Name: Paenarthrobacter ureafaciens
+                ConceptType: Species
+                ConceptId: species/paenarthrobacter-ureafaciens
+                ConceptSource: LPSN
+                Id: 3292
+                LpsnRecordNumber: 794234
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter ureafaciens
+                  ConceptId: species/arthrobacter-ureafaciens
+                  ConceptSource: LPSN
+                  Id: 1852
+                  LpsnRecordNumber: 773454
+            - Name: Paeniglutamicibacter
+              ConceptType: Genus
+              ConceptId: genus/paeniglutamicibacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518965
+              Children:
+              - Name: Paeniglutamicibacter gangotriensis
+                ConceptType: Species
+                ConceptId: species/paeniglutamicibacter-gangotriensis
+                ConceptSource: LPSN
+                Id: 3013
+                LpsnRecordNumber: 794247
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter gangotriensis
+                  ConceptId: species/arthrobacter-gangotriensis
+                  ConceptSource: LPSN
+                  Id: 862
+                  LpsnRecordNumber: 773408
+              - Name: Paeniglutamicibacter kerguelensis
+                ConceptType: Species
+                ConceptId: species/paeniglutamicibacter-kerguelensis
+                ConceptSource: LPSN
+                Id: 2968
+                LpsnRecordNumber: 794248
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter kerguelensis
+                  ConceptId: species/arthrobacter-kerguelensis
+                  ConceptSource: LPSN
+                  Id: 133
+                  LpsnRecordNumber: 773413
+              - Name: Paeniglutamicibacter psychrophenolicus
+                ConceptType: Species
+                ConceptId: species/paeniglutamicibacter-psychrophenolicus
+                ConceptSource: LPSN
+                Id: 3090
+                LpsnRecordNumber: 794249
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter psychrophenolicus
+                  ConceptId: species/arthrobacter-psychrophenolicus
+                  ConceptSource: LPSN
+                  Id: 980
+                  LpsnRecordNumber: 773434
+              - Name: Paeniglutamicibacter sulfureus
+                ConceptType: Species
+                ConceptId: species/paeniglutamicibacter-sulfureus
+                ConceptSource: LPSN
+                Id: 3024
+                LpsnRecordNumber: 774237
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter sulfureus
+                  ConceptId: species/arthrobacter-sulfureus
+                  ConceptSource: LPSN
+                  Id: 1136
+                  LpsnRecordNumber: 773448
+            - Name: Pseudarthrobacter
+              ConceptType: Genus
+              ConceptId: genus/pseudarthrobacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518964
+              Children:
+              - Name: Pseudarthrobacter chlorophenolicus
+                ConceptType: Species
+                ConceptId: species/pseudarthrobacter-chlorophenolicus
+                ConceptSource: LPSN
+                Id: 3191
+                LpsnRecordNumber: 794236
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter chlorophenolicus
+                  ConceptId: species/arthrobacter-chlorophenolicus
+                  ConceptSource: LPSN
+                  Id: 304
+                  LpsnRecordNumber: 773396
+              - Name: Pseudarthrobacter oxydans
+                ConceptType: Species
+                ConceptId: species/pseudarthrobacter-oxydans
+                ConceptSource: LPSN
+                Id: 2976
+                LpsnRecordNumber: 794240
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter oxydans
+                  ConceptId: species/arthrobacter-oxydans
+                  ConceptSource: LPSN
+                  Id: 1058
+                  LpsnRecordNumber: 773425
+              - Name: Pseudarthrobacter polychromogenes
+                ConceptType: Species
+                ConceptId: species/pseudarthrobacter-polychromogenes
+                ConceptSource: LPSN
+                Id: 3225
+                LpsnRecordNumber: 794235
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter polychromogenes
+                  ConceptId: species/arthrobacter-polychromogenes
+                  ConceptSource: LPSN
+                  Id: 1952
+                  LpsnRecordNumber: 773431
+              - Name: Pseudarthrobacter scleromae
+                ConceptType: Species
+                ConceptId: species/pseudarthrobacter-scleromae
+                ConceptSource: LPSN
+                Id: 3007
+                LpsnRecordNumber: 794242
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter scleromae
+                  ConceptId: species/arthrobacter-scleromae
+                  ConceptSource: LPSN
+                  Id: 1733
+                  LpsnRecordNumber: 773440
+              - Name: Pseudarthrobacter sulfonivorans
+                ConceptType: Species
+                ConceptId: species/pseudarthrobacter-sulfonivorans
+                ConceptSource: LPSN
+                Id: 3321
+                LpsnRecordNumber: 794244
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter sulfonivorans
+                  ConceptId: species/arthrobacter-sulfonivorans
+                  ConceptSource: LPSN
+                  Id: 363
+                  LpsnRecordNumber: 773447
+            - Name: Pseudoglutamicibacter
+              ConceptType: Genus
+              ConceptId: genus/pseudoglutamicibacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518962
+              Children:
+              - Name: Pseudoglutamicibacter albus
+                ConceptType: Species
+                ConceptId: species/pseudoglutamicibacter-albus
+                ConceptSource: LPSN
+                Id: 3164
+                LpsnRecordNumber: 794227
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter albus
+                  ConceptId: species/arthrobacter-albus
+                  ConceptSource: LPSN
+                  Id: 1280
+                  LpsnRecordNumber: 773389
+              - Name: Pseudoglutamicibacter cumminsii
+                ConceptType: Species
+                ConceptId: species/pseudoglutamicibacter-cumminsii
+                ConceptSource: LPSN
+                Id: 3006
+                LpsnRecordNumber: 794226
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter cumminsii
+                  ConceptId: species/arthrobacter-cumminsii
+                  ConceptSource: LPSN
+                  Id: 1916
+                  LpsnRecordNumber: 773401
+            - Name: Rothia
+              ConceptType: Genus
+              ConceptId: genus/rothia
+              ConceptSource: LPSN
+              Id: 2234
+              LpsnRecordNumber: 516509
+              CommonCommensal: true
+              Children:
+              - Name: Rothia aeria
+                ConceptType: Species
+                ConceptId: species/rothia-aeria
+                ConceptSource: LPSN
+                Id: 1383
+                LpsnRecordNumber: 780592
+                CommonCommensal: true
+              - Name: Rothia dentocariosa
+                ConceptType: Species
+                ConceptId: species/rothia-dentocariosa
+                ConceptSource: LPSN
+                Id: 1377
+                LpsnRecordNumber: 780594
+                CommonCommensal: true
+              - Name: Rothia kristinae
+                ConceptType: Species
+                ConceptId: species/rothia-kristinae
+                ConceptSource: LPSN
+                Id: 3269
+                LpsnRecordNumber: 798264
+                CommonCommensal: true
+                Synonyms:
+                - Name: Kocuria kristinae
+                  ConceptId: species/kocuria-kristinae
+                  ConceptSource: LPSN
+                  Id: 809
+                  LpsnRecordNumber: 777193
+                - Name: Micrococcus kristinae
+                  ConceptId: species/micrococcus-kristinae
+                  ConceptSource: LPSN
+                  Id: 2536
+                  LpsnRecordNumber: 778117
+              - Name: Rothia mucilaginosa
+                ConceptType: Species
+                ConceptId: species/rothia-mucilaginosa
+                ConceptSource: LPSN
+                Id: 1242
+                LpsnRecordNumber: 780595
+                CommonCommensal: true
+                Synonyms:
+                - Name: Stomatococcus mucilaginosus
+                  ConceptId: species/stomatococcus-mucilaginosus
+                  ConceptSource: LPSN
+                  Id: 2171
+                  LpsnRecordNumber: 781278
+          - Name: Promicromonosporaceae
+            ConceptType: Family
+            ConceptId: family/promicromonosporaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1113
+            Children:
+            - Name: Cellulosimicrobium
+              ConceptType: Genus
+              ConceptId: genus/cellulosimicrobium
+              ConceptSource: LPSN
+              Id: 1315
+              LpsnRecordNumber: 515330
+              CommonCommensal: true
+              Children:
+              - Name: Cellulosimicrobium cellulans
+                ConceptType: Species
+                ConceptId: species/cellulosimicrobium-cellulans
+                ConceptSource: LPSN
+                Id: 1271
+                LpsnRecordNumber: 774572
+                CommonCommensal: true
+                Synonyms:
+                - Name: Cellulomonas cellulans
+                  ConceptId: species/cellulomonas-cellulans
+                  ConceptSource: LPSN
+                  Id: 2498
+                  LpsnRecordNumber: 774548
+            - Name: Oerskovia
+              ConceptType: Genus
+              ConceptId: genus/oerskovia
+              ConceptSource: LPSN
+              Id: 241
+              LpsnRecordNumber: 516206
+              CommonCommensal: true
+          - Name: Tropherymataceae
+            ConceptType: Family
+            ConceptId: family/tropherymataceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 4823
+            Children:
+            - Name: Tropheryma
+              ConceptType: Genus
+              ConceptId: genus/tropheryma-1
+              ConceptSource: LPSN
+              Id: 2958
+              LpsnRecordNumber: 517381
+              Children:
+              - Name: Tropheryma whipplei
+                ConceptType: Species
+                ConceptId: species/tropheryma-whipplei
+                ConceptSource: LPSN
+                Id: 2959
+                LpsnRecordNumber: 785128
+        - Name: Micromonosporales
+          ConceptType: Order
+          ConceptId: order/micromonosporales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5170
+          Children:
+          - Name: Micromonosporaceae
+            ConceptType: Family
+            ConceptId: family/micromonosporaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 885
+            Children:
+            - Name: Micromonospora
+              ConceptType: Genus
+              ConceptId: genus/micromonospora
+              ConceptSource: LPSN
+              Id: 2192
+              LpsnRecordNumber: 516092
+              Children:
+              - Name: Micromonospora chalcea
+                ConceptType: Species
+                ConceptId: species/micromonospora-chalcea
+                ConceptSource: LPSN
+                Id: 435
+                LpsnRecordNumber: 778163
+        - Name: Mycobacteriales
+          ConceptType: Order
+          ConceptId: order/mycobacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 4995
+          Children:
+          - Name: Corynebacteriaceae
+            ConceptType: Family
+            ConceptId: family/corynebacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 346
+            Children:
+            - Name: Corynebacterium
+              ConceptType: Genus
+              ConceptId: genus/corynebacterium
+              ConceptSource: LPSN
+              Id: 1968
+              LpsnRecordNumber: 515427
+              CommonCommensal: true
+              Children:
+              - Name: Corynebacterium accolens
+                ConceptType: Species
+                ConceptId: species/corynebacterium-accolens
+                ConceptSource: LPSN
+                Id: 1616
+                LpsnRecordNumber: 775143
+                CommonCommensal: true
+              - Name: Corynebacterium afermentans
+                ConceptType: Species
+                ConceptId: species/corynebacterium-afermentans
+                ConceptSource: LPSN
+                Id: 593
+                LpsnRecordNumber: 783694
+                CommonCommensal: true
+                Children:
+                - Name: Corynebacterium afermentans subsp. afermentans
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/corynebacterium-afermentans-afermentans
+                  ConceptSource: LPSN
+                  Id: 1135
+                  LpsnRecordNumber: 775147
+                  CommonCommensal: true
+                - Name: Corynebacterium afermentans subsp. lipophilum
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/corynebacterium-afermentans-lipophilum
+                  ConceptSource: LPSN
+                  Id: 339
+                  LpsnRecordNumber: 775148
+                  CommonCommensal: true
+              - Name: Corynebacterium ammoniagenes
+                ConceptType: Species
+                ConceptId: species/corynebacterium-ammoniagenes
+                ConceptSource: LPSN
+                Id: 129
+                LpsnRecordNumber: 775150
+                CommonCommensal: true
+                Synonyms:
+                - Name: Brevibacterium ammoniagenes
+                  ConceptId: species/brevibacterium-ammoniagenes
+                  ConceptSource: LPSN
+                  Id: 1784
+                  LpsnRecordNumber: 774198
+              - Name: Corynebacterium amycolatum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-amycolatum
+                ConceptSource: LPSN
+                Id: 460
+                LpsnRecordNumber: 775151
+                CommonCommensal: true
+              - Name: Corynebacterium appendicis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-appendicis
+                ConceptSource: LPSN
+                Id: 2214
+                LpsnRecordNumber: 775152
+                CommonCommensal: true
+              - Name: Corynebacterium aquatimens
+                ConceptType: Species
+                ConceptId: species/corynebacterium-aquatimens
+                ConceptSource: LPSN
+                Id: 2915
+                LpsnRecordNumber: 790174
+                CommonCommensal: true
+              - Name: Corynebacterium aquilae
+                ConceptType: Species
+                ConceptId: species/corynebacterium-aquilae
+                ConceptSource: LPSN
+                Id: 2417
+                LpsnRecordNumber: 775154
+                CommonCommensal: true
+              - Name: Corynebacterium argentoratense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-argentoratense
+                ConceptSource: LPSN
+                Id: 2594
+                LpsnRecordNumber: 775155
+                CommonCommensal: true
+              - Name: Corynebacterium atypicum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-atypicum
+                ConceptSource: LPSN
+                Id: 2321
+                LpsnRecordNumber: 775156
+                CommonCommensal: true
+              - Name: Corynebacterium aurimucosum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-aurimucosum
+                ConceptSource: LPSN
+                Id: 2438
+                LpsnRecordNumber: 775157
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium nigricans
+                  ConceptId: species/corynebacterium-nigricans
+                  ConceptSource: LPSN
+                  Id: 1067
+                  LpsnRecordNumber: 775229
+              - Name: Corynebacterium auris
+                ConceptType: Species
+                ConceptId: species/corynebacterium-auris
+                ConceptSource: LPSN
+                Id: 2194
+                LpsnRecordNumber: 775158
+                CommonCommensal: true
+              - Name: Corynebacterium auriscanis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-auriscanis
+                ConceptSource: LPSN
+                Id: 1153
+                LpsnRecordNumber: 775159
+                CommonCommensal: true
+              - Name: Corynebacterium belfantii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-belfantii
+                ConceptSource: LPSN
+                Id: 2916
+                LpsnRecordNumber: 798019
+                CommonCommensal: true
+              - Name: Corynebacterium beticola
+                ConceptType: Species
+                ConceptId: species/corynebacterium-beticola
+                ConceptSource: LPSN
+                Id: 1901
+                LpsnRecordNumber: 775163
+                CommonCommensal: true
+              - Name: Corynebacterium bovis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-bovis
+                ConceptSource: LPSN
+                Id: 2479
+                LpsnRecordNumber: 775164
+                CommonCommensal: true
+              - Name: Corynebacterium callunae
+                ConceptType: Species
+                ConceptId: species/corynebacterium-callunae
+                ConceptSource: LPSN
+                Id: 936
+                LpsnRecordNumber: 775165
+                CommonCommensal: true
+              - Name: Corynebacterium camporealense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-camporealense
+                ConceptSource: LPSN
+                Id: 3101
+                LpsnRecordNumber: 30053
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium camporealensis
+                  ConceptId: species/corynebacterium-camporealensis
+                  ConceptSource: LPSN
+                  Id: 1042
+                  LpsnRecordNumber: 775166
+              - Name: Corynebacterium canis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-canis
+                ConceptSource: LPSN
+                Id: 2917
+                LpsnRecordNumber: 788871
+                CommonCommensal: true
+              - Name: Corynebacterium capitovis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-capitovis
+                ConceptSource: LPSN
+                Id: 485
+                LpsnRecordNumber: 775168
+                CommonCommensal: true
+              - Name: Corynebacterium casei
+                ConceptType: Species
+                ConceptId: species/corynebacterium-casei
+                ConceptSource: LPSN
+                Id: 1844
+                LpsnRecordNumber: 775169
+                CommonCommensal: true
+              - Name: Corynebacterium caspium
+                ConceptType: Species
+                ConceptId: species/corynebacterium-caspium
+                ConceptSource: LPSN
+                Id: 1080
+                LpsnRecordNumber: 775170
+                CommonCommensal: true
+              - Name: Corynebacterium ciconiae
+                ConceptType: Species
+                ConceptId: species/corynebacterium-ciconiae
+                ConceptSource: LPSN
+                Id: 2509
+                LpsnRecordNumber: 775172
+                CommonCommensal: true
+              - Name: Corynebacterium confusum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-confusum
+                ConceptSource: LPSN
+                Id: 452
+                LpsnRecordNumber: 775174
+                CommonCommensal: true
+              - Name: Corynebacterium coyleae
+                ConceptType: Species
+                ConceptId: species/corynebacterium-coyleae
+                ConceptSource: LPSN
+                Id: 1813
+                LpsnRecordNumber: 775175
+                CommonCommensal: true
+              - Name: Corynebacterium cystitidis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-cystitidis
+                ConceptSource: LPSN
+                Id: 1611
+                LpsnRecordNumber: 775177
+                CommonCommensal: true
+              - Name: Corynebacterium dentalis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-dentalis
+                ConceptSource: LPSN
+                Id: 2918
+                LpsnRecordNumber: 3414
+                CommonCommensal: true
+              - Name: Corynebacterium diphtheriae
+                ConceptType: Species
+                ConceptId: species/corynebacterium-diphtheriae
+                ConceptSource: LPSN
+                Id: 70
+                LpsnRecordNumber: 775178
+              - Name: Corynebacterium durum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-durum
+                ConceptSource: LPSN
+                Id: 1867
+                LpsnRecordNumber: 775179
+                CommonCommensal: true
+              - Name: Corynebacterium efficiens
+                ConceptType: Species
+                ConceptId: species/corynebacterium-efficiens
+                ConceptSource: LPSN
+                Id: 506
+                LpsnRecordNumber: 775180
+                CommonCommensal: true
+              - Name: Corynebacterium falsenii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-falsenii
+                ConceptSource: LPSN
+                Id: 2468
+                LpsnRecordNumber: 775182
+                CommonCommensal: true
+              - Name: Corynebacterium felinum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-felinum
+                ConceptSource: LPSN
+                Id: 41
+                LpsnRecordNumber: 775184
+                CommonCommensal: true
+              - Name: Corynebacterium flavescens
+                ConceptType: Species
+                ConceptId: species/corynebacterium-flavescens
+                ConceptSource: LPSN
+                Id: 1109
+                LpsnRecordNumber: 775189
+                CommonCommensal: true
+              - Name: Corynebacterium fournieri
+                ConceptType: Species
+                ConceptId: species/corynebacterium-fournieri
+                ConceptSource: LPSN
+                Id: 2919
+                LpsnRecordNumber: 797970
+                CommonCommensal: true
+              - Name: Corynebacterium freiburgense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-freiburgense
+                ConceptSource: LPSN
+                Id: 2920
+                LpsnRecordNumber: 788039
+                CommonCommensal: true
+              - Name: Corynebacterium freneyi
+                ConceptType: Species
+                ConceptId: species/corynebacterium-freneyi
+                ConceptSource: LPSN
+                Id: 163
+                LpsnRecordNumber: 775190
+                CommonCommensal: true
+              - Name: Corynebacterium genitalium
+                ConceptType: Species
+                ConceptId: species/corynebacterium-genitalium
+                ConceptSource: LPSN
+                Id: 2941
+                LpsnRecordNumber: 37233
+                CommonCommensal: true
+              - Name: Corynebacterium glaucum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-glaucum
+                ConceptSource: LPSN
+                Id: 1756
+                LpsnRecordNumber: 775191
+                CommonCommensal: true
+              - Name: Corynebacterium glucuronolyticum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-glucuronolyticum
+                ConceptSource: LPSN
+                Id: 1620
+                LpsnRecordNumber: 775192
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium seminale
+                  ConceptId: species/corynebacterium-seminale
+                  ConceptSource: LPSN
+                  Id: 78
+                  LpsnRecordNumber: 775246
+              - Name: Corynebacterium glutamicum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-glutamicum
+                ConceptSource: LPSN
+                Id: 514
+                LpsnRecordNumber: 775193
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium lilium
+                  ConceptId: species/corynebacterium-lilium
+                  ConceptSource: LPSN
+                  Id: 2576
+                  LpsnRecordNumber: 775212
+              - Name: Corynebacterium gottingense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-gottingense
+                ConceptSource: LPSN
+                Id: 2921
+                LpsnRecordNumber: 795620
+                CommonCommensal: true
+              - Name: Corynebacterium halotolerans
+                ConceptType: Species
+                ConceptId: species/corynebacterium-halotolerans
+                ConceptSource: LPSN
+                Id: 2475
+                LpsnRecordNumber: 775197
+                CommonCommensal: true
+              - Name: Corynebacterium hansenii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-hansenii
+                ConceptSource: LPSN
+                Id: 2922
+                LpsnRecordNumber: 786249
+                CommonCommensal: true
+              - Name: Corynebacterium imitans
+                ConceptType: Species
+                ConceptId: species/corynebacterium-imitans
+                ConceptSource: LPSN
+                Id: 1378
+                LpsnRecordNumber: 775204
+                CommonCommensal: true
+              - Name: Corynebacterium jeikeium
+                ConceptType: Species
+                ConceptId: species/corynebacterium-jeikeium
+                ConceptSource: LPSN
+                Id: 1991
+                LpsnRecordNumber: 775207
+                CommonCommensal: true
+              - Name: Corynebacterium kroppenstedtii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-kroppenstedtii
+                ConceptSource: LPSN
+                Id: 373
+                LpsnRecordNumber: 775208
+                CommonCommensal: true
+              - Name: Corynebacterium kutscheri
+                ConceptType: Species
+                ConceptId: species/corynebacterium-kutscheri
+                ConceptSource: LPSN
+                Id: 1715
+                LpsnRecordNumber: 775209
+                CommonCommensal: true
+              - Name: Corynebacterium lipophiloflavum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-lipophiloflavum
+                ConceptSource: LPSN
+                Id: 1474
+                LpsnRecordNumber: 775213
+                CommonCommensal: true
+              - Name: Corynebacterium lowii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-lowii
+                ConceptSource: LPSN
+                Id: 2923
+                LpsnRecordNumber: 794320
+                CommonCommensal: true
+              - Name: Corynebacterium macginleyi
+                ConceptType: Species
+                ConceptId: species/corynebacterium-macginleyi
+                ConceptSource: LPSN
+                Id: 777
+                LpsnRecordNumber: 775214
+                CommonCommensal: true
+              - Name: Corynebacterium massiliense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-massiliense
+                ConceptSource: LPSN
+                Id: 2245
+                LpsnRecordNumber: 788040
+                CommonCommensal: true
+              - Name: Corynebacterium mastitidis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-mastitidis
+                ConceptSource: LPSN
+                Id: 618
+                LpsnRecordNumber: 775217
+                CommonCommensal: true
+              - Name: Corynebacterium matruchotii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-matruchotii
+                ConceptSource: LPSN
+                Id: 2230
+                LpsnRecordNumber: 775218
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacterionema matruchotii
+                  ConceptId: species/bacterionema-matruchotii
+                  ConceptSource: LPSN
+                  Id: 1546
+                  LpsnRecordNumber: 773913
+              - Name: Corynebacterium mediolanum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-mediolanum
+                ConceptSource: LPSN
+                Id: 2942
+                LpsnRecordNumber: 25767
+                CommonCommensal: true
+              - Name: Corynebacterium minutissimum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-minutissimum
+                ConceptSource: LPSN
+                Id: 970
+                LpsnRecordNumber: 775222
+                CommonCommensal: true
+              - Name: Corynebacterium mucifaciens
+                ConceptType: Species
+                ConceptId: species/corynebacterium-mucifaciens
+                ConceptSource: LPSN
+                Id: 176
+                LpsnRecordNumber: 775224
+                CommonCommensal: true
+              - Name: Corynebacterium mycetoides
+                ConceptType: Species
+                ConceptId: species/corynebacterium-mycetoides
+                ConceptSource: LPSN
+                Id: 2360
+                LpsnRecordNumber: 775226
+                CommonCommensal: true
+              - Name: Corynebacterium oculi
+                ConceptType: Species
+                ConceptId: species/corynebacterium-oculi
+                ConceptSource: LPSN
+                Id: 2924
+                LpsnRecordNumber: 794321
+                CommonCommensal: true
+              - Name: Corynebacterium otitidis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-otitidis
+                ConceptSource: LPSN
+                Id: 3036
+                LpsnRecordNumber: 798143
+                CommonCommensal: true
+                Synonyms:
+                - Name: Turicella otitidis
+                  ConceptId: species/turicella-otitidis
+                  ConceptSource: LPSN
+                  Id: 901
+                  LpsnRecordNumber: 782901
+              - Name: Corynebacterium phocae
+                ConceptType: Species
+                ConceptId: species/corynebacterium-phocae
+                ConceptSource: LPSN
+                Id: 1106
+                LpsnRecordNumber: 775235
+                CommonCommensal: true
+              - Name: Corynebacterium pilbarense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-pilbarense
+                ConceptSource: LPSN
+                Id: 2925
+                LpsnRecordNumber: 788608
+                CommonCommensal: true
+              - Name: Corynebacterium pilosum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-pilosum
+                ConceptSource: LPSN
+                Id: 898
+                LpsnRecordNumber: 775236
+                CommonCommensal: true
+              - Name: Corynebacterium propinquum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-propinquum
+                ConceptSource: LPSN
+                Id: 927
+                LpsnRecordNumber: 775238
+                CommonCommensal: true
+              - Name: Corynebacterium pseudodiphtheriticum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-pseudodiphtheriticum
+                ConceptSource: LPSN
+                Id: 2516
+                LpsnRecordNumber: 775239
+                CommonCommensal: true
+              - Name: Corynebacterium pseudogenitalium
+                ConceptType: Species
+                ConceptId: species/corynebacterium-pseudogenitalium
+                ConceptSource: LPSN
+                Id: 2943
+                LpsnRecordNumber: 37234
+                CommonCommensal: true
+              - Name: Corynebacterium pseudotuberculosis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-pseudotuberculosis
+                ConceptSource: LPSN
+                Id: 214
+                LpsnRecordNumber: 775240
+                CommonCommensal: true
+              - Name: Corynebacterium pyruviciproducens
+                ConceptType: Species
+                ConceptId: species/corynebacterium-pyruviciproducens
+                ConceptSource: LPSN
+                Id: 1605
+                LpsnRecordNumber: 788542
+                CommonCommensal: true
+              - Name: Corynebacterium renale
+                ConceptType: Species
+                ConceptId: species/corynebacterium-renale
+                ConceptSource: LPSN
+                Id: 2096
+                LpsnRecordNumber: 775243
+                CommonCommensal: true
+              - Name: Corynebacterium resistens
+                ConceptType: Species
+                ConceptId: species/corynebacterium-resistens
+                ConceptSource: LPSN
+                Id: 150
+                LpsnRecordNumber: 783700
+                CommonCommensal: true
+              - Name: Corynebacterium riegelii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-riegelii
+                ConceptSource: LPSN
+                Id: 336
+                LpsnRecordNumber: 775244
+                CommonCommensal: true
+              - Name: Corynebacterium rouxii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-rouxii
+                ConceptSource: LPSN
+                Id: 2926
+                LpsnRecordNumber: 3547
+                CommonCommensal: true
+              - Name: Corynebacterium rubrum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-rubrum
+                ConceptSource: LPSN
+                Id: 2944
+                LpsnRecordNumber: 9373
+                CommonCommensal: true
+              - Name: Corynebacterium simulans
+                ConceptType: Species
+                ConceptId: species/corynebacterium-simulans
+                ConceptSource: LPSN
+                Id: 584
+                LpsnRecordNumber: 775249
+                CommonCommensal: true
+              - Name: Corynebacterium singulare
+                ConceptType: Species
+                ConceptId: species/corynebacterium-singulare
+                ConceptSource: LPSN
+                Id: 1412
+                LpsnRecordNumber: 775250
+                CommonCommensal: true
+              - Name: Corynebacterium sphenisci
+                ConceptType: Species
+                ConceptId: species/corynebacterium-sphenisci
+                ConceptSource: LPSN
+                Id: 2454
+                LpsnRecordNumber: 775252
+                CommonCommensal: true
+              - Name: Corynebacterium spheniscorum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-spheniscorum
+                ConceptSource: LPSN
+                Id: 311
+                LpsnRecordNumber: 775253
+                CommonCommensal: true
+              - Name: Corynebacterium sputi
+                ConceptType: Species
+                ConceptId: species/corynebacterium-sputi
+                ConceptSource: LPSN
+                Id: 2927
+                LpsnRecordNumber: 787660
+                CommonCommensal: true
+              - Name: Corynebacterium striatum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-striatum
+                ConceptSource: LPSN
+                Id: 2473
+                LpsnRecordNumber: 775254
+                CommonCommensal: true
+              - Name: Corynebacterium suicordis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-suicordis
+                ConceptSource: LPSN
+                Id: 1982
+                LpsnRecordNumber: 775255
+                CommonCommensal: true
+              - Name: Corynebacterium sundsvallense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-sundsvallense
+                ConceptSource: LPSN
+                Id: 1695
+                LpsnRecordNumber: 775257
+                CommonCommensal: true
+              - Name: Corynebacterium terpenotabidum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-terpenotabidum
+                ConceptSource: LPSN
+                Id: 1635
+                LpsnRecordNumber: 775258
+                CommonCommensal: true
+              - Name: Corynebacterium testudinoris
+                ConceptType: Species
+                ConceptId: species/corynebacterium-testudinoris
+                ConceptSource: LPSN
+                Id: 532
+                LpsnRecordNumber: 775259
+                CommonCommensal: true
+              - Name: Corynebacterium thomssenii
+                ConceptType: Species
+                ConceptId: species/corynebacterium-thomssenii
+                ConceptSource: LPSN
+                Id: 190
+                LpsnRecordNumber: 775260
+                CommonCommensal: true
+              - Name: Corynebacterium timonense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-timonense
+                ConceptSource: LPSN
+                Id: 2928
+                LpsnRecordNumber: 788041
+                CommonCommensal: true
+              - Name: Corynebacterium tuberculostearicum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-tuberculostearicum
+                ConceptSource: LPSN
+                Id: 1767
+                LpsnRecordNumber: 775262
+                CommonCommensal: true
+              - Name: Corynebacterium tuscaniense
+                ConceptType: Species
+                ConceptId: species/corynebacterium-tuscaniense
+                ConceptSource: LPSN
+                Id: 1227
+                LpsnRecordNumber: 785465
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium tuscaniae
+                  ConceptId: species/corynebacterium-tuscaniae
+                  ConceptSource: LPSN
+                  Id: 2929
+                  LpsnRecordNumber: 785498
+              - Name: Corynebacterium ulcerans
+                ConceptType: Species
+                ConceptId: species/corynebacterium-ulcerans
+                ConceptSource: LPSN
+                Id: 2113
+                LpsnRecordNumber: 775264
+                CommonCommensal: true
+              - Name: Corynebacterium urealyticum
+                ConceptType: Species
+                ConceptId: species/corynebacterium-urealyticum
+                ConceptSource: LPSN
+                Id: 2330
+                LpsnRecordNumber: 775266
+                CommonCommensal: true
+              - Name: Corynebacterium ureicelerivorans
+                ConceptType: Species
+                ConceptId: species/corynebacterium-ureicelerivorans
+                ConceptSource: LPSN
+                Id: 1595
+                LpsnRecordNumber: 785382
+                CommonCommensal: true
+              - Name: Corynebacterium variabile
+                ConceptType: Species
+                ConceptId: species/corynebacterium-variabile
+                ConceptSource: LPSN
+                Id: 1821
+                LpsnRecordNumber: 775267
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter variabilis
+                  ConceptId: species/arthrobacter-variabilis
+                  ConceptSource: LPSN
+                  Id: 123
+                  LpsnRecordNumber: 773455
+                - Name: Corynebacterium mooreparkense
+                  ConceptId: species/corynebacterium-mooreparkense
+                  ConceptSource: LPSN
+                  Id: 1052
+                  LpsnRecordNumber: 775223
+                - Name: Corynebacterium variabilis
+                  ConceptId: species/corynebacterium-variabilis
+                  ConceptSource: LPSN
+                  Id: 677
+                  LpsnRecordNumber: 783701
+              - Name: Corynebacterium vitaeruminis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-vitaeruminis
+                ConceptSource: LPSN
+                Id: 2372
+                LpsnRecordNumber: 775268
+                CommonCommensal: true
+                Synonyms:
+                - Name: Brevibacterium vitaeruminis
+                  ConceptId: species/brevibacterium-vitaeruminis
+                  ConceptSource: LPSN
+                  Id: 2985
+                  LpsnRecordNumber: 783560
+                - Name: Brevibacterium vitarumen
+                  ConceptId: species/brevibacterium-vitarumen
+                  ConceptSource: LPSN
+                  Id: 182
+                  LpsnRecordNumber: 774239
+                - Name: Corynebacterium vitarumen
+                  ConceptId: species/corynebacterium-vitarumen
+                  ConceptSource: LPSN
+                  Id: 1548
+                  LpsnRecordNumber: 783702
+              - Name: Corynebacterium xerosis
+                ConceptType: Species
+                ConceptId: species/corynebacterium-xerosis
+                ConceptSource: LPSN
+                Id: 1686
+                LpsnRecordNumber: 775269
+                CommonCommensal: true
+              Synonyms:
+              - Name: Turicella
+                ConceptId: genus/turicella
+                ConceptSource: LPSN
+                Id: 1601
+                LpsnRecordNumber: 516876
+          - Name: Dietziaceae
+            ConceptType: Family
+            ConceptId: family/dietziaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 457
+            Children:
+            - Name: Dietzia
+              ConceptType: Genus
+              ConceptId: genus/dietzia
+              ConceptSource: LPSN
+              Id: 1532
+              LpsnRecordNumber: 515535
+              Children:
+              - Name: Dietzia maris
+                ConceptType: Species
+                ConceptId: species/dietzia-maris
+                ConceptSource: LPSN
+                Id: 3285
+                LpsnRecordNumber: 775787
+                Synonyms:
+                - Name: Dietzia cinnamea
+                  ConceptId: species/dietzia-cinnamea
+                  ConceptSource: LPSN
+                  Id: 1789
+                  LpsnRecordNumber: 775784
+          - Name: Gordoniaceae
+            ConceptType: Family
+            ConceptId: family/gordoniaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 582
+            Children:
+            - Name: Gordonia
+              ConceptType: Genus
+              ConceptId: genus/gordonia
+              ConceptSource: LPSN
+              Id: 608
+              LpsnRecordNumber: 515720
+              CommonCommensal: true
+              Children:
+              - Name: Gordonia bronchialis
+                ConceptType: Species
+                ConceptId: species/gordonia-bronchialis
+                ConceptSource: LPSN
+                Id: 2527
+                LpsnRecordNumber: 776583
+                CommonCommensal: true
+                Synonyms:
+                - Name: Rhodococcus bronchialis
+                  ConceptId: species/rhodococcus-bronchialis
+                  ConceptSource: LPSN
+                  Id: 122
+                  LpsnRecordNumber: 780442
+              - Name: Gordonia otitidis
+                ConceptType: Species
+                ConceptId: species/gordonia-otitidis
+                ConceptSource: LPSN
+                Id: 2367
+                LpsnRecordNumber: 776594
+                CommonCommensal: true
+              - Name: Gordonia polyisoprenivorans
+                ConceptType: Species
+                ConceptId: species/gordonia-polyisoprenivorans
+                ConceptSource: LPSN
+                Id: 727
+                LpsnRecordNumber: 776596
+                CommonCommensal: true
+              - Name: Gordonia rubripertincta
+                ConceptType: Species
+                ConceptId: species/gordonia-rubripertincta
+                ConceptSource: LPSN
+                Id: 2539
+                LpsnRecordNumber: 776598
+                CommonCommensal: true
+                Synonyms:
+                - Name: Gordonia rubropertinctus
+                  ConceptId: species/gordonia-rubropertinctus
+                  ConceptSource: LPSN
+                  Id: 1369
+                  LpsnRecordNumber: 783925
+                - Name: Rhodococcus rubropertinctus
+                  ConceptId: species/rhodococcus-rubropertinctus
+                  ConceptSource: LPSN
+                  Id: 924
+                  LpsnRecordNumber: 780472
+              - Name: Gordonia sputi
+                ConceptType: Species
+                ConceptId: species/gordonia-sputi
+                ConceptSource: LPSN
+                Id: 2146
+                LpsnRecordNumber: 776603
+                CommonCommensal: true
+              - Name: Gordonia terrae
+                ConceptType: Species
+                ConceptId: species/gordonia-terrae
+                ConceptSource: LPSN
+                Id: 2465
+                LpsnRecordNumber: 776604
+                CommonCommensal: true
+                Synonyms:
+                - Name: Rhodococcus terrae
+                  ConceptId: species/rhodococcus-terrae
+                  ConceptSource: LPSN
+                  Id: 1184
+                  LpsnRecordNumber: 780476
+          - Name: Mycobacteriaceae
+            ConceptType: Family
+            ConceptId: family/mycobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 912
+            Children:
+            - Name: Mycobacterium
+              ConceptType: Genus
+              ConceptId: genus/mycobacterium
+              ConceptSource: LPSN
+              Id: 1395
+              LpsnRecordNumber: 516137
+              Children:
+              - Name: Mycobacterium avium complex
+                ConceptType: Group
+                ConceptId: 2
+                ConceptSource: NeoIPC
+                Id: 2599
+                Children:
+                - Name: Mycobacterium arosiense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-arosiense
+                  ConceptSource: LPSN
+                  Id: 2853
+                  LpsnRecordNumber: 785698
+                - Name: Mycobacterium avium
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-avium
+                  ConceptSource: LPSN
+                  Id: 2461
+                  LpsnRecordNumber: 784303
+                  Children:
+                  - Name: Mycobacterium avium subsp. paratuberculosis
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/mycobacterium-avium-paratuberculosis
+                    ConceptSource: LPSN
+                    Id: 3099
+                    LpsnRecordNumber: 778400
+                    Synonyms:
+                    - Name: Mycobacterium paratuberculosis
+                      ConceptId: species/mycobacterium-paratuberculosis
+                      ConceptSource: LPSN
+                      Id: 869
+                      LpsnRecordNumber: 778502
+                  Synonyms:
+                  - Name: Mycobacterium bouchedurhonense
+                    ConceptId: species/mycobacterium-bouchedurhonense
+                    ConceptSource: LPSN
+                    Id: 2858
+                    LpsnRecordNumber: 788196
+                - Name: Mycobacterium colombiense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-colombiense
+                  ConceptSource: LPSN
+                  Id: 2861
+                  LpsnRecordNumber: 785392
+                - Name: Mycobacterium intracellulare
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-intracellulare
+                  ConceptSource: LPSN
+                  Id: 268
+                  LpsnRecordNumber: 778469
+                  Children:
+                  - Name: Mycobacterium intracellulare subsp. chimaera
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/mycobacterium-intracellulare-chimaera
+                    ConceptSource: LPSN
+                    Id: 2859
+                    LpsnRecordNumber: 798169
+                    Synonyms:
+                    - Name: Mycobacterium chimaera
+                      ConceptId: species/mycobacterium-chimaera
+                      ConceptSource: LPSN
+                      Id: 2860
+                      LpsnRecordNumber: 778422
+                - Name: Mycobacterium marseillense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-marseillense
+                  ConceptSource: LPSN
+                  Id: 2876
+                  LpsnRecordNumber: 788198
+                - Name: Mycobacterium timonense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-timonense
+                  ConceptSource: LPSN
+                  Id: 2895
+                  LpsnRecordNumber: 788197
+              - Name: Mycobacterium fortuitum complex
+                ConceptType: Group
+                ConceptId: 80
+                ConceptSource: NeoIPC
+                Id: 2951
+                Children:
+                - Name: Mycobacterium conceptionense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-conceptionense
+                  ConceptSource: LPSN
+                  Id: 2862
+                  LpsnRecordNumber: 785474
+                - Name: Mycobacterium fortuitum
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-fortuitum
+                  ConceptSource: LPSN
+                  Id: 2457
+                  LpsnRecordNumber: 778444
+                - Name: Mycobacterium mageritense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-mageritense
+                  ConceptSource: LPSN
+                  Id: 2282
+                  LpsnRecordNumber: 778480
+                - Name: Mycobacterium peregrinum
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-peregrinum
+                  ConceptSource: LPSN
+                  Id: 2530
+                  LpsnRecordNumber: 778504
+                - Name: Mycobacterium porcinum
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-porcinum
+                  ConceptSource: LPSN
+                  Id: 124
+                  LpsnRecordNumber: 778508
+                - Name: Mycobacterium senegalense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-senegalense
+                  ConceptSource: LPSN
+                  Id: 2890
+                  LpsnRecordNumber: 778524
+                - Name: Mycobacterium septicum
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-septicum
+                  ConceptSource: LPSN
+                  Id: 2387
+                  LpsnRecordNumber: 778525
+              - Name: Mycobacterium terrae complex
+                ConceptType: Group
+                ConceptId: 81
+                ConceptSource: NeoIPC
+                Id: 2952
+                Children:
+                - Name: Mycobacterium arupense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-arupense
+                  ConceptSource: LPSN
+                  Id: 2854
+                  LpsnRecordNumber: 778395
+                - Name: Mycobacterium heraklionense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-heraklionense
+                  ConceptSource: LPSN
+                  Id: 2867
+                  LpsnRecordNumber: 790509
+                - Name: Mycobacterium hiberniae
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-hiberniae
+                  ConceptSource: LPSN
+                  Id: 1644
+                  LpsnRecordNumber: 778461
+                - Name: Mycobacterium kumamotonense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-kumamotonense
+                  ConceptSource: LPSN
+                  Id: 2870
+                  LpsnRecordNumber: 786029
+                - Name: Mycobacterium longobardum
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-longobardum
+                  ConceptSource: LPSN
+                  Id: 2874
+                  LpsnRecordNumber: 790475
+                - Name: Mycobacterium nonchromogenicum
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-nonchromogenicum
+                  ConceptSource: LPSN
+                  Id: 1703
+                  LpsnRecordNumber: 778495
+                - Name: Mycobacterium senuense
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-senuense
+                  ConceptSource: LPSN
+                  Id: 2891
+                  LpsnRecordNumber: 787251
+                - Name: Mycobacterium terrae
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-terrae
+                  ConceptSource: LPSN
+                  Id: 361
+                  LpsnRecordNumber: 778533
+              - Name: Mycobacterium tuberculosis complex
+                ConceptType: Group
+                ConceptId: 82
+                ConceptSource: NeoIPC
+                Id: 2953
+                Children:
+                - Name: Mycobacterium mungi
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-mungi
+                  ConceptSource: LPSN
+                  Id: 2880
+                  LpsnRecordNumber: 801230
+                - Name: Mycobacterium tuberculosis
+                  ConceptType: Species
+                  ConceptId: species/mycobacterium-tuberculosis
+                  ConceptSource: LPSN
+                  Id: 1346
+                  LpsnRecordNumber: 778540
+                  Children:
+                  - Name: Mycobacterium tuberculosis subsp. canetti
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/mycobacterium-tuberculosis-canetti
+                    ConceptSource: LPSN
+                    Id: 2948
+                    LpsnRecordNumber: 801066
+                    Synonyms:
+                    - Name: Mycobacterium canetti
+                      ConceptId: species/mycobacterium-canetti
+                      ConceptSource: LPSN
+                      Id: 2949
+                      LpsnRecordNumber: 801062
+                  Synonyms:
+                  - Name: Mycobacterium africanum
+                    ConceptId: species/mycobacterium-africanum
+                    ConceptSource: LPSN
+                    Id: 1897
+                    LpsnRecordNumber: 784301
+                  - Name: Mycobacterium bovis
+                    ConceptId: species/mycobacterium-bovis
+                    ConceptSource: LPSN
+                    Id: 1159
+                    LpsnRecordNumber: 784305
+                  - Name: Mycobacterium caprae
+                    ConceptId: species/mycobacterium-caprae
+                    ConceptSource: LPSN
+                    Id: 1793
+                    LpsnRecordNumber: 784307
+                  - Name: Mycobacterium microti
+                    ConceptId: species/mycobacterium-microti
+                    ConceptSource: LPSN
+                    Id: 1669
+                    LpsnRecordNumber: 778485
+                  - Name: Mycobacterium pinnipedii
+                    ConceptId: species/mycobacterium-pinnipedii
+                    ConceptSource: LPSN
+                    Id: 1054
+                    LpsnRecordNumber: 784312
+              - Name: Mycobacterium abscessus
+                ConceptType: Species
+                ConceptId: species/mycobacterium-abscessus-1
+                ConceptSource: LPSN
+                Id: 381
+                LpsnRecordNumber: 778388
+                Children:
+                - Name: Mycobacterium abscessus subsp. massiliense
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/mycobacterium-abscessus-massiliense
+                  ConceptSource: LPSN
+                  Id: 2877
+                  LpsnRecordNumber: 794775
+                  Synonyms:
+                  - Name: Mycobacterium massiliense
+                    ConceptId: species/mycobacterium-massiliense
+                    ConceptSource: LPSN
+                    Id: 2878
+                    LpsnRecordNumber: 785475
+              - Name: Mycobacterium agri
+                ConceptType: Species
+                ConceptId: species/mycobacterium-agri
+                ConceptSource: LPSN
+                Id: 825
+                LpsnRecordNumber: 778390
+              - Name: Mycobacterium aichiense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-aichiense
+                ConceptSource: LPSN
+                Id: 1188
+                LpsnRecordNumber: 778391
+              - Name: Mycobacterium alsense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-alsense
+                ConceptSource: LPSN
+                Id: 2852
+                LpsnRecordNumber: 793716
+              - Name: Mycobacterium alvei
+                ConceptType: Species
+                ConceptId: species/mycobacterium-alvei
+                ConceptSource: LPSN
+                Id: 146
+                LpsnRecordNumber: 778393
+              - Name: Mycobacterium asiaticum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-asiaticum
+                ConceptSource: LPSN
+                Id: 2502
+                LpsnRecordNumber: 778396
+              - Name: Mycobacterium aubagnense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-aubagnense
+                ConceptSource: LPSN
+                Id: 2855
+                LpsnRecordNumber: 784302
+              - Name: Mycobacterium aurum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-aurum
+                ConceptSource: LPSN
+                Id: 1696
+                LpsnRecordNumber: 778397
+              - Name: Mycobacterium austroafricanum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-austroafricanum
+                ConceptSource: LPSN
+                Id: 415
+                LpsnRecordNumber: 778398
+                Synonyms:
+                - Name: Mycobacterium vanbaalenii
+                  ConceptId: species/mycobacterium-vanbaalenii
+                  ConceptSource: LPSN
+                  Id: 1082
+                  LpsnRecordNumber: 778544
+              - Name: Mycobacterium bacteremicum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-bacteremicum
+                ConceptSource: LPSN
+                Id: 2856
+                LpsnRecordNumber: 790162
+              - Name: Mycobacterium basiliense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-basiliense
+                ConceptSource: LPSN
+                Id: 2857
+                LpsnRecordNumber: 800746
+              - Name: Mycobacterium boenickei
+                ConceptType: Species
+                ConceptId: species/mycobacterium-boenickei
+                ConceptSource: LPSN
+                Id: 74
+                LpsnRecordNumber: 778403
+              - Name: Mycobacterium bohemicum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-bohemicum
+                ConceptSource: LPSN
+                Id: 1200
+                LpsnRecordNumber: 778404
+              - Name: Mycobacterium branderi
+                ConceptType: Species
+                ConceptId: species/mycobacterium-branderi
+                ConceptSource: LPSN
+                Id: 673
+                LpsnRecordNumber: 778409
+              - Name: Mycobacterium brisbanense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-brisbanense
+                ConceptSource: LPSN
+                Id: 2020
+                LpsnRecordNumber: 778410
+              - Name: Mycobacterium brumae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-brumae
+                ConceptSource: LPSN
+                Id: 1726
+                LpsnRecordNumber: 778411
+              - Name: Mycobacterium canariasense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-canariasense
+                ConceptSource: LPSN
+                Id: 1040
+                LpsnRecordNumber: 778414
+              - Name: Mycobacterium celatum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-celatum
+                ConceptSource: LPSN
+                Id: 2351
+                LpsnRecordNumber: 778415
+              - Name: Mycobacterium chelonae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-chelonae
+                ConceptSource: LPSN
+                Id: 1588
+                LpsnRecordNumber: 778416
+              - Name: Mycobacterium chesapeaki
+                ConceptType: Species
+                ConceptId: species/mycobacterium-chesapeaki
+                ConceptSource: LPSN
+                Id: 2950
+                LpsnRecordNumber: 801063
+              - Name: Mycobacterium chitae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-chitae
+                ConceptSource: LPSN
+                Id: 1769
+                LpsnRecordNumber: 778423
+              - Name: Mycobacterium chlorophenolicum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-chlorophenolicum
+                ConceptSource: LPSN
+                Id: 2965
+                LpsnRecordNumber: 778424
+                Synonyms:
+                - Name: Rhodococcus chlorophenolicus
+                  ConceptId: species/rhodococcus-chlorophenolicus
+                  ConceptSource: LPSN
+                  Id: 1050
+                  LpsnRecordNumber: 780443
+              - Name: Mycobacterium chubuense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-chubuense
+                ConceptSource: LPSN
+                Id: 2508
+                LpsnRecordNumber: 778425
+              - Name: Mycobacterium confluentis
+                ConceptType: Species
+                ConceptId: species/mycobacterium-confluentis
+                ConceptSource: LPSN
+                Id: 2100
+                LpsnRecordNumber: 778428
+              - Name: Mycobacterium conspicuum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-conspicuum
+                ConceptSource: LPSN
+                Id: 2067
+                LpsnRecordNumber: 778429
+              - Name: Mycobacterium cookii
+                ConceptType: Species
+                ConceptId: species/mycobacterium-cookii
+                ConceptSource: LPSN
+                Id: 787
+                LpsnRecordNumber: 778431
+              - Name: Mycobacterium cosmeticum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-cosmeticum
+                ConceptSource: LPSN
+                Id: 654
+                LpsnRecordNumber: 778432
+              - Name: Mycobacterium diernhoferi
+                ConceptType: Species
+                ConceptId: species/mycobacterium-diernhoferi
+                ConceptSource: LPSN
+                Id: 884
+                LpsnRecordNumber: 778433
+              - Name: Mycobacterium doricum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-doricum
+                ConceptSource: LPSN
+                Id: 115
+                LpsnRecordNumber: 778434
+              - Name: Mycobacterium duvalii
+                ConceptType: Species
+                ConceptId: species/mycobacterium-duvalii
+                ConceptSource: LPSN
+                Id: 982
+                LpsnRecordNumber: 778435
+              - Name: Mycobacterium elephantis
+                ConceptType: Species
+                ConceptId: species/mycobacterium-elephantis
+                ConceptSource: LPSN
+                Id: 507
+                LpsnRecordNumber: 778436
+              - Name: Mycobacterium europaeum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-europaeum
+                ConceptSource: LPSN
+                Id: 2863
+                LpsnRecordNumber: 789342
+              - Name: Mycobacterium fallax
+                ConceptType: Species
+                ConceptId: species/mycobacterium-fallax
+                ConceptSource: LPSN
+                Id: 955
+                LpsnRecordNumber: 778437
+              - Name: Mycobacterium farcinogenes
+                ConceptType: Species
+                ConceptId: species/mycobacterium-farcinogenes
+                ConceptSource: LPSN
+                Id: 418
+                LpsnRecordNumber: 778438
+              - Name: Mycobacterium flavescens
+                ConceptType: Species
+                ConceptId: species/mycobacterium-flavescens
+                ConceptSource: LPSN
+                Id: 574
+                LpsnRecordNumber: 778440
+              - Name: Mycobacterium florentinum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-florentinum
+                ConceptSource: LPSN
+                Id: 2864
+                LpsnRecordNumber: 778442
+              - Name: Mycobacterium fragae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-fragae
+                ConceptSource: LPSN
+                Id: 2865
+                LpsnRecordNumber: 790944
+              - Name: Mycobacterium frederiksbergense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-frederiksbergense
+                ConceptSource: LPSN
+                Id: 1817
+                LpsnRecordNumber: 778447
+              - Name: Mycobacterium gadium
+                ConceptType: Species
+                ConceptId: species/mycobacterium-gadium
+                ConceptSource: LPSN
+                Id: 911
+                LpsnRecordNumber: 778450
+              - Name: Mycobacterium gastri
+                ConceptType: Species
+                ConceptId: species/mycobacterium-gastri
+                ConceptSource: LPSN
+                Id: 666
+                LpsnRecordNumber: 778451
+              - Name: Mycobacterium genavense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-genavense
+                ConceptSource: LPSN
+                Id: 423
+                LpsnRecordNumber: 778452
+              - Name: Mycobacterium gilvum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-gilvum
+                ConceptSource: LPSN
+                Id: 1693
+                LpsnRecordNumber: 778453
+              - Name: Mycobacterium goodii
+                ConceptType: Species
+                ConceptId: species/mycobacterium-goodii
+                ConceptSource: LPSN
+                Id: 2551
+                LpsnRecordNumber: 778454
+              - Name: Mycobacterium gordonae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-gordonae
+                ConceptSource: LPSN
+                Id: 838
+                LpsnRecordNumber: 778455
+              - Name: Mycobacterium grossiae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-grossiae
+                ConceptSource: LPSN
+                Id: 2866
+                LpsnRecordNumber: 796156
+              - Name: Mycobacterium haemophilum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-haemophilum
+                ConceptSource: LPSN
+                Id: 1912
+                LpsnRecordNumber: 778457
+              - Name: Mycobacterium hassiacum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-hassiacum
+                ConceptSource: LPSN
+                Id: 1579
+                LpsnRecordNumber: 778458
+              - Name: Mycobacterium heckeshornense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-heckeshornense
+                ConceptSource: LPSN
+                Id: 1454
+                LpsnRecordNumber: 778459
+              - Name: Mycobacterium heidelbergense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-heidelbergense
+                ConceptSource: LPSN
+                Id: 1164
+                LpsnRecordNumber: 778460
+              - Name: Mycobacterium hodleri
+                ConceptType: Species
+                ConceptId: species/mycobacterium-hodleri
+                ConceptSource: LPSN
+                Id: 1498
+                LpsnRecordNumber: 778462
+              - Name: Mycobacterium holsaticum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-holsaticum
+                ConceptSource: LPSN
+                Id: 2490
+                LpsnRecordNumber: 778463
+              - Name: Mycobacterium houstonense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-houstonense
+                ConceptSource: LPSN
+                Id: 127
+                LpsnRecordNumber: 778464
+              - Name: Mycobacterium immunogenum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-immunogenum
+                ConceptSource: LPSN
+                Id: 1017
+                LpsnRecordNumber: 778465
+              - Name: Mycobacterium interjectum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-interjectum
+                ConceptSource: LPSN
+                Id: 1680
+                LpsnRecordNumber: 778467
+              - Name: Mycobacterium intermedium
+                ConceptType: Species
+                ConceptId: species/mycobacterium-intermedium
+                ConceptSource: LPSN
+                Id: 2208
+                LpsnRecordNumber: 778468
+              - Name: Mycobacterium iranicum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-iranicum
+                ConceptSource: LPSN
+                Id: 2868
+                LpsnRecordNumber: 790675
+              - Name: Mycobacterium kansasii
+                ConceptType: Species
+                ConceptId: species/mycobacterium-kansasii
+                ConceptSource: LPSN
+                Id: 2042
+                LpsnRecordNumber: 778470
+              - Name: Mycobacterium komossense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-komossense
+                ConceptSource: LPSN
+                Id: 187
+                LpsnRecordNumber: 778473
+              - Name: Mycobacterium koreense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-koreense
+                ConceptSource: LPSN
+                Id: 2869
+                LpsnRecordNumber: 789918
+              - Name: Mycobacterium kubicae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-kubicae
+                ConceptSource: LPSN
+                Id: 1594
+                LpsnRecordNumber: 778474
+              - Name: Mycobacterium kyorinense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-kyorinense
+                ConceptSource: LPSN
+                Id: 2871
+                LpsnRecordNumber: 787903
+              - Name: Mycobacterium lacus
+                ConceptType: Species
+                ConceptId: species/mycobacterium-lacus
+                ConceptSource: LPSN
+                Id: 2133
+                LpsnRecordNumber: 778476
+              - Name: Mycobacterium lentiflavum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-lentiflavum
+                ConceptSource: LPSN
+                Id: 2219
+                LpsnRecordNumber: 778477
+              - Name: Mycobacterium leprae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-leprae
+                ConceptSource: LPSN
+                Id: 581
+                LpsnRecordNumber: 784308
+              - Name: Mycobacterium lepromatosis
+                ConceptType: Species
+                ConceptId: species/mycobacterium-lepromatosis
+                ConceptSource: LPSN
+                Id: 2872
+                LpsnRecordNumber: 801064
+              - Name: Mycobacterium llatzerense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-llatzerense
+                ConceptSource: LPSN
+                Id: 2873
+                LpsnRecordNumber: 787650
+              - Name: Mycobacterium madagascariense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-madagascariense
+                ConceptSource: LPSN
+                Id: 1667
+                LpsnRecordNumber: 778479
+              - Name: Mycobacterium malmoense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-malmoense
+                ConceptSource: LPSN
+                Id: 152
+                LpsnRecordNumber: 778482
+              - Name: Mycobacterium mantenii
+                ConceptType: Species
+                ConceptId: species/mycobacterium-mantenii
+                ConceptSource: LPSN
+                Id: 2875
+                LpsnRecordNumber: 788199
+              - Name: Mycobacterium marinum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-marinum
+                ConceptSource: LPSN
+                Id: 1762
+                LpsnRecordNumber: 778484
+              - Name: Mycobacterium monacense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-monacense
+                ConceptSource: LPSN
+                Id: 2879
+                LpsnRecordNumber: 785641
+              - Name: Mycobacterium montefiorense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-montefiorense
+                ConceptSource: LPSN
+                Id: 965
+                LpsnRecordNumber: 778487
+              - Name: Mycobacterium moriokaense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-moriokaense
+                ConceptSource: LPSN
+                Id: 2257
+                LpsnRecordNumber: 778488
+              - Name: Mycobacterium mucogenicum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-mucogenicum
+                ConceptSource: LPSN
+                Id: 1973
+                LpsnRecordNumber: 778489
+              - Name: Mycobacterium murale
+                ConceptType: Species
+                ConceptId: species/mycobacterium-murale
+                ConceptSource: LPSN
+                Id: 569
+                LpsnRecordNumber: 778490
+              - Name: Mycobacterium nebraskense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-nebraskense
+                ConceptSource: LPSN
+                Id: 2881
+                LpsnRecordNumber: 778491
+              - Name: Mycobacterium neoaurum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-neoaurum
+                ConceptSource: LPSN
+                Id: 2358
+                LpsnRecordNumber: 778493
+              - Name: Mycobacterium neworleansense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-neworleansense
+                ConceptSource: LPSN
+                Id: 528
+                LpsnRecordNumber: 778494
+              - Name: Mycobacterium noviomagense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-noviomagense
+                ConceptSource: LPSN
+                Id: 2882
+                LpsnRecordNumber: 787797
+              - Name: Mycobacterium novocastrense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-novocastrense
+                ConceptSource: LPSN
+                Id: 1142
+                LpsnRecordNumber: 778496
+              - Name: Mycobacterium obuense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-obuense
+                ConceptSource: LPSN
+                Id: 2374
+                LpsnRecordNumber: 778497
+              - Name: Mycobacterium palustre
+                ConceptType: Species
+                ConceptId: species/mycobacterium-palustre
+                ConceptSource: LPSN
+                Id: 1145
+                LpsnRecordNumber: 778498
+              - Name: Mycobacterium paraffinicum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-paraffinicum
+                ConceptSource: LPSN
+                Id: 2883
+                LpsnRecordNumber: 778499
+              - Name: Mycobacterium parafortuitum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-parafortuitum
+                ConceptSource: LPSN
+                Id: 233
+                LpsnRecordNumber: 778500
+              - Name: Mycobacterium paragordonae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-paragordonae
+                ConceptSource: LPSN
+                Id: 2884
+                LpsnRecordNumber: 791474
+              - Name: Mycobacterium parakoreense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-parakoreense
+                ConceptSource: LPSN
+                Id: 2885
+                LpsnRecordNumber: 790883
+              - Name: Mycobacterium parascrofulaceum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-parascrofulaceum
+                ConceptSource: LPSN
+                Id: 322
+                LpsnRecordNumber: 778501
+              - Name: Mycobacterium paraseoulense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-paraseoulense
+                ConceptSource: LPSN
+                Id: 2886
+                LpsnRecordNumber: 785359
+              - Name: Mycobacterium parmense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-parmense
+                ConceptSource: LPSN
+                Id: 2451
+                LpsnRecordNumber: 778503
+              - Name: Mycobacterium phlei
+                ConceptType: Species
+                ConceptId: species/mycobacterium-phlei
+                ConceptSource: LPSN
+                Id: 341
+                LpsnRecordNumber: 778506
+              - Name: Mycobacterium phocaicum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-phocaicum
+                ConceptSource: LPSN
+                Id: 1032
+                LpsnRecordNumber: 784311
+              - Name: Mycobacterium poriferae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-poriferae
+                ConceptSource: LPSN
+                Id: 2887
+                LpsnRecordNumber: 778509
+              - Name: Mycobacterium psychrotolerans
+                ConceptType: Species
+                ConceptId: species/mycobacterium-psychrotolerans
+                ConceptSource: LPSN
+                Id: 1585
+                LpsnRecordNumber: 778510
+              - Name: Mycobacterium rhodesiae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-rhodesiae
+                ConceptSource: LPSN
+                Id: 728
+                LpsnRecordNumber: 778515
+              - Name: Mycobacterium riyadhense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-riyadhense
+                ConceptSource: LPSN
+                Id: 2888
+                LpsnRecordNumber: 787867
+              - Name: Mycobacterium saskatchewanense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-saskatchewanense
+                ConceptSource: LPSN
+                Id: 2889
+                LpsnRecordNumber: 778522
+              - Name: Mycobacterium scrofulaceum
+                ConceptType: Species
+                ConceptId: species/mycobacterium-scrofulaceum
+                ConceptSource: LPSN
+                Id: 1182
+                LpsnRecordNumber: 778523
+              - Name: Mycobacterium seoulense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-seoulense
+                ConceptSource: LPSN
+                Id: 2892
+                LpsnRecordNumber: 786034
+              - Name: Mycobacterium setense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-setense
+                ConceptSource: LPSN
+                Id: 2893
+                LpsnRecordNumber: 785697
+              - Name: Mycobacterium sherrisii
+                ConceptType: Species
+                ConceptId: species/mycobacterium-sherrisii
+                ConceptSource: LPSN
+                Id: 1123
+                LpsnRecordNumber: 789292
+              - Name: Mycobacterium shimoidei
+                ConceptType: Species
+                ConceptId: species/mycobacterium-shimoidei
+                ConceptSource: LPSN
+                Id: 1133
+                LpsnRecordNumber: 778526
+              - Name: Mycobacterium shinjukuense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-shinjukuense
+                ConceptSource: LPSN
+                Id: 2894
+                LpsnRecordNumber: 789393
+              - Name: Mycobacterium shottsii
+                ConceptType: Species
+                ConceptId: species/mycobacterium-shottsii
+                ConceptSource: LPSN
+                Id: 186
+                LpsnRecordNumber: 784314
+              - Name: Mycobacterium simiae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-simiae
+                ConceptSource: LPSN
+                Id: 1970
+                LpsnRecordNumber: 778527
+              - Name: Mycobacterium smegmatis
+                ConceptType: Species
+                ConceptId: species/mycobacterium-smegmatis
+                ConceptSource: LPSN
+                Id: 1252
+                LpsnRecordNumber: 778528
+              - Name: Mycobacterium sphagni
+                ConceptType: Species
+                ConceptId: species/mycobacterium-sphagni
+                ConceptSource: LPSN
+                Id: 291
+                LpsnRecordNumber: 778530
+              - Name: Mycobacterium szulgai
+                ConceptType: Species
+                ConceptId: species/mycobacterium-szulgai
+                ConceptSource: LPSN
+                Id: 2491
+                LpsnRecordNumber: 778532
+              - Name: Mycobacterium thermoresistibile
+                ConceptType: Species
+                ConceptId: species/mycobacterium-thermoresistibile
+                ConceptSource: LPSN
+                Id: 2477
+                LpsnRecordNumber: 778535
+              - Name: Mycobacterium tokaiense
+                ConceptType: Species
+                ConceptId: species/mycobacterium-tokaiense
+                ConceptSource: LPSN
+                Id: 2050
+                LpsnRecordNumber: 778536
+              - Name: Mycobacterium triplex
+                ConceptType: Species
+                ConceptId: species/mycobacterium-triplex
+                ConceptSource: LPSN
+                Id: 215
+                LpsnRecordNumber: 778538
+              - Name: Mycobacterium triviale
+                ConceptType: Species
+                ConceptId: species/mycobacterium-triviale
+                ConceptSource: LPSN
+                Id: 1449
+                LpsnRecordNumber: 778539
+              - Name: Mycobacterium tusciae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-tusciae
+                ConceptSource: LPSN
+                Id: 1323
+                LpsnRecordNumber: 778541
+              - Name: Mycobacterium ulcerans
+                ConceptType: Species
+                ConceptId: species/mycobacterium-ulcerans
+                ConceptSource: LPSN
+                Id: 2025
+                LpsnRecordNumber: 778542
+              - Name: Mycobacterium vaccae
+                ConceptType: Species
+                ConceptId: species/mycobacterium-vaccae
+                ConceptSource: LPSN
+                Id: 975
+                LpsnRecordNumber: 778543
+              - Name: Mycobacterium wolinskyi
+                ConceptType: Species
+                ConceptId: species/mycobacterium-wolinskyi
+                ConceptSource: LPSN
+                Id: 2435
+                LpsnRecordNumber: 778545
+              - Name: Mycobacterium xenopi
+                ConceptType: Species
+                ConceptId: species/mycobacterium-xenopi
+                ConceptSource: LPSN
+                Id: 2289
+                LpsnRecordNumber: 778546
+          - Name: Nocardiaceae
+            ConceptType: Family
+            ConceptId: family/nocardiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 963
+            Children:
+            - Name: Nocardia
+              ConceptType: Genus
+              ConceptId: genus/nocardia
+              ConceptSource: LPSN
+              Id: 1148
+              LpsnRecordNumber: 516182
+              Children:
+              - Name: Nocardia asteroides complex
+                ConceptType: Group
+                ConceptId: 83
+                ConceptSource: NeoIPC
+                Id: 2954
+                Children:
+                - Name: Nocardia abscessus
+                  ConceptType: Species
+                  ConceptId: species/nocardia-abscessus
+                  ConceptSource: LPSN
+                  Id: 137
+                  LpsnRecordNumber: 778677
+                - Name: Nocardia asteroides
+                  ConceptType: Species
+                  ConceptId: species/nocardia-asteroides
+                  ConceptSource: LPSN
+                  Id: 1260
+                  LpsnRecordNumber: 778689
+                - Name: Nocardia cyriacigeorgica
+                  ConceptType: Species
+                  ConceptId: species/nocardia-cyriacigeorgica
+                  ConceptSource: LPSN
+                  Id: 378
+                  LpsnRecordNumber: 778714
+                - Name: Nocardia farcinica
+                  ConceptType: Species
+                  ConceptId: species/nocardia-farcinica
+                  ConceptSource: LPSN
+                  Id: 1004
+                  LpsnRecordNumber: 778720
+                - Name: Nocardia nova
+                  ConceptType: Species
+                  ConceptId: species/nocardia-nova
+                  ConceptSource: LPSN
+                  Id: 2368
+                  LpsnRecordNumber: 778753
+                - Name: Nocardia otitidiscaviarum
+                  ConceptType: Species
+                  ConceptId: species/nocardia-otitidiscaviarum
+                  ConceptSource: LPSN
+                  Id: 2069
+                  LpsnRecordNumber: 778757
+              - Name: Nocardia africana
+                ConceptType: Species
+                ConceptId: species/nocardia-africana
+                ConceptSource: LPSN
+                Id: 1265
+                LpsnRecordNumber: 778679
+              - Name: Nocardia anaemiae
+                ConceptType: Species
+                ConceptId: species/nocardia-anaemiae
+                ConceptSource: LPSN
+                Id: 2590
+                LpsnRecordNumber: 778683
+              - Name: Nocardia aobensis
+                ConceptType: Species
+                ConceptId: species/nocardia-aobensis
+                ConceptSource: LPSN
+                Id: 530
+                LpsnRecordNumber: 778684
+              - Name: Nocardia araoensis
+                ConceptType: Species
+                ConceptId: species/nocardia-araoensis
+                ConceptSource: LPSN
+                Id: 548
+                LpsnRecordNumber: 778686
+              - Name: Nocardia arthritidis
+                ConceptType: Species
+                ConceptId: species/nocardia-arthritidis
+                ConceptSource: LPSN
+                Id: 2000
+                LpsnRecordNumber: 778687
+              - Name: Nocardia asiatica
+                ConceptType: Species
+                ConceptId: species/nocardia-asiatica
+                ConceptSource: LPSN
+                Id: 1697
+                LpsnRecordNumber: 778688
+              - Name: Nocardia beijingensis
+                ConceptType: Species
+                ConceptId: species/nocardia-beijingensis
+                ConceptSource: LPSN
+                Id: 656
+                LpsnRecordNumber: 778693
+              - Name: Nocardia brasiliensis
+                ConceptType: Species
+                ConceptId: species/nocardia-brasiliensis
+                ConceptSource: LPSN
+                Id: 1899
+                LpsnRecordNumber: 778695
+              - Name: Nocardia brevicatena
+                ConceptType: Species
+                ConceptId: species/nocardia-brevicatena
+                ConceptSource: LPSN
+                Id: 2022
+                LpsnRecordNumber: 778696
+                Synonyms:
+                - Name: Micropolyspora brevicatena
+                  ConceptId: species/micropolyspora-brevicatena
+                  ConceptSource: LPSN
+                  Id: 204
+                  LpsnRecordNumber: 778221
+              - Name: Nocardia carnea
+                ConceptType: Species
+                ConceptId: species/nocardia-carnea
+                ConceptSource: LPSN
+                Id: 1069
+                LpsnRecordNumber: 778700
+              - Name: Nocardia elegans
+                ConceptType: Species
+                ConceptId: species/nocardia-elegans
+                ConceptSource: LPSN
+                Id: 1632
+                LpsnRecordNumber: 778717
+              - Name: Nocardia higoensis
+                ConceptType: Species
+                ConceptId: species/nocardia-higoensis
+                ConceptSource: LPSN
+                Id: 725
+                LpsnRecordNumber: 778727
+              - Name: Nocardia inohanensis
+                ConceptType: Species
+                ConceptId: species/nocardia-inohanensis
+                ConceptSource: LPSN
+                Id: 1811
+                LpsnRecordNumber: 778731
+              - Name: Nocardia kruczakiae
+                ConceptType: Species
+                ConceptId: species/nocardia-kruczakiae
+                ConceptSource: LPSN
+                Id: 1898
+                LpsnRecordNumber: 778737
+              - Name: Nocardia mexicana
+                ConceptType: Species
+                ConceptId: species/nocardia-mexicana
+                ConceptSource: LPSN
+                Id: 783
+                LpsnRecordNumber: 778744
+              - Name: Nocardia niigatensis
+                ConceptType: Species
+                ConceptId: species/nocardia-niigatensis
+                ConceptSource: LPSN
+                Id: 1786
+                LpsnRecordNumber: 778750
+              - Name: Nocardia paucivorans
+                ConceptType: Species
+                ConceptId: species/nocardia-paucivorans
+                ConceptSource: LPSN
+                Id: 498
+                LpsnRecordNumber: 778759
+              - Name: Nocardia pneumoniae
+                ConceptType: Species
+                ConceptId: species/nocardia-pneumoniae
+                ConceptSource: LPSN
+                Id: 2357
+                LpsnRecordNumber: 778766
+              - Name: Nocardia pseudobrasiliensis
+                ConceptType: Species
+                ConceptId: species/nocardia-pseudobrasiliensis
+                ConceptSource: LPSN
+                Id: 800
+                LpsnRecordNumber: 778769
+              - Name: Nocardia sienata
+                ConceptType: Species
+                ConceptId: species/nocardia-sienata
+                ConceptSource: LPSN
+                Id: 120
+                LpsnRecordNumber: 778785
+              - Name: Nocardia testacea
+                ConceptType: Species
+                ConceptId: species/nocardia-testacea
+                ConceptSource: LPSN
+                Id: 2280
+                LpsnRecordNumber: 778796
+              - Name: Nocardia transvalensis
+                ConceptType: Species
+                ConceptId: species/nocardia-transvalensis
+                ConceptSource: LPSN
+                Id: 1864
+                LpsnRecordNumber: 778800
+              - Name: Nocardia veterana
+                ConceptType: Species
+                ConceptId: species/nocardia-veterana
+                ConceptSource: LPSN
+                Id: 1455
+                LpsnRecordNumber: 778806
+              - Name: Nocardia yamanashiensis
+                ConceptType: Species
+                ConceptId: species/nocardia-yamanashiensis
+                ConceptSource: LPSN
+                Id: 1293
+                LpsnRecordNumber: 778809
+            - Name: Rhodococcus
+              ConceptType: Genus
+              ConceptId: genus/rhodococcus
+              ConceptSource: LPSN
+              Id: 2252
+              LpsnRecordNumber: 516476
+              CommonCommensal: true
+              Children:
+              - Name: Rhodococcus chubuensis
+                ConceptType: Species
+                ConceptId: species/rhodococcus-chubuensis
+                ConceptSource: LPSN
+                Id: 1393
+                LpsnRecordNumber: 780444
+                CommonCommensal: true
+              - Name: Rhodococcus equi
+                ConceptType: Species
+                ConceptId: species/rhodococcus-equi
+                ConceptSource: LPSN
+                Id: 1776
+                LpsnRecordNumber: 780448
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium equi
+                  ConceptId: species/corynebacterium-equi
+                  ConceptSource: LPSN
+                  Id: 1155
+                  LpsnRecordNumber: 775181
+              - Name: Rhodococcus erythropolis
+                ConceptType: Species
+                ConceptId: species/rhodococcus-erythropolis
+                ConceptSource: LPSN
+                Id: 1712
+                LpsnRecordNumber: 780449
+                CommonCommensal: true
+              - Name: Rhodococcus fascians
+                ConceptType: Species
+                ConceptId: species/rhodococcus-fascians
+                ConceptSource: LPSN
+                Id: 2169
+                LpsnRecordNumber: 780450
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium fascians
+                  ConceptId: species/corynebacterium-fascians
+                  ConceptSource: LPSN
+                  Id: 234
+                  LpsnRecordNumber: 775183
+                - Name: Rhodococcus luteus
+                  ConceptId: species/rhodococcus-luteus
+                  ConceptSource: LPSN
+                  Id: 1279
+                  LpsnRecordNumber: 780458
+              - Name: Rhodococcus globerulus
+                ConceptType: Species
+                ConceptId: species/rhodococcus-globerulus
+                ConceptSource: LPSN
+                Id: 998
+                LpsnRecordNumber: 780451
+                CommonCommensal: true
+              - Name: Rhodococcus gordoniae
+                ConceptType: Species
+                ConceptId: species/rhodococcus-gordoniae
+                ConceptSource: LPSN
+                Id: 1076
+                LpsnRecordNumber: 780452
+                CommonCommensal: true
+              - Name: Rhodococcus hoagii
+                ConceptType: Species
+                ConceptId: species/rhodococcus-hoagii
+                ConceptSource: LPSN
+                Id: 3115
+                LpsnRecordNumber: 791654
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium hoagii
+                  ConceptId: species/corynebacterium-hoagii
+                  ConceptSource: LPSN
+                  Id: 246
+                  LpsnRecordNumber: 775200
+              - Name: Rhodococcus obuensis
+                ConceptType: Species
+                ConceptId: species/rhodococcus-obuensis
+                ConceptSource: LPSN
+                Id: 2464
+                LpsnRecordNumber: 780462
+                CommonCommensal: true
+              - Name: Rhodococcus rhodochrous
+                ConceptType: Species
+                ConceptId: species/rhodococcus-rhodochrous
+                ConceptSource: LPSN
+                Id: 1971
+                LpsnRecordNumber: 780469
+                CommonCommensal: true
+                Synonyms:
+                - Name: Rhodococcus roseus
+                  ConceptId: species/rhodococcus-roseus
+                  ConceptSource: LPSN
+                  Id: 2412
+                  LpsnRecordNumber: 780470
+          - Name: Tsukamurellaceae
+            ConceptType: Family
+            ConceptId: family/tsukamurellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1523
+            Children:
+            - Name: Tsukamurella
+              ConceptType: Genus
+              ConceptId: genus/tsukamurella
+              ConceptSource: LPSN
+              Id: 2305
+              LpsnRecordNumber: 516872
+              CommonCommensal: true
+              Children:
+              - Name: Tsukamurella inchonensis
+                ConceptType: Species
+                ConceptId: species/tsukamurella-inchonensis
+                ConceptSource: LPSN
+                Id: 1806
+                LpsnRecordNumber: 782888
+                CommonCommensal: true
+              - Name: Tsukamurella paurometabola
+                ConceptType: Species
+                ConceptId: species/tsukamurella-paurometabola
+                ConceptSource: LPSN
+                Id: 221
+                LpsnRecordNumber: 782889
+                CommonCommensal: true
+                Synonyms:
+                - Name: Corynebacterium paurometabolum
+                  ConceptId: species/corynebacterium-paurometabolum
+                  ConceptSource: LPSN
+                  Id: 328
+                  LpsnRecordNumber: 775233
+                - Name: Rhodococcus aurantiacus
+                  ConceptId: species/rhodococcus-aurantiacus
+                  ConceptSource: LPSN
+                  Id: 216
+                  LpsnRecordNumber: 780439
+              - Name: Tsukamurella pulmonis
+                ConceptType: Species
+                ConceptId: species/tsukamurella-pulmonis
+                ConceptSource: LPSN
+                Id: 2430
+                LpsnRecordNumber: 782892
+                CommonCommensal: true
+              - Name: Tsukamurella strandjordii
+                ConceptType: Species
+                ConceptId: species/tsukamurella-strandjordii
+                ConceptSource: LPSN
+                Id: 73
+                LpsnRecordNumber: 782895
+                CommonCommensal: true
+              - Name: Tsukamurella tyrosinosolvens
+                ConceptType: Species
+                ConceptId: species/tsukamurella-tyrosinosolvens
+                ConceptSource: LPSN
+                Id: 2425
+                LpsnRecordNumber: 782896
+                CommonCommensal: true
+        - Name: Propionibacteriales
+          ConceptType: Order
+          ConceptId: order/propionibacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5171
+          Children:
+          - Name: Propionibacteriaceae
+            ConceptType: Family
+            ConceptId: family/propionibacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1114
+            Children:
+            - Name: Acidipropionibacterium
+              ConceptType: Genus
+              ConceptId: genus/acidipropionibacterium
+              ConceptSource: LPSN
+              LpsnRecordNumber: 519071
+              Children:
+              - Name: Acidipropionibacterium acidipropionici
+                ConceptType: Species
+                ConceptId: species/acidipropionibacterium-acidipropionici
+                ConceptSource: LPSN
+                Id: 3030
+                LpsnRecordNumber: 794760
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium acidipropionici
+                  ConceptId: species/propionibacterium-acidipropionici
+                  ConceptSource: LPSN
+                  Id: 2068
+                  LpsnRecordNumber: 779818
+              - Name: Acidipropionibacterium jensenii
+                ConceptType: Species
+                ConceptId: species/acidipropionibacterium-jensenii
+                ConceptSource: LPSN
+                Id: 3272
+                LpsnRecordNumber: 794758
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium jensenii
+                  ConceptId: species/propionibacterium-jensenii
+                  ConceptSource: LPSN
+                  Id: 2497
+                  LpsnRecordNumber: 779828
+              - Name: Acidipropionibacterium microaerophilum
+                ConceptType: Species
+                ConceptId: species/acidipropionibacterium-microaerophilum
+                ConceptSource: LPSN
+                Id: 2991
+                LpsnRecordNumber: 794761
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium microaerophilum
+                  ConceptId: species/propionibacterium-microaerophilum
+                  ConceptSource: LPSN
+                  Id: 966
+                  LpsnRecordNumber: 779830
+              - Name: Acidipropionibacterium thoenii
+                ConceptType: Species
+                ConceptId: species/acidipropionibacterium-thoenii
+                ConceptSource: LPSN
+                Id: 3286
+                LpsnRecordNumber: 794759
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium thoenii
+                  ConceptId: species/propionibacterium-thoenii
+                  ConceptSource: LPSN
+                  Id: 2198
+                  LpsnRecordNumber: 779836
+            - Name: Arachnia
+              ConceptType: Genus
+              ConceptId: genus/arachnia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 515163
+              Children:
+              - Name: Arachnia propionica
+                ConceptType: Species
+                ConceptId: species/arachnia-propionica
+                ConceptSource: LPSN
+                Id: 2436
+                LpsnRecordNumber: 773347
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium propionicum
+                  ConceptId: species/propionibacterium-propionicum
+                  ConceptSource: LPSN
+                  Id: 2062
+                  LpsnRecordNumber: 779833
+            - Name: Cutibacterium
+              ConceptType: Genus
+              ConceptId: genus/cutibacterium
+              ConceptSource: LPSN
+              Id: 56
+              LpsnRecordNumber: 519072
+              CommonCommensal: true
+              Children:
+              - Name: Cutibacterium acnes
+                ConceptType: Species
+                ConceptId: species/cutibacterium-acnes
+                ConceptSource: LPSN
+                Id: 1331
+                LpsnRecordNumber: 794765
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium acnes
+                  ConceptId: species/propionibacterium-acnes
+                  ConceptSource: LPSN
+                  Id: 2348
+                  LpsnRecordNumber: 779819
+              - Name: Cutibacterium avidum
+                ConceptType: Species
+                ConceptId: species/cutibacterium-avidum
+                ConceptSource: LPSN
+                Id: 3283
+                LpsnRecordNumber: 794766
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium avidum
+                  ConceptId: species/propionibacterium-avidum
+                  ConceptSource: LPSN
+                  Id: 757
+                  LpsnRecordNumber: 779822
+              - Name: Cutibacterium granulosum
+                ConceptType: Species
+                ConceptId: species/cutibacterium-granulosum
+                ConceptSource: LPSN
+                Id: 2996
+                LpsnRecordNumber: 794767
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium granulosum
+                  ConceptId: species/propionibacterium-granulosum
+                  ConceptSource: LPSN
+                  Id: 956
+                  LpsnRecordNumber: 779826
+            - Name: Propionibacterium
+              ConceptType: Genus
+              ConceptId: genus/propionibacterium
+              ConceptSource: LPSN
+              Id: 1753
+              LpsnRecordNumber: 516391
+              CommonCommensal: true
+              Children:
+              - Name: Propionibacterium australiense
+                ConceptType: Species
+                ConceptId: species/propionibacterium-australiense
+                ConceptSource: LPSN
+                Id: 18
+                LpsnRecordNumber: 779821
+                CommonCommensal: true
+              - Name: Propionibacterium cyclohexanicum
+                ConceptType: Species
+                ConceptId: species/propionibacterium-cyclohexanicum
+                ConceptSource: LPSN
+                Id: 986
+                LpsnRecordNumber: 779823
+                CommonCommensal: true
+              - Name: Propionibacterium freudenreichii
+                ConceptType: Species
+                ConceptId: species/propionibacterium-freudenreichii
+                ConceptSource: LPSN
+                Id: 399
+                LpsnRecordNumber: 784695
+                CommonCommensal: true
+            - Name: Propioniferax
+              ConceptType: Genus
+              ConceptId: genus/propioniferax
+              ConceptSource: LPSN
+              Id: 1998
+              LpsnRecordNumber: 516393
+              CommonCommensal: true
+              Children:
+              - Name: Propioniferax innocua
+                ConceptType: Species
+                ConceptId: species/propioniferax-innocua
+                ConceptSource: LPSN
+                Id: 3316
+                LpsnRecordNumber: 779839
+                CommonCommensal: true
+                Synonyms:
+                - Name: Propionibacterium innocuum
+                  ConceptId: species/propionibacterium-innocuum
+                  ConceptSource: LPSN
+                  Id: 542
+                  LpsnRecordNumber: 779827
+            - Name: Propionimicrobium
+              ConceptType: Genus
+              ConceptId: genus/propionimicrobium
+              ConceptSource: LPSN
+              Id: 2512
+              LpsnRecordNumber: 516395
+              Children:
+              - Name: Propionimicrobium lymphophilum
+                ConceptType: Species
+                ConceptId: species/propionimicrobium-lymphophilum
+                ConceptSource: LPSN
+                Id: 2571
+                LpsnRecordNumber: 779843
+                Synonyms:
+                - Name: Propionibacterium lymphophilum
+                  ConceptId: species/propionibacterium-lymphophilum
+                  ConceptSource: LPSN
+                  Id: 586
+                  LpsnRecordNumber: 779829
+        - Name: Pseudonocardiales
+          ConceptType: Order
+          ConceptId: order/pseudonocardiales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5172
+          Children:
+          - Name: Pseudonocardiaceae
+            ConceptType: Family
+            ConceptId: family/pseudonocardiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1137
+            Children:
+            - Name: Amycolatopsis
+              ConceptType: Genus
+              ConceptId: genus/amycolatopsis
+              ConceptSource: LPSN
+              Id: 1492
+              LpsnRecordNumber: 515111
+              Children:
+              - Name: Amycolatopsis orientalis
+                ConceptType: Species
+                ConceptId: species/amycolatopsis-orientalis
+                ConceptSource: LPSN
+                Id: 686
+                LpsnRecordNumber: 783364
+                Synonyms:
+                - Name: Nocardia orientalis
+                  ConceptId: species/nocardia-orientalis
+                  ConceptSource: LPSN
+                  Id: 2183
+                  LpsnRecordNumber: 778756
+            - Name: Saccharomonospora
+              ConceptType: Genus
+              ConceptId: genus/saccharomonospora
+              ConceptSource: LPSN
+              Id: 1706
+              LpsnRecordNumber: 516525
+              Children:
+              - Name: Saccharomonospora glauca
+                ConceptType: Species
+                ConceptId: species/saccharomonospora-glauca
+                ConceptSource: LPSN
+                Id: 835
+                LpsnRecordNumber: 780634
+              - Name: Saccharomonospora viridis
+                ConceptType: Species
+                ConceptId: species/saccharomonospora-viridis
+                ConceptSource: LPSN
+                Id: 2172
+                LpsnRecordNumber: 780638
+            - Name: Saccharopolyspora
+              ConceptType: Genus
+              ConceptId: genus/saccharopolyspora
+              ConceptSource: LPSN
+              Id: 1389
+              LpsnRecordNumber: 516530
+              Children:
+              - Name: Saccharopolyspora rectivirgula
+                ConceptType: Species
+                ConceptId: species/saccharopolyspora-rectivirgula
+                ConceptSource: LPSN
+                Id: 1422
+                LpsnRecordNumber: 780691
+        - Name: Streptosporangiales
+          ConceptType: Order
+          ConceptId: order/streptosporangiales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5173
+          Children:
+          - Name: Nocardiopsidaceae
+            ConceptType: Family
+            ConceptId: family/nocardiopsidaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 29686
+            Children:
+            - Name: Nocardiopsis
+              ConceptType: Genus
+              ConceptId: genus/nocardiopsis
+              ConceptSource: LPSN
+              Id: 372
+              LpsnRecordNumber: 516184
+              Children:
+              - Name: Nocardiopsis dassonvillei
+                ConceptType: Species
+                ConceptId: species/nocardiopsis-dassonvillei
+                ConceptSource: LPSN
+                Id: 1890
+                LpsnRecordNumber: 784508
+              - Name: Nocardiopsis synnemataformans
+                ConceptType: Species
+                ConceptId: species/nocardiopsis-synnemataformans
+                ConceptSource: LPSN
+                Id: 2489
+                LpsnRecordNumber: 778878
+          - Name: Thermomonosporaceae
+            ConceptType: Family
+            ConceptId: family/thermomonosporaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1458
+            Children:
+            - Name: Actinomadura
+              ConceptType: Genus
+              ConceptId: genus/actinomadura
+              ConceptSource: LPSN
+              Id: 1198
+              LpsnRecordNumber: 517407
+              Children:
+              - Name: Actinomadura latina
+                ConceptType: Species
+                ConceptId: species/actinomadura-latina
+                ConceptSource: LPSN
+                Id: 2428
+                LpsnRecordNumber: 772719
+              - Name: Actinomadura madurae
+                ConceptType: Species
+                ConceptId: species/actinomadura-madurae
+                ConceptSource: LPSN
+                Id: 1902
+                LpsnRecordNumber: 772727
+              - Name: Actinomadura pelletieri
+                ConceptType: Species
+                ConceptId: species/actinomadura-pelletieri
+                ConceptSource: LPSN
+                Id: 1513
+                LpsnRecordNumber: 772737
+      - Name: Coriobacteriia
+        ConceptType: Class
+        ConceptId: class/coriobacteriia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 4796
+        Children:
+        - Name: Coriobacteriales
+          ConceptType: Order
+          ConceptId: order/coriobacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5049
+          Children:
+          - Name: Atopobiaceae
+            ConceptType: Family
+            ConceptId: family/atopobiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1962
+            Children:
+            - Name: Atopobium
+              ConceptType: Genus
+              ConceptId: genus/atopobium
+              ConceptSource: LPSN
+              Id: 1858
+              LpsnRecordNumber: 515198
+              Children:
+              - Name: Atopobium fossor
+                ConceptType: Species
+                ConceptId: species/atopobium-fossor
+                ConceptSource: LPSN
+                Id: 2191
+                LpsnRecordNumber: 773537
+                Synonyms:
+                - Name: Eubacterium fossor
+                  ConceptId: species/eubacterium-fossor
+                  ConceptSource: LPSN
+                  Id: 271
+                  LpsnRecordNumber: 776084
+              - Name: Atopobium minutum
+                ConceptType: Species
+                ConceptId: species/atopobium-minutum
+                ConceptSource: LPSN
+                Id: 1742
+                LpsnRecordNumber: 773538
+                Synonyms:
+                - Name: Lactobacillus minutus
+                  ConceptId: species/lactobacillus-minutus
+                  ConceptSource: LPSN
+                  Id: 1983
+                  LpsnRecordNumber: 777349
+            - Name: Fannyhessea
+              ConceptType: Genus
+              ConceptId: genus/fannyhessea
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520431
+              Children:
+              - Name: Fannyhessea vaginae
+                ConceptType: Species
+                ConceptId: species/fannyhessea-vaginae
+                ConceptSource: LPSN
+                Id: 3233
+                LpsnRecordNumber: 798326
+                Synonyms:
+                - Name: Atopobium vaginae
+                  ConceptId: species/atopobium-vaginae
+                  ConceptSource: LPSN
+                  Id: 479
+                  LpsnRecordNumber: 773541
+            - Name: Lancefieldella
+              ConceptType: Genus
+              ConceptId: genus/lancefieldella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520436
+              Children:
+              - Name: Lancefieldella parvula
+                ConceptType: Species
+                ConceptId: species/lancefieldella-parvula
+                ConceptSource: LPSN
+                Id: 3011
+                LpsnRecordNumber: 798324
+                Carbapenems: true
+                Synonyms:
+                - Name: Atopobium parvulum
+                  ConceptId: species/atopobium-parvulum
+                  ConceptSource: LPSN
+                  Id: 1812
+                  LpsnRecordNumber: 773539
+                - Name: Peptostreptococcus parvulus
+                  ConceptId: species/peptostreptococcus-parvulus
+                  ConceptSource: LPSN
+                  Id: 2401
+                  LpsnRecordNumber: 779391
+                - Name: Streptococcus parvulus
+                  ConceptId: species/streptococcus-parvulus
+                  ConceptSource: LPSN
+                  Id: 26
+                  LpsnRecordNumber: 4075
+              - Name: Lancefieldella rimae
+                ConceptType: Species
+                ConceptId: species/lancefieldella-rimae
+                ConceptSource: LPSN
+                Id: 3154
+                LpsnRecordNumber: 798325
+                Carbapenems: true
+                Synonyms:
+                - Name: Atopobium rimae
+                  ConceptId: species/atopobium-rimae
+                  ConceptSource: LPSN
+                  Id: 1664
+                  LpsnRecordNumber: 773540
+                - Name: Lactobacillus rimae
+                  ConceptId: species/lactobacillus-rimae
+                  ConceptSource: LPSN
+                  Id: 356
+                  LpsnRecordNumber: 777384
+          - Name: Coriobacteriaceae
+            ConceptType: Family
+            ConceptId: family/coriobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 344
+            Children:
+            - Name: Collinsella
+              ConceptType: Genus
+              ConceptId: genus/collinsella
+              ConceptSource: LPSN
+              Id: 897
+              LpsnRecordNumber: 515399
+              Children:
+              - Name: Collinsella aerofaciens
+                ConceptType: Species
+                ConceptId: species/collinsella-aerofaciens
+                ConceptSource: LPSN
+                Id: 1460
+                LpsnRecordNumber: 775055
+                Synonyms:
+                - Name: Eubacterium aerofaciens
+                  ConceptId: species/eubacterium-aerofaciens
+                  ConceptSource: LPSN
+                  Id: 1327
+                  LpsnRecordNumber: 776065
+              - Name: Collinsella intestinalis
+                ConceptType: Species
+                ConceptId: species/collinsella-intestinalis
+                ConceptSource: LPSN
+                Id: 2164
+                LpsnRecordNumber: 775056
+              - Name: Collinsella stercoris
+                ConceptType: Species
+                ConceptId: species/collinsella-stercoris
+                ConceptSource: LPSN
+                Id: 2140
+                LpsnRecordNumber: 775057
+        - Name: Eggerthellales
+          ConceptType: Order
+          ConceptId: order/eggerthellales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5138
+          Children:
+          - Name: Eggerthellaceae
+            ConceptType: Family
+            ConceptId: family/eggerthellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1961
+            Children:
+            - Name: Cryptobacterium
+              ConceptType: Genus
+              ConceptId: genus/cryptobacterium
+              ConceptSource: LPSN
+              Id: 2016
+              LpsnRecordNumber: 515442
+              Children:
+              - Name: Cryptobacterium curtum
+                ConceptType: Species
+                ConceptId: species/cryptobacterium-curtum
+                ConceptSource: LPSN
+                Id: 1831
+                LpsnRecordNumber: 775287
+            - Name: Eggerthella
+              ConceptType: Genus
+              ConceptId: genus/eggerthella
+              ConceptSource: LPSN
+              Id: 2708
+              LpsnRecordNumber: 515567
+              Children:
+              - Name: Eggerthella lenta
+                ConceptType: Species
+                ConceptId: species/eggerthella-lenta
+                ConceptSource: LPSN
+                Id: 2709
+                LpsnRecordNumber: 775884
+                Synonyms:
+                - Name: Eubacterium lentum
+                  ConceptId: species/eubacterium-lentum
+                  ConceptSource: LPSN
+                  Id: 1433
+                  LpsnRecordNumber: 776087
+              - Name: Eggerthella sinensis
+                ConceptType: Species
+                ConceptId: species/eggerthella-sinensis
+                ConceptSource: LPSN
+                Id: 2710
+                LpsnRecordNumber: 785467
+            - Name: Slackia
+              ConceptType: Genus
+              ConceptId: genus/slackia
+              ConceptSource: LPSN
+              Id: 355
+              LpsnRecordNumber: 516610
+              Children:
+              - Name: Slackia exigua
+                ConceptType: Species
+                ConceptId: species/slackia-exigua
+                ConceptSource: LPSN
+                Id: 1564
+                LpsnRecordNumber: 780951
+                Synonyms:
+                - Name: Eubacterium exiguum
+                  ConceptId: species/eubacterium-exiguum
+                  ConceptSource: LPSN
+                  Id: 1300
+                  LpsnRecordNumber: 776081
+              - Name: Slackia heliotrinireducens
+                ConceptType: Species
+                ConceptId: species/slackia-heliotrinireducens
+                ConceptSource: LPSN
+                Id: 1598
+                LpsnRecordNumber: 780953
+      - Name: Thermoleophilia
+        ConceptType: Class
+        ConceptId: class/thermoleophilia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 102
+        Children:
+        - Name: Solirubrobacterales
+          ConceptType: Order
+          ConceptId: order/solirubrobacterales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5115
+          Children:
+          - Name: Patulibacteraceae
+            ConceptType: Family
+            ConceptId: family/patulibacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1606
+            Children:
+            - Name: Patulibacter
+              ConceptType: Genus
+              ConceptId: genus/patulibacter
+              ConceptSource: LPSN
+              Id: 1771
+              LpsnRecordNumber: 516268
+    - Name: Bacillota
+      ConceptType: Phylum
+      ConceptId: phylum/bacillota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 25911
+      Children:
+      - Name: Bacilli
+        ConceptType: Class
+        ConceptId: class/bacilli
+        ConceptSource: LPSN
+        LpsnRecordNumber: 4771
+        Children:
+        - Name: Caryophanales
+          ConceptType: Order
+          ConceptId: order/caryophanales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5013
+          Children:
+          - Name: Alicyclobacillaceae
+            ConceptType: Family
+            ConceptId: family/alicyclobacillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 84
+            Children:
+            - Name: Kyrpidia
+              ConceptType: Genus
+              ConceptId: genus/kyrpidia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518204
+              Children:
+              - Name: Kyrpidia tusciae
+                ConceptType: Species
+                ConceptId: species/kyrpidia-tusciae
+                ConceptSource: LPSN
+                Id: 3082
+                LpsnRecordNumber: 789884
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus tusciae
+                  ConceptId: species/bacillus-tusciae
+                  ConceptSource: LPSN
+                  Id: 1878
+                  LpsnRecordNumber: 773901
+          - Name: Bacillaceae
+            ConceptType: Family
+            ConceptId: family/bacillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 191
+            Children:
+            - Name: Alkalicoccobacillus
+              ConceptType: Genus
+              ConceptId: genus/alkalicoccobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 26517
+              Children:
+              - Name: Alkalicoccobacillus gibsonii
+                ConceptType: Species
+                ConceptId: species/alkalicoccobacillus-gibsonii
+                ConceptSource: LPSN
+                Id: 3550
+                LpsnRecordNumber: 40058
+                Synonyms:
+                - Name: Bacillus gibsonii
+                  ConceptId: species/bacillus-gibsonii
+                  ConceptSource: LPSN
+                  Id: 1372
+                  LpsnRecordNumber: 773714
+                - Name: Shouchella gibsonii
+                  ConceptId: species/shouchella-gibsonii
+                  ConceptSource: LPSN
+                  Id: 3041
+                  LpsnRecordNumber: 26620
+            - Name: Alkalicoccus
+              ConceptType: Genus
+              ConceptId: genus/alkalicoccus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 519169
+              Children:
+              - Name: Alkalicoccus saliphilus
+                ConceptType: Species
+                ConceptId: species/alkalicoccus-saliphilus
+                ConceptSource: LPSN
+                Id: 3258
+                LpsnRecordNumber: 795285
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus saliphilus
+                  ConceptId: species/bacillus-saliphilus
+                  ConceptSource: LPSN
+                  Id: 324
+                  LpsnRecordNumber: 773828
+            - Name: Alkalihalobacillus
+              ConceptType: Genus
+              ConceptId: genus/alkalihalobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4936
+              Children:
+              - Name: Alkalihalobacillus alcalophilus
+                ConceptType: Species
+                ConceptId: species/alkalihalobacillus-alcalophilus
+                ConceptSource: LPSN
+                Id: 2992
+                LpsnRecordNumber: 5933
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus alcalophilus
+                  ConceptId: species/bacillus-alcalophilus
+                  ConceptSource: LPSN
+                  Id: 722
+                  LpsnRecordNumber: 773625
+              - Name: Alkalihalobacillus algicola
+                ConceptType: Species
+                ConceptId: species/alkalihalobacillus-algicola
+                ConceptSource: LPSN
+                Id: 3093
+                LpsnRecordNumber: 7348
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus algicola
+                  ConceptId: species/bacillus-algicola
+                  ConceptSource: LPSN
+                  Id: 1621
+                  LpsnRecordNumber: 783415
+              - Name: Alkalihalobacillus macyae
+                ConceptType: Species
+                ConceptId: species/alkalihalobacillus-macyae
+                ConceptSource: LPSN
+                Id: 3046
+                LpsnRecordNumber: 7372
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus macyae
+                  ConceptId: species/bacillus-macyae
+                  ConceptSource: LPSN
+                  Id: 237
+                  LpsnRecordNumber: 773763
+              - Name: Alkalihalobacillus pseudalcaliphilus
+                ConceptType: Species
+                ConceptId: species/alkalihalobacillus-pseudalcaliphilus
+                ConceptSource: LPSN
+                Id: 2984
+                LpsnRecordNumber: 7385
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus pseudalcaliphilus
+                  ConceptId: species/bacillus-pseudalcaliphilus
+                  ConceptSource: LPSN
+                  Id: 27
+                  LpsnRecordNumber: 773810
+            - Name: Alkalihalophilus
+              ConceptType: Genus
+              ConceptId: genus/alkalihalophilus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 26521
+              Children:
+              - Name: Alkalihalophilus pseudofirmus
+                ConceptType: Species
+                ConceptId: species/alkalihalophilus-pseudofirmus
+                ConceptSource: LPSN
+                Id: 3230
+                LpsnRecordNumber: 26731
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus pseudofirmus
+                  ConceptId: species/bacillus-pseudofirmus
+                  ConceptSource: LPSN
+                  Id: 2537
+                  LpsnRecordNumber: 773811
+            - Name: Anaerobacillus
+              ConceptType: Genus
+              ConceptId: genus/anaerobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517973
+              Children:
+              - Name: Anaerobacillus arseniciselenatis
+                ConceptType: Species
+                ConceptId: species/anaerobacillus-arseniciselenatis
+                ConceptSource: LPSN
+                Id: 2982
+                LpsnRecordNumber: 788508
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus arseniciselenatis
+                  ConceptId: species/bacillus-arseniciselenatis
+                  ConceptSource: LPSN
+                  Id: 218
+                  LpsnRecordNumber: 773641
+            - Name: Bacillus
+              ConceptType: Genus
+              ConceptId: genus/bacillus
+              ConceptSource: LPSN
+              Id: 1256
+              LpsnRecordNumber: 515217
+              CommonCommensal: true
+              Children:
+              - Name: Bacillus cereus group
+                ConceptType: Group
+                ConceptId: 76
+                ConceptSource: NeoIPC
+                Id: 2935
+                Children:
+                - Name: Bacillus anthracis
+                  ConceptType: Species
+                  ConceptId: species/bacillus-anthracis
+                  ConceptSource: LPSN
+                  Id: 2032
+                  LpsnRecordNumber: 773635
+                - Name: Bacillus cereus
+                  ConceptType: Species
+                  ConceptId: species/bacillus-cereus
+                  ConceptSource: LPSN
+                  Id: 1202
+                  LpsnRecordNumber: 773670
+                  CommonCommensal: true
+                - Name: Bacillus cytotoxicus
+                  ConceptType: Species
+                  ConceptId: species/bacillus-cytotoxicus
+                  ConceptSource: LPSN
+                  Id: 2912
+                  LpsnRecordNumber: 790412
+                  CommonCommensal: true
+                - Name: Bacillus mycoides
+                  ConceptType: Species
+                  ConceptId: species/bacillus-mycoides
+                  ConceptSource: LPSN
+                  Id: 2506
+                  LpsnRecordNumber: 773780
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Bacillus weihenstephanensis
+                    ConceptId: species/bacillus-weihenstephanensis
+                    ConceptSource: LPSN
+                    Id: 1967
+                    LpsnRecordNumber: 773911
+                - Name: Bacillus pseudomycoides
+                  ConceptType: Species
+                  ConceptId: species/bacillus-pseudomycoides
+                  ConceptSource: LPSN
+                  Id: 2089
+                  LpsnRecordNumber: 773813
+                  CommonCommensal: true
+                - Name: Bacillus thuringiensis
+                  ConceptType: Species
+                  ConceptId: species/bacillus-thuringiensis
+                  ConceptSource: LPSN
+                  Id: 282
+                  LpsnRecordNumber: 773869
+                  CommonCommensal: true
+              - Name: Bacillus subtilis group
+                ConceptType: Group
+                ConceptId: 77
+                ConceptSource: NeoIPC
+                Id: 2938
+                Children:
+                - Name: Bacillus amyloliquefaciens
+                  ConceptType: Species
+                  ConceptId: species/bacillus-amyloliquefaciens
+                  ConceptSource: LPSN
+                  Id: 315
+                  LpsnRecordNumber: 773632
+                  CommonCommensal: true
+                - Name: Bacillus atrophaeus
+                  ConceptType: Species
+                  ConceptId: species/bacillus-atrophaeus
+                  ConceptSource: LPSN
+                  Id: 1796
+                  LpsnRecordNumber: 773644
+                  CommonCommensal: true
+                - Name: Bacillus mojavensis
+                  ConceptType: Species
+                  ConceptId: species/bacillus-mojavensis
+                  ConceptSource: LPSN
+                  Id: 672
+                  LpsnRecordNumber: 773776
+                  CommonCommensal: true
+                - Name: Bacillus pumilus
+                  ConceptType: Species
+                  ConceptId: species/bacillus-pumilus
+                  ConceptSource: LPSN
+                  Id: 2045
+                  LpsnRecordNumber: 773820
+                  CommonCommensal: true
+                - Name: Bacillus subtilis
+                  ConceptType: Species
+                  ConceptId: species/bacillus-subtilis
+                  ConceptSource: LPSN
+                  Id: 1364
+                  LpsnRecordNumber: 773846
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Bacillus subtilis subsp. subtilis
+                    ConceptId: subspecies/bacillus-subtilis-subtilis
+                    ConceptSource: LPSN
+                    Id: 1976
+                    LpsnRecordNumber: 773849
+                - Name: Bacillus tequilensis
+                  ConceptType: Species
+                  ConceptId: species/bacillus-tequilensis
+                  ConceptSource: LPSN
+                  Id: 851
+                  LpsnRecordNumber: 783435
+                  CommonCommensal: true
+                - Name: Bacillus vallismortis
+                  ConceptType: Species
+                  ConceptId: species/bacillus-vallismortis
+                  ConceptSource: LPSN
+                  Id: 854
+                  LpsnRecordNumber: 773903
+                  CommonCommensal: true
+              - Name: Bacillus aeolius
+                ConceptType: Species
+                ConceptId: species/bacillus-aeolius
+                ConceptSource: LPSN
+                Id: 2933
+                LpsnRecordNumber: 773619
+                CommonCommensal: true
+              - Name: Bacillus aerius
+                ConceptType: Species
+                ConceptId: species/bacillus-aerius
+                ConceptSource: LPSN
+                Id: 2934
+                LpsnRecordNumber: 783412
+                CommonCommensal: true
+              - Name: Bacillus benzoevorans
+                ConceptType: Species
+                ConceptId: species/bacillus-benzoevorans
+                ConceptSource: LPSN
+                Id: 2241
+                LpsnRecordNumber: 773651
+                CommonCommensal: true
+              - Name: Bacillus carboniphilus
+                ConceptType: Species
+                ConceptId: species/bacillus-carboniphilus
+                ConceptSource: LPSN
+                Id: 1403
+                LpsnRecordNumber: 773665
+                CommonCommensal: true
+              - Name: Bacillus circulans
+                ConceptType: Species
+                ConceptId: species/bacillus-circulans
+                ConceptSource: LPSN
+                Id: 2034
+                LpsnRecordNumber: 773676
+                CommonCommensal: true
+                Synonyms:
+                - Name: Niallia circulans
+                  ConceptId: species/niallia-circulans
+                  ConceptSource: LPSN
+                  Id: 3288
+                  LpsnRecordNumber: 14716
+              - Name: Bacillus coagulans
+                ConceptType: Species
+                ConceptId: species/bacillus-coagulans
+                ConceptSource: LPSN
+                Id: 2228
+                LpsnRecordNumber: 773679
+                CommonCommensal: true
+                Synonyms:
+                - Name: Weizmannia coagulans
+                  ConceptId: species/weizmannia-coagulans
+                  ConceptSource: LPSN
+                  Id: 3159
+                  LpsnRecordNumber: 14726
+              - Name: Bacillus decisifrondis
+                ConceptType: Species
+                ConceptId: species/bacillus-decisifrondis
+                ConceptSource: LPSN
+                Id: 130
+                LpsnRecordNumber: 786251
+                CommonCommensal: true
+              - Name: Bacillus horti
+                ConceptType: Species
+                ConceptId: species/bacillus-horti
+                ConceptSource: LPSN
+                Id: 1581
+                LpsnRecordNumber: 773733
+                CommonCommensal: true
+              - Name: Bacillus inaquosorum
+                ConceptType: Species
+                ConceptId: species/bacillus-inaquosorum
+                ConceptSource: LPSN
+                Id: 3329
+                LpsnRecordNumber: 7855
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus subtilis subsp. inaquosorum
+                  ConceptId: subspecies/bacillus-subtilis-inaquosorum
+                  ConceptSource: LPSN
+                  Id: 242
+                  LpsnRecordNumber: 788115
+              - Name: Bacillus infantis
+                ConceptType: Species
+                ConceptId: species/bacillus-infantis
+                ConceptSource: LPSN
+                Id: 1962
+                LpsnRecordNumber: 785644
+                CommonCommensal: true
+              - Name: Bacillus infernus
+                ConceptType: Species
+                ConceptId: species/bacillus-infernus
+                ConceptSource: LPSN
+                Id: 2306
+                LpsnRecordNumber: 773737
+                CommonCommensal: true
+              - Name: Bacillus licheniformis
+                ConceptType: Species
+                ConceptId: species/bacillus-licheniformis
+                ConceptSource: LPSN
+                Id: 1406
+                LpsnRecordNumber: 773752
+                CommonCommensal: true
+              - Name: Bacillus methanolicus
+                ConceptType: Species
+                ConceptId: species/bacillus-methanolicus
+                ConceptSource: LPSN
+                Id: 1038
+                LpsnRecordNumber: 773774
+                CommonCommensal: true
+              - Name: Bacillus nealsonii
+                ConceptType: Species
+                ConceptId: species/bacillus-nealsonii
+                ConceptSource: LPSN
+                Id: 1102
+                LpsnRecordNumber: 773784
+                CommonCommensal: true
+                Synonyms:
+                - Name: Niallia nealsonii
+                  ConceptId: species/niallia-nealsonii
+                  ConceptSource: LPSN
+                  Id: 3131
+                  LpsnRecordNumber: 14773
+              - Name: Bacillus smithii
+                ConceptType: Species
+                ConceptId: species/bacillus-smithii
+                ConceptSource: LPSN
+                Id: 1941
+                LpsnRecordNumber: 773836
+                CommonCommensal: true
+              - Name: Bacillus sonorensis
+                ConceptType: Species
+                ConceptId: species/bacillus-sonorensis
+                ConceptSource: LPSN
+                Id: 2560
+                LpsnRecordNumber: 773839
+                CommonCommensal: true
+              - Name: Bacillus spizizenii
+                ConceptType: Species
+                ConceptId: species/bacillus-spizizenii
+                ConceptSource: LPSN
+                Id: 3213
+                LpsnRecordNumber: 7856
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus subtilis subsp. spizizenii
+                  ConceptId: subspecies/bacillus-subtilis-spizizenii
+                  ConceptSource: LPSN
+                  Id: 2173
+                  LpsnRecordNumber: 773848
+              - Name: Bacillus thermoamylovorans
+                ConceptType: Species
+                ConceptId: species/bacillus-thermoamylovorans
+                ConceptSource: LPSN
+                Id: 2525
+                LpsnRecordNumber: 773857
+                CommonCommensal: true
+              - Name: Bacillus thermocloacae
+                ConceptType: Species
+                ConceptId: species/bacillus-thermocloacae
+                ConceptSource: LPSN
+                Id: 794
+                LpsnRecordNumber: 773859
+                CommonCommensal: true
+              - Name: Bacillus velezensis
+                ConceptType: Species
+                ConceptId: species/bacillus-velezensis
+                ConceptSource: LPSN
+                Id: 659
+                LpsnRecordNumber: 783437
+                CommonCommensal: true
+            - Name: Ectobacillus
+              ConceptType: Genus
+              ConceptId: genus/ectobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14506
+              Children:
+              - Name: Ectobacillus funiculus
+                ConceptType: Species
+                ConceptId: species/ectobacillus-funiculus
+                ConceptSource: LPSN
+                Id: 3214
+                LpsnRecordNumber: 14748
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus funiculus
+                  ConceptId: species/bacillus-funiculus
+                  ConceptSource: LPSN
+                  Id: 1407
+                  LpsnRecordNumber: 773710
+            - Name: Evansella
+              ConceptType: Genus
+              ConceptId: genus/evansella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14509
+              Children:
+              - Name: Evansella clarkii
+                ConceptType: Species
+                ConceptId: species/evansella-clarkii
+                ConceptSource: LPSN
+                Id: 3300
+                LpsnRecordNumber: 14750
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus clarkii
+                  ConceptId: species/bacillus-clarkii
+                  ConceptSource: LPSN
+                  Id: 2500
+                  LpsnRecordNumber: 773677
+              - Name: Evansella vedderi
+                ConceptType: Species
+                ConceptId: species/evansella-vedderi
+                ConceptSource: LPSN
+                Id: 3314
+                LpsnRecordNumber: 14752
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus vedderi
+                  ConceptId: species/bacillus-vedderi
+                  ConceptSource: LPSN
+                  Id: 1469
+                  LpsnRecordNumber: 773904
+            - Name: Exiguobacterium
+              ConceptType: Genus
+              ConceptId: genus/exiguobacterium
+              ConceptSource: LPSN
+              Id: 1151
+              LpsnRecordNumber: 515610
+              CommonCommensal: true
+              Children:
+              - Name: Exiguobacterium acetylicum
+                ConceptType: Species
+                ConceptId: species/exiguobacterium-acetylicum
+                ConceptSource: LPSN
+                Id: 753
+                LpsnRecordNumber: 776137
+                CommonCommensal: true
+            - Name: Falsibacillus
+              ConceptType: Genus
+              ConceptId: genus/falsibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517929
+              Children:
+              - Name: Falsibacillus pallidus
+                ConceptType: Species
+                ConceptId: species/falsibacillus-pallidus
+                ConceptSource: LPSN
+                Id: 2936
+                LpsnRecordNumber: 788283
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus pallidus
+                  ConceptId: species/bacillus-pallidus
+                  ConceptSource: LPSN
+                  Id: 2937
+                  LpsnRecordNumber: 773796
+            - Name: Ferdinandcohnia
+              ConceptType: Genus
+              ConceptId: genus/ferdinandcohnia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14510
+              Children:
+              - Name: Ferdinandcohnia humi
+                ConceptType: Species
+                ConceptId: species/ferdinandcohnia-humi
+                ConceptSource: LPSN
+                Id: 3215
+                LpsnRecordNumber: 14584
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus humi
+                  ConceptId: species/bacillus-humi
+                  ConceptSource: LPSN
+                  Id: 2499
+                  LpsnRecordNumber: 773734
+            - Name: Fictibacillus
+              ConceptType: Genus
+              ConceptId: genus/fictibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518400
+              Children:
+              - Name: Fictibacillus barbaricus
+                ConceptType: Species
+                ConceptId: species/fictibacillus-barbaricus
+                ConceptSource: LPSN
+                Id: 3304
+                LpsnRecordNumber: 791001
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus barbaricus
+                  ConceptId: species/bacillus-barbaricus
+                  ConceptSource: LPSN
+                  Id: 603
+                  LpsnRecordNumber: 773648
+              - Name: Fictibacillus gelatini
+                ConceptType: Species
+                ConceptId: species/fictibacillus-gelatini
+                ConceptSource: LPSN
+                Id: 3195
+                LpsnRecordNumber: 791007
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus gelatini
+                  ConceptId: species/bacillus-gelatini
+                  ConceptSource: LPSN
+                  Id: 1491
+                  LpsnRecordNumber: 773713
+            - Name: Geobacillus
+              ConceptType: Genus
+              ConceptId: genus/geobacillus
+              ConceptSource: LPSN
+              Id: 1710
+              LpsnRecordNumber: 517040
+              Children:
+              - Name: Geobacillus kaustophilus
+                ConceptType: Species
+                ConceptId: species/geobacillus-kaustophilus
+                ConceptSource: LPSN
+                Id: 3033
+                LpsnRecordNumber: 776445
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus kaustophilus
+                  ConceptId: species/bacillus-kaustophilus
+                  ConceptSource: LPSN
+                  Id: 2121
+                  LpsnRecordNumber: 773741
+              - Name: Geobacillus stearothermophilus
+                ConceptType: Species
+                ConceptId: species/geobacillus-stearothermophilus
+                ConceptSource: LPSN
+                Id: 583
+                LpsnRecordNumber: 776449
+              - Name: Geobacillus thermocatenulatus
+                ConceptType: Species
+                ConceptId: species/geobacillus-thermocatenulatus
+                ConceptSource: LPSN
+                Id: 3023
+                LpsnRecordNumber: 776453
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus thermocatenulatus
+                  ConceptId: species/bacillus-thermocatenulatus
+                  ConceptSource: LPSN
+                  Id: 715
+                  LpsnRecordNumber: 773858
+              - Name: Geobacillus thermodenitrificans
+                ConceptType: Species
+                ConceptId: species/geobacillus-thermodenitrificans
+                ConceptSource: LPSN
+                Id: 929
+                LpsnRecordNumber: 776454
+                Synonyms:
+                - Name: Bacillus thermodenitrificans
+                  ConceptId: species/bacillus-thermodenitrificans
+                  ConceptSource: LPSN
+                  Id: 577
+                  LpsnRecordNumber: 773860
+            - Name: Gottfriedia
+              ConceptType: Genus
+              ConceptId: genus/gottfriedia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14511
+              Children:
+              - Name: Gottfriedia luciferensis
+                ConceptType: Species
+                ConceptId: species/gottfriedia-luciferensis
+                ConceptSource: LPSN
+                Id: 3074
+                LpsnRecordNumber: 14722
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus luciferensis
+                  ConceptId: species/bacillus-luciferensis
+                  ConceptSource: LPSN
+                  Id: 121
+                  LpsnRecordNumber: 783425
+            - Name: Gracilibacillus
+              ConceptType: Genus
+              ConceptId: genus/gracilibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517043
+              Children:
+              - Name: Gracilibacillus dipsosauri
+                ConceptType: Species
+                ConceptId: species/gracilibacillus-dipsosauri
+                ConceptSource: LPSN
+                Id: 3185
+                LpsnRecordNumber: 776606
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus dipsosauri
+                  ConceptId: species/bacillus-dipsosauri
+                  ConceptSource: LPSN
+                  Id: 2543
+                  LpsnRecordNumber: 773689
+            - Name: Halalkalibacter
+              ConceptType: Genus
+              ConceptId: genus/halalkalibacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 26522
+              Children:
+              - Name: Halalkalibacter krulwichiae
+                ConceptType: Species
+                ConceptId: species/halalkalibacter-krulwichiae
+                ConceptSource: LPSN
+                Id: 3262
+                LpsnRecordNumber: 26622
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus krulwichiae
+                  ConceptId: species/bacillus-krulwichiae
+                  ConceptSource: LPSN
+                  Id: 111
+                  LpsnRecordNumber: 773744
+            - Name: Halalkalibacterium
+              ConceptType: Genus
+              ConceptId: genus/halalkalibacterium
+              ConceptSource: LPSN
+              LpsnRecordNumber: 26523
+              Children:
+              - Name: Halalkalibacterium halodurans
+                ConceptType: Species
+                ConceptId: species/halalkalibacterium-halodurans
+                ConceptSource: LPSN
+                Id: 3077
+                LpsnRecordNumber: 26732
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus halodurans
+                  ConceptId: species/bacillus-halodurans
+                  ConceptSource: LPSN
+                  Id: 2463
+                  LpsnRecordNumber: 773725
+                - Name: Bacillus okuhidensis
+                  ConceptId: species/bacillus-okuhidensis
+                  ConceptSource: LPSN
+                  Id: 637
+                  LpsnRecordNumber: 773791
+            - Name: Heyndrickxia
+              ConceptType: Genus
+              ConceptId: genus/heyndrickxia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14512
+              Children:
+              - Name: Heyndrickxia oleronia
+                ConceptType: Species
+                ConceptId: species/heyndrickxia-oleronia
+                ConceptSource: LPSN
+                Id: 3010
+                LpsnRecordNumber: 14756
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus oleronius
+                  ConceptId: species/bacillus-oleronius
+                  ConceptSource: LPSN
+                  Id: 1838
+                  LpsnRecordNumber: 773792
+              - Name: Heyndrickxia shackletonii
+                ConceptType: Species
+                ConceptId: species/heyndrickxia-shackletonii
+                ConceptSource: LPSN
+                Id: 3528
+                LpsnRecordNumber: 39738
+                Synonyms:
+                - Name: Bacillus shackletonii
+                  ConceptId: species/bacillus-shackletonii
+                  ConceptSource: LPSN
+                  Id: 1118
+                  LpsnRecordNumber: 783433
+                - Name: Margalitia shackletonii
+                  ConceptId: species/margalitia-shackletonii
+                  ConceptSource: LPSN
+                  Id: 3320
+                  LpsnRecordNumber: 14727
+              - Name: Heyndrickxia sporothermodurans
+                ConceptType: Species
+                ConceptId: species/heyndrickxia-sporothermodurans
+                ConceptSource: LPSN
+                Id: 3106
+                LpsnRecordNumber: 14757
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus sporothermodurans
+                  ConceptId: species/bacillus-sporothermodurans
+                  ConceptSource: LPSN
+                  Id: 1097
+                  LpsnRecordNumber: 773843
+            - Name: Lederbergia
+              ConceptType: Genus
+              ConceptId: genus/lederbergia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14513
+              Children:
+              - Name: Lederbergia galactosidilytica
+                ConceptType: Species
+                ConceptId: species/lederbergia-galactosidilytica
+                ConceptSource: LPSN
+                Id: 3282
+                LpsnRecordNumber: 18331
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus galactosidilyticus
+                  ConceptId: species/bacillus-galactosidilyticus
+                  ConceptSource: LPSN
+                  Id: 866
+                  LpsnRecordNumber: 773712
+              - Name: Lederbergia lenta
+                ConceptType: Species
+                ConceptId: species/lederbergia-lenta
+                ConceptSource: LPSN
+                Id: 3125
+                LpsnRecordNumber: 18332
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus lentus
+                  ConceptId: species/bacillus-lentus
+                  ConceptSource: LPSN
+                  Id: 736
+                  LpsnRecordNumber: 773751
+            - Name: Metabacillus
+              ConceptType: Genus
+              ConceptId: genus/metabacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4943
+              Children:
+              - Name: Metabacillus fastidiosus
+                ConceptType: Species
+                ConceptId: species/metabacillus-fastidiosus
+                ConceptSource: LPSN
+                Id: 3265
+                LpsnRecordNumber: 5934
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus fastidiosus
+                  ConceptId: species/bacillus-fastidiosus
+                  ConceptSource: LPSN
+                  Id: 39
+                  LpsnRecordNumber: 773697
+              - Name: Metabacillus idriensis
+                ConceptType: Species
+                ConceptId: species/metabacillus-idriensis
+                ConceptSource: LPSN
+                Id: 3121
+                LpsnRecordNumber: 14769
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus idriensis
+                  ConceptId: species/bacillus-idriensis
+                  ConceptSource: LPSN
+                  Id: 240
+                  LpsnRecordNumber: 785645
+              - Name: Metabacillus indicus
+                ConceptType: Species
+                ConceptId: species/metabacillus-indicus
+                ConceptSource: LPSN
+                Id: 3150
+                LpsnRecordNumber: 7367
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus indicus
+                  ConceptId: species/bacillus-indicus
+                  ConceptSource: LPSN
+                  Id: 612
+                  LpsnRecordNumber: 773736
+            - Name: Parageobacillus
+              ConceptType: Genus
+              ConceptId: genus/parageobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520462
+              Children:
+              - Name: Parageobacillus thermantarcticus
+                ConceptType: Species
+                ConceptId: species/parageobacillus-thermantarcticus
+                ConceptSource: LPSN
+                Id: 3029
+                LpsnRecordNumber: 798340
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus thermantarcticus
+                  ConceptId: species/bacillus-thermantarcticus
+                  ConceptSource: LPSN
+                  Id: 2298
+                  LpsnRecordNumber: 773852
+              - Name: Parageobacillus thermoglucosidasius
+                ConceptType: Species
+                ConceptId: species/parageobacillus-thermoglucosidasius
+                ConceptSource: LPSN
+                Id: 3174
+                LpsnRecordNumber: 798342
+                Synonyms:
+                - Name: Bacillus thermoglucosidasius
+                  ConceptId: species/bacillus-thermoglucosidasius
+                  ConceptSource: LPSN
+                  Id: 2437
+                  LpsnRecordNumber: 773861
+                - Name: Geobacillus thermoglucosidasius
+                  ConceptId: species/geobacillus-thermoglucosidasius
+                  ConceptSource: LPSN
+                  Id: 1997
+                  LpsnRecordNumber: 776455
+            - Name: Peribacillus
+              ConceptType: Genus
+              ConceptId: genus/peribacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4946
+              Children:
+              - Name: Peribacillus asahii
+                ConceptType: Species
+                ConceptId: species/peribacillus-asahii
+                ConceptSource: LPSN
+                Id: 3296
+                LpsnRecordNumber: 7351
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus asahii
+                  ConceptId: species/bacillus-asahii
+                  ConceptSource: LPSN
+                  Id: 634
+                  LpsnRecordNumber: 783420
+              - Name: Peribacillus butanolivorans
+                ConceptType: Species
+                ConceptId: species/peribacillus-butanolivorans
+                ConceptSource: LPSN
+                Id: 2981
+                LpsnRecordNumber: 7355
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus butanolivorans
+                  ConceptId: species/bacillus-butanolivorans
+                  ConceptSource: LPSN
+                  Id: 482
+                  LpsnRecordNumber: 785894
+              - Name: Peribacillus muralis
+                ConceptType: Species
+                ConceptId: species/peribacillus-muralis
+                ConceptSource: LPSN
+                Id: 3302
+                LpsnRecordNumber: 7374
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus muralis
+                  ConceptId: species/bacillus-muralis
+                  ConceptSource: LPSN
+                  Id: 2275
+                  LpsnRecordNumber: 773778
+              - Name: Peribacillus psychrosaccharolyticus
+                ConceptType: Species
+                ConceptId: species/peribacillus-psychrosaccharolyticus
+                ConceptSource: LPSN
+                Id: 3252
+                LpsnRecordNumber: 7387
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus psychrosaccharolyticus
+                  ConceptId: species/bacillus-psychrosaccharolyticus
+                  ConceptSource: LPSN
+                  Id: 2481
+                  LpsnRecordNumber: 773816
+              - Name: Peribacillus simplex
+                ConceptType: Species
+                ConceptId: species/peribacillus-simplex
+                ConceptSource: LPSN
+                Id: 3060
+                LpsnRecordNumber: 5938
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus simplex
+                  ConceptId: species/bacillus-simplex
+                  ConceptSource: LPSN
+                  Id: 1920
+                  LpsnRecordNumber: 773834
+            - Name: Priestia
+              ConceptType: Genus
+              ConceptId: genus/priestia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14526
+              Children:
+              - Name: Priestia endophytica
+                ConceptType: Species
+                ConceptId: species/priestia-endophytica
+                ConceptSource: LPSN
+                Id: 3271
+                LpsnRecordNumber: 14827
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus endophyticus
+                  ConceptId: species/bacillus-endophyticus
+                  ConceptSource: LPSN
+                  Id: 273
+                  LpsnRecordNumber: 773694
+              - Name: Priestia flexa
+                ConceptType: Species
+                ConceptId: species/priestia-flexa
+                ConceptSource: LPSN
+                Id: 3177
+                LpsnRecordNumber: 14828
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus flexus
+                  ConceptId: species/bacillus-flexus
+                  ConceptSource: LPSN
+                  Id: 1550
+                  LpsnRecordNumber: 773703
+              - Name: Priestia megaterium
+                ConceptType: Species
+                ConceptId: species/priestia-megaterium
+                ConceptSource: LPSN
+                Id: 3226
+                LpsnRecordNumber: 14830
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus megaterium
+                  ConceptId: species/bacillus-megaterium
+                  ConceptSource: LPSN
+                  Id: 1785
+                  LpsnRecordNumber: 773771
+            - Name: Pseudalkalibacillus
+              ConceptType: Genus
+              ConceptId: genus/pseudalkalibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 26525
+              Children:
+              - Name: Pseudalkalibacillus decolorationis
+                ConceptType: Species
+                ConceptId: species/pseudalkalibacillus-decolorationis
+                ConceptSource: LPSN
+                Id: 3183
+                LpsnRecordNumber: 26619
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus decolorationis
+                  ConceptId: species/bacillus-decolorationis
+                  ConceptSource: LPSN
+                  Id: 623
+                  LpsnRecordNumber: 773687
+              - Name: Pseudalkalibacillus hwajinpoensis
+                ConceptType: Species
+                ConceptId: species/pseudalkalibacillus-hwajinpoensis
+                ConceptSource: LPSN
+                Id: 3008
+                LpsnRecordNumber: 26621
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus hwajinpoensis
+                  ConceptId: species/bacillus-hwajinpoensis
+                  ConceptSource: LPSN
+                  Id: 2199
+                  LpsnRecordNumber: 773735
+            - Name: Pseudobacillus
+              ConceptType: Genus
+              ConceptId: genus/pseudobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 55691
+              Children:
+              - Name: Pseudobacillus badius
+                ConceptType: Species
+                ConceptId: species/pseudobacillus-badius
+                ConceptSource: LPSN
+                Id: 3481
+                LpsnRecordNumber: 55701
+                Synonyms:
+                - Name: Bacillus badius
+                  ConceptId: species/bacillus-badius
+                  ConceptSource: LPSN
+                  Id: 1617
+                  LpsnRecordNumber: 773647
+            - Name: Rossellomorea
+              ConceptType: Genus
+              ConceptId: genus/rossellomorea
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14531
+              Children:
+              - Name: Rossellomorea aquimaris
+                ConceptType: Species
+                ConceptId: species/rossellomorea-aquimaris
+                ConceptSource: LPSN
+                Id: 3217
+                LpsnRecordNumber: 14785
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus aquimaris
+                  ConceptId: species/bacillus-aquimaris
+                  ConceptSource: LPSN
+                  Id: 2329
+                  LpsnRecordNumber: 773638
+              - Name: Rossellomorea marisflavi
+                ConceptType: Species
+                ConceptId: species/rossellomorea-marisflavi
+                ConceptSource: LPSN
+                Id: 3216
+                LpsnRecordNumber: 14787
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus marisflavi
+                  ConceptId: species/bacillus-marisflavi
+                  ConceptSource: LPSN
+                  Id: 1596
+                  LpsnRecordNumber: 773767
+              - Name: Rossellomorea vietnamensis
+                ConceptType: Species
+                ConceptId: species/rossellomorea-vietnamensis
+                ConceptSource: LPSN
+                Id: 3307
+                LpsnRecordNumber: 14789
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus vietnamensis
+                  ConceptId: species/bacillus-vietnamensis
+                  ConceptSource: LPSN
+                  Id: 1994
+                  LpsnRecordNumber: 783438
+            - Name: Salipaludibacillus
+              ConceptType: Genus
+              ConceptId: genus/salipaludibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518978
+              Children:
+              - Name: Salipaludibacillus agaradhaerens
+                ConceptType: Species
+                ConceptId: species/salipaludibacillus-agaradhaerens
+                ConceptSource: LPSN
+                Id: 3085
+                LpsnRecordNumber: 794302
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus agaradhaerens
+                  ConceptId: species/bacillus-agaradhaerens
+                  ConceptSource: LPSN
+                  Id: 278
+                  LpsnRecordNumber: 773621
+            - Name: Salisediminibacterium
+              ConceptType: Genus
+              ConceptId: genus/salisediminibacterium
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518244
+              Children:
+              - Name: Salisediminibacterium selenitireducens
+                ConceptType: Species
+                ConceptId: species/salisediminibacterium-selenitireducens
+                ConceptSource: LPSN
+                Id: 2980
+                LpsnRecordNumber: 14836
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus selenitireducens
+                  ConceptId: species/bacillus-selenitireducens
+                  ConceptSource: LPSN
+                  Id: 1437
+                  LpsnRecordNumber: 773830
+            - Name: Schinkia
+              ConceptType: Genus
+              ConceptId: genus/schinkia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14533
+              Children:
+              - Name: Schinkia azotoformans
+                ConceptType: Species
+                ConceptId: species/schinkia-azotoformans
+                ConceptSource: LPSN
+                Id: 3122
+                LpsnRecordNumber: 14724
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus azotoformans
+                  ConceptId: species/bacillus-azotoformans
+                  ConceptSource: LPSN
+                  Id: 1000
+                  LpsnRecordNumber: 773646
+            - Name: Shouchella
+              ConceptType: Genus
+              ConceptId: genus/shouchella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 26527
+              Children:
+              - Name: Shouchella clausii
+                ConceptType: Species
+                ConceptId: species/shouchella-clausii
+                ConceptSource: LPSN
+                Id: 3134
+                LpsnRecordNumber: 26618
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus clausii
+                  ConceptId: species/bacillus-clausii
+                  ConceptSource: LPSN
+                  Id: 789
+                  LpsnRecordNumber: 773678
+              - Name: Shouchella patagoniensis
+                ConceptType: Species
+                ConceptId: species/shouchella-patagoniensis
+                ConceptSource: LPSN
+                Id: 3165
+                LpsnRecordNumber: 26628
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus patagoniensis
+                  ConceptId: species/bacillus-patagoniensis
+                  ConceptSource: LPSN
+                  Id: 2315
+                  LpsnRecordNumber: 773803
+            - Name: Siminovitchia
+              ConceptType: Genus
+              ConceptId: genus/siminovitchia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14535
+              Children:
+              - Name: Siminovitchia farraginis
+                ConceptType: Species
+                ConceptId: species/siminovitchia-farraginis
+                ConceptSource: LPSN
+                Id: 3256
+                LpsnRecordNumber: 14794
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus farraginis
+                  ConceptId: species/bacillus-farraginis
+                  ConceptSource: LPSN
+                  Id: 969
+                  LpsnRecordNumber: 773696
+              - Name: Siminovitchia fordii
+                ConceptType: Species
+                ConceptId: species/siminovitchia-fordii
+                ConceptSource: LPSN
+                Id: 3295
+                LpsnRecordNumber: 14723
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus fordii
+                  ConceptId: species/bacillus-fordii
+                  ConceptSource: LPSN
+                  Id: 971
+                  LpsnRecordNumber: 773704
+              - Name: Siminovitchia fortis
+                ConceptType: Species
+                ConceptId: species/siminovitchia-fortis
+                ConceptSource: LPSN
+                Id: 3004
+                LpsnRecordNumber: 14838
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus fortis
+                  ConceptId: species/bacillus-fortis
+                  ConceptSource: LPSN
+                  Id: 1939
+                  LpsnRecordNumber: 773706
+            - Name: Sutcliffiella
+              ConceptType: Genus
+              ConceptId: genus/sutcliffiella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14537
+              Children:
+              - Name: Sutcliffiella cohnii
+                ConceptType: Species
+                ConceptId: species/sutcliffiella-cohnii
+                ConceptSource: LPSN
+                Id: 3140
+                LpsnRecordNumber: 14719
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus cohnii
+                  ConceptId: species/bacillus-cohnii
+                  ConceptSource: LPSN
+                  Id: 845
+                  LpsnRecordNumber: 773681
+              - Name: Sutcliffiella halmapala
+                ConceptType: Species
+                ConceptId: species/sutcliffiella-halmapala
+                ConceptSource: LPSN
+                Id: 3220
+                LpsnRecordNumber: 14803
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus halmapalus
+                  ConceptId: species/bacillus-halmapalus
+                  ConceptSource: LPSN
+                  Id: 448
+                  LpsnRecordNumber: 773722
+              - Name: Sutcliffiella horikoshii
+                ConceptType: Species
+                ConceptId: species/sutcliffiella-horikoshii
+                ConceptSource: LPSN
+                Id: 3196
+                LpsnRecordNumber: 14840
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus horikoshii
+                  ConceptId: species/bacillus-horikoshii
+                  ConceptSource: LPSN
+                  Id: 2064
+                  LpsnRecordNumber: 773732
+            - Name: Virgibacillus
+              ConceptType: Genus
+              ConceptId: genus/virgibacillus
+              ConceptSource: LPSN
+              Id: 521
+              LpsnRecordNumber: 517158
+              CommonCommensal: true
+              Children:
+              - Name: Virgibacillus halodenitrificans
+                ConceptType: Species
+                ConceptId: species/virgibacillus-halodenitrificans
+                ConceptSource: LPSN
+                Id: 3000
+                LpsnRecordNumber: 783041
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus halodenitrificans
+                  ConceptId: species/bacillus-halodenitrificans
+                  ConceptSource: LPSN
+                  Id: 2011
+                  LpsnRecordNumber: 773724
+              - Name: Virgibacillus pantothenticus
+                ConceptType: Species
+                ConceptId: species/virgibacillus-pantothenticus
+                ConceptSource: LPSN
+                Id: 2585
+                LpsnRecordNumber: 783048
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus pantothenticus
+                  ConceptId: species/bacillus-pantothenticus
+                  ConceptSource: LPSN
+                  Id: 599
+                  LpsnRecordNumber: 773799
+              - Name: Virgibacillus salexigens
+                ConceptType: Species
+                ConceptId: species/virgibacillus-salexigens
+                ConceptSource: LPSN
+                Id: 3096
+                LpsnRecordNumber: 783052
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus salexigens
+                  ConceptId: species/bacillus-salexigens
+                  ConceptSource: LPSN
+                  Id: 864
+                  LpsnRecordNumber: 773827
+          - Name: Caryophanaceae
+            ConceptType: Family
+            ConceptId: family/caryophanaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 281
+            Children:
+            - Name: Bhargavaea
+              ConceptType: Genus
+              ConceptId: genus/bhargavaea
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517903
+              Children:
+              - Name: Bhargavaea ginsengi
+                ConceptType: Species
+                ConceptId: species/bhargavaea-ginsengi
+                ConceptSource: LPSN
+                Id: 3171
+                LpsnRecordNumber: 790216
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus ginsengi
+                  ConceptId: species/bacillus-ginsengi
+                  ConceptSource: LPSN
+                  Id: 2377
+                  LpsnRecordNumber: 785995
+            - Name: Jeotgalibacillus
+              ConceptType: Genus
+              ConceptId: genus/jeotgalibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517255
+              Children:
+              - Name: Jeotgalibacillus marinus
+                ConceptType: Species
+                ConceptId: species/jeotgalibacillus-marinus
+                ConceptSource: LPSN
+                Id: 3137
+                LpsnRecordNumber: 788329
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus marinus
+                  ConceptId: species/bacillus-marinus
+                  ConceptSource: LPSN
+                  Id: 185
+                  LpsnRecordNumber: 773766
+            - Name: Kurthia
+              ConceptType: Genus
+              ConceptId: genus/kurthia
+              ConceptSource: LPSN
+              Id: 1090
+              LpsnRecordNumber: 515903
+            - Name: Lysinibacillus
+              ConceptType: Genus
+              ConceptId: genus/lysinibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517559
+              Children:
+              - Name: Lysinibacillus odysseyi
+                ConceptType: Species
+                ConceptId: species/lysinibacillus-odysseyi
+                ConceptSource: LPSN
+                Id: 3091
+                LpsnRecordNumber: 790233
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus odysseyi
+                  ConceptId: species/bacillus-odysseyi
+                  ConceptSource: LPSN
+                  Id: 1623
+                  LpsnRecordNumber: 783428
+              - Name: Lysinibacillus sphaericus
+                ConceptType: Species
+                ConceptId: species/lysinibacillus-sphaericus
+                ConceptSource: LPSN
+                Id: 2913
+                LpsnRecordNumber: 786260
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus sphaericus
+                  ConceptId: species/bacillus-sphaericus
+                  ConceptSource: LPSN
+                  Id: 2914
+                  LpsnRecordNumber: 786263
+            - Name: Psychrobacillus
+              ConceptType: Genus
+              ConceptId: genus/psychrobacillus
+              ConceptSource: LPSN
+              Id: 51
+              LpsnRecordNumber: 518073
+            - Name: Rummeliibacillus
+              ConceptType: Genus
+              ConceptId: genus/rummeliibacillus
+              ConceptSource: LPSN
+              Id: 2190
+              LpsnRecordNumber: 517868
+              CommonCommensal: true
+              Children:
+              - Name: Rummeliibacillus pycnus
+                ConceptType: Species
+                ConceptId: species/rummeliibacillus-pycnus
+                ConceptSource: LPSN
+                Id: 486
+                LpsnRecordNumber: 787881
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus pycnus
+                  ConceptId: species/bacillus-pycnus
+                  ConceptSource: LPSN
+                  Id: 1549
+                  LpsnRecordNumber: 773822
+            - Name: Solibacillus
+              ConceptType: Genus
+              ConceptId: genus/solibacillus
+              ConceptSource: LPSN
+              Id: 520
+              LpsnRecordNumber: 517867
+              CommonCommensal: true
+              Children:
+              - Name: Solibacillus silvestris
+                ConceptType: Species
+                ConceptId: species/solibacillus-silvestris
+                ConceptSource: LPSN
+                Id: 1913
+                LpsnRecordNumber: 787879
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus silvestris
+                  ConceptId: species/bacillus-silvestris
+                  ConceptSource: LPSN
+                  Id: 357
+                  LpsnRecordNumber: 773832
+            - Name: Sporosarcina
+              ConceptType: Genus
+              ConceptId: genus/sporosarcina
+              ConceptSource: LPSN
+              Id: 1724
+              LpsnRecordNumber: 516655
+              Children:
+              - Name: Sporosarcina pasteurii
+                ConceptType: Species
+                ConceptId: species/sporosarcina-pasteurii
+                ConceptSource: LPSN
+                Id: 3193
+                LpsnRecordNumber: 781143
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus pasteurii
+                  ConceptId: species/bacillus-pasteurii
+                  ConceptSource: LPSN
+                  Id: 1848
+                  LpsnRecordNumber: 773802
+              - Name: Sporosarcina psychrophila
+                ConceptType: Species
+                ConceptId: species/sporosarcina-psychrophila
+                ConceptSource: LPSN
+                Id: 2990
+                LpsnRecordNumber: 781144
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus psychrophilus
+                  ConceptId: species/bacillus-psychrophilus
+                  ConceptSource: LPSN
+                  Id: 949
+                  LpsnRecordNumber: 773815
+            - Name: Ureibacillus
+              ConceptType: Genus
+              ConceptId: genus/ureibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 516885
+              Children:
+              - Name: Ureibacillus massiliensis
+                ConceptType: Species
+                ConceptId: species/ureibacillus-massiliensis
+                ConceptSource: LPSN
+                Id: 3260
+                LpsnRecordNumber: 7854
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus massiliensis
+                  ConceptId: species/bacillus-massiliensis
+                  ConceptSource: LPSN
+                  Id: 1397
+                  LpsnRecordNumber: 783427
+          - Name: Cytobacillaceae
+            ConceptType: Family
+            ConceptId: family/cytobacillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 55514
+            Children:
+            - Name: Cytobacillus
+              ConceptType: Genus
+              ConceptId: genus/cytobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4937
+              Children:
+              - Name: Cytobacillus firmus
+                ConceptType: Species
+                ConceptId: species/cytobacillus-firmus
+                ConceptSource: LPSN
+                Id: 3105
+                LpsnRecordNumber: 5935
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus firmus
+                  ConceptId: species/bacillus-firmus
+                  ConceptSource: LPSN
+                  Id: 475
+                  LpsnRecordNumber: 773700
+            - Name: Mesobacillus
+              ConceptType: Genus
+              ConceptId: genus/mesobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4942
+              Children:
+              - Name: Mesobacillus boroniphilus
+                ConceptType: Species
+                ConceptId: species/mesobacillus-boroniphilus
+                ConceptSource: LPSN
+                Id: 3305
+                LpsnRecordNumber: 7354
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus boroniphilus
+                  ConceptId: species/bacillus-boroniphilus
+                  ConceptSource: LPSN
+                  Id: 2324
+                  LpsnRecordNumber: 786083
+              - Name: Mesobacillus jeotgali
+                ConceptType: Species
+                ConceptId: species/mesobacillus-jeotgali
+                ConceptSource: LPSN
+                Id: 2979
+                LpsnRecordNumber: 5936
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus jeotgali
+                  ConceptId: species/bacillus-jeotgali
+                  ConceptSource: LPSN
+                  Id: 1117
+                  LpsnRecordNumber: 773739
+              - Name: Mesobacillus subterraneus
+                ConceptType: Species
+                ConceptId: species/mesobacillus-subterraneus
+                ConceptSource: LPSN
+                Id: 3003
+                LpsnRecordNumber: 7390
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus subterraneus
+                  ConceptId: species/bacillus-subterraneus
+                  ConceptSource: LPSN
+                  Id: 1960
+                  LpsnRecordNumber: 773845
+            - Name: Neobacillus
+              ConceptType: Genus
+              ConceptId: genus/neobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4945
+              Children:
+              - Name: Neobacillus bataviensis
+                ConceptType: Species
+                ConceptId: species/neobacillus-bataviensis
+                ConceptSource: LPSN
+                Id: 3098
+                LpsnRecordNumber: 7352
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus bataviensis
+                  ConceptId: species/bacillus-bataviensis
+                  ConceptSource: LPSN
+                  Id: 267
+                  LpsnRecordNumber: 773649
+              - Name: Neobacillus drentensis
+                ConceptType: Species
+                ConceptId: species/neobacillus-drentensis
+                ConceptSource: LPSN
+                Id: 3301
+                LpsnRecordNumber: 7358
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus drentensis
+                  ConceptId: species/bacillus-drentensis
+                  ConceptSource: LPSN
+                  Id: 2250
+                  LpsnRecordNumber: 773691
+              - Name: Neobacillus fumarioli
+                ConceptType: Species
+                ConceptId: species/neobacillus-fumarioli
+                ConceptSource: LPSN
+                Id: 3270
+                LpsnRecordNumber: 7360
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus fumarioli
+                  ConceptId: species/bacillus-fumarioli
+                  ConceptSource: LPSN
+                  Id: 1735
+                  LpsnRecordNumber: 773708
+              - Name: Neobacillus niacini
+                ConceptType: Species
+                ConceptId: species/neobacillus-niacini
+                ConceptSource: LPSN
+                Id: 3129
+                LpsnRecordNumber: 5937
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus niacini
+                  ConceptId: species/bacillus-niacini
+                  ConceptSource: LPSN
+                  Id: 433
+                  LpsnRecordNumber: 773787
+              - Name: Neobacillus novalis
+                ConceptType: Species
+                ConceptId: species/neobacillus-novalis
+                ConceptSource: LPSN
+                Id: 3062
+                LpsnRecordNumber: 7378
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus novalis
+                  ConceptId: species/bacillus-novalis
+                  ConceptSource: LPSN
+                  Id: 2422
+                  LpsnRecordNumber: 773790
+              - Name: Neobacillus pocheonensis
+                ConceptType: Species
+                ConceptId: species/neobacillus-pocheonensis
+                ConceptSource: LPSN
+                Id: 3009
+                LpsnRecordNumber: 14824
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus pocheonensis
+                  ConceptId: species/bacillus-pocheonensis
+                  ConceptSource: LPSN
+                  Id: 3
+                  LpsnRecordNumber: 786904
+              - Name: Neobacillus soli
+                ConceptType: Species
+                ConceptId: species/neobacillus-soli
+                ConceptSource: LPSN
+                Id: 3123
+                LpsnRecordNumber: 7389
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus soli
+                  ConceptId: species/bacillus-soli
+                  ConceptSource: LPSN
+                  Id: 2076
+                  LpsnRecordNumber: 773838
+              - Name: Neobacillus vireti
+                ConceptType: Species
+                ConceptId: species/neobacillus-vireti
+                ConceptSource: LPSN
+                Id: 3250
+                LpsnRecordNumber: 7393
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus vireti
+                  ConceptId: species/bacillus-vireti
+                  ConceptSource: LPSN
+                  Id: 1224
+                  LpsnRecordNumber: 773907
+            - Name: Robertmurraya
+              ConceptType: Genus
+              ConceptId: genus/robertmurraya
+              ConceptSource: LPSN
+              LpsnRecordNumber: 14529
+              Children:
+              - Name: Robertmurraya korlensis
+                ConceptType: Species
+                ConceptId: species/robertmurraya-korlensis
+                ConceptSource: LPSN
+                Id: 3236
+                LpsnRecordNumber: 14833
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus korlensis
+                  ConceptId: species/bacillus-korlensis
+                  ConceptSource: LPSN
+                  Id: 979
+                  LpsnRecordNumber: 787972
+              - Name: Robertmurraya siralis
+                ConceptType: Species
+                ConceptId: species/robertmurraya-siralis
+                ConceptSource: LPSN
+                Id: 3243
+                LpsnRecordNumber: 14784
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus siralis
+                  ConceptId: species/bacillus-siralis
+                  ConceptSource: LPSN
+                  Id: 906
+                  LpsnRecordNumber: 773835
+          - Name: Gemellaceae
+            ConceptType: Family
+            ConceptId: family/gemellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 43789
+            Children:
+            - Name: Gemella
+              ConceptType: Genus
+              ConceptId: genus/gemella
+              ConceptSource: LPSN
+              Id: 2003
+              LpsnRecordNumber: 515682
+              Children:
+              - Name: Gemella bergeri
+                ConceptType: Species
+                ConceptId: species/gemella-bergeri
+                ConceptSource: LPSN
+                Id: 3276
+                LpsnRecordNumber: 783897
+                Synonyms:
+                - Name: Gemella bergeriae
+                  ConceptId: species/gemella-bergeriae
+                  ConceptSource: LPSN
+                  Id: 1114
+                  LpsnRecordNumber: 798351
+              - Name: Gemella haemolysans
+                ConceptType: Species
+                ConceptId: species/gemella-haemolysans
+                ConceptSource: LPSN
+                Id: 1209
+                LpsnRecordNumber: 783898
+              - Name: Gemella morbillorum
+                ConceptType: Species
+                ConceptId: species/gemella-morbillorum
+                ConceptSource: LPSN
+                Id: 1392
+                LpsnRecordNumber: 776434
+                Synonyms:
+                - Name: Streptococcus morbillorum
+                  ConceptId: species/streptococcus-morbillorum
+                  ConceptSource: LPSN
+                  Id: 1926
+                  LpsnRecordNumber: 781362
+              - Name: Gemella sanguinis
+                ConceptType: Species
+                ConceptId: species/gemella-sanguinis
+                ConceptSource: LPSN
+                Id: 1415
+                LpsnRecordNumber: 783900
+          - Name: Listeriaceae
+            ConceptType: Family
+            ConceptId: family/listeriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 766
+            Children:
+            - Name: Listeria
+              ConceptType: Genus
+              ConceptId: genus/listeria
+              ConceptSource: LPSN
+              Id: 157
+              LpsnRecordNumber: 515972
+              Children:
+              - Name: Listeria grayi
+                ConceptType: Species
+                ConceptId: species/listeria-grayi
+                ConceptSource: LPSN
+                Id: 1199
+                LpsnRecordNumber: 777586
+              - Name: Listeria innocua
+                ConceptType: Species
+                ConceptId: species/listeria-innocua
+                ConceptSource: LPSN
+                Id: 2515
+                LpsnRecordNumber: 777587
+              - Name: Listeria ivanovii
+                ConceptType: Species
+                ConceptId: species/listeria-ivanovii
+                ConceptSource: LPSN
+                Id: 2118
+                LpsnRecordNumber: 784159
+              - Name: Listeria monocytogenes
+                ConceptType: Species
+                ConceptId: species/listeria-monocytogenes
+                ConceptSource: LPSN
+                Id: 368
+                LpsnRecordNumber: 777590
+              - Name: Listeria seeligeri
+                ConceptType: Species
+                ConceptId: species/listeria-seeligeri
+                ConceptSource: LPSN
+                Id: 172
+                LpsnRecordNumber: 777592
+              - Name: Listeria welshimeri
+                ConceptType: Species
+                ConceptId: species/listeria-welshimeri
+                ConceptSource: LPSN
+                Id: 1057
+                LpsnRecordNumber: 777593
+          - Name: Paenibacillaceae
+            ConceptType: Family
+            ConceptId: family/paenibacillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1013
+            Children:
+            - Name: Aneurinibacillus
+              ConceptType: Genus
+              ConceptId: genus/aneurinibacillus
+              ConceptSource: LPSN
+              Id: 331
+              LpsnRecordNumber: 515136
+              Children:
+              - Name: Aneurinibacillus aneurinilyticus
+                ConceptType: Species
+                ConceptId: species/aneurinibacillus-aneurinilyticus
+                ConceptSource: LPSN
+                Id: 1921
+                LpsnRecordNumber: 773274
+                Synonyms:
+                - Name: Bacillus aneurinilyticus
+                  ConceptId: species/bacillus-aneurinilyticus
+                  ConceptSource: LPSN
+                  Id: 3290
+                  LpsnRecordNumber: 773634
+                - Name: Bacillus aneurinolyticus
+                  ConceptId: species/bacillus-aneurinolyticus
+                  ConceptSource: LPSN
+                  Id: 1035
+                  LpsnRecordNumber: 783418
+            - Name: Brevibacillus
+              ConceptType: Genus
+              ConceptId: genus/brevibacillus
+              ConceptSource: LPSN
+              Id: 493
+              LpsnRecordNumber: 515269
+              CommonCommensal: true
+              Children:
+              - Name: Brevibacillus agri
+                ConceptType: Species
+                ConceptId: species/brevibacillus-agri
+                ConceptSource: LPSN
+                Id: 962
+                LpsnRecordNumber: 774183
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus agri
+                  ConceptId: species/bacillus-agri
+                  ConceptSource: LPSN
+                  Id: 320
+                  LpsnRecordNumber: 773624
+                - Name: Bacillus galactophilus
+                  ConceptId: species/bacillus-galactophilus
+                  ConceptSource: LPSN
+                  Id: 1321
+                  LpsnRecordNumber: 783423
+              - Name: Brevibacillus brevis
+                ConceptType: Species
+                ConceptId: species/brevibacillus-brevis
+                ConceptSource: LPSN
+                Id: 1486
+                LpsnRecordNumber: 774185
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus brevis
+                  ConceptId: species/bacillus-brevis
+                  ConceptSource: LPSN
+                  Id: 48
+                  LpsnRecordNumber: 773657
+              - Name: Brevibacillus centrosporus
+                ConceptType: Species
+                ConceptId: species/brevibacillus-centrosporus
+                ConceptSource: LPSN
+                Id: 1687
+                LpsnRecordNumber: 774186
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus centrosporus
+                  ConceptId: species/bacillus-centrosporus
+                  ConceptSource: LPSN
+                  Id: 804
+                  LpsnRecordNumber: 773669
+              - Name: Brevibacillus laterosporus
+                ConceptType: Species
+                ConceptId: species/brevibacillus-laterosporus
+                ConceptSource: LPSN
+                Id: 1557
+                LpsnRecordNumber: 774190
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus laterosporus
+                  ConceptId: species/bacillus-laterosporus
+                  ConceptSource: LPSN
+                  Id: 2013
+                  LpsnRecordNumber: 773748
+              - Name: Brevibacillus parabrevis
+                ConceptType: Species
+                ConceptId: species/brevibacillus-parabrevis
+                ConceptSource: LPSN
+                Id: 389
+                LpsnRecordNumber: 774192
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus parabrevis
+                  ConceptId: species/bacillus-parabrevis
+                  ConceptSource: LPSN
+                  Id: 921
+                  LpsnRecordNumber: 773801
+            - Name: Paenibacillus
+              ConceptType: Genus
+              ConceptId: genus/paenibacillus
+              ConceptSource: LPSN
+              Id: 285
+              LpsnRecordNumber: 516243
+              CommonCommensal: true
+              Children:
+              - Name: Paenibacillus agaridevorans
+                ConceptType: Species
+                ConceptId: species/paenibacillus-agaridevorans
+                ConceptSource: LPSN
+                Id: 1329
+                LpsnRecordNumber: 779041
+                CommonCommensal: true
+              - Name: Paenibacillus alvei
+                ConceptType: Species
+                ConceptId: species/paenibacillus-alvei
+                ConceptSource: LPSN
+                Id: 184
+                LpsnRecordNumber: 779044
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus alvei
+                  ConceptId: species/bacillus-alvei
+                  ConceptSource: LPSN
+                  Id: 671
+                  LpsnRecordNumber: 773630
+              - Name: Paenibacillus edaphicus
+                ConceptType: Species
+                ConceptId: species/paenibacillus-edaphicus
+                ConceptSource: LPSN
+                Id: 1336
+                LpsnRecordNumber: 788340
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus edaphicus
+                  ConceptId: species/bacillus-edaphicus
+                  ConceptSource: LPSN
+                  Id: 140
+                  LpsnRecordNumber: 773692
+              - Name: Paenibacillus ehimensis
+                ConceptType: Species
+                ConceptId: species/paenibacillus-ehimensis
+                ConceptSource: LPSN
+                Id: 3209
+                LpsnRecordNumber: 779064
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus ehimensis
+                  ConceptId: species/bacillus-ehimensis
+                  ConceptSource: LPSN
+                  Id: 1540
+                  LpsnRecordNumber: 773693
+              - Name: Paenibacillus larvae
+                ConceptType: Species
+                ConceptId: species/paenibacillus-larvae
+                ConceptSource: LPSN
+                Id: 1653
+                LpsnRecordNumber: 779077
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus larvae
+                  ConceptId: species/bacillus-larvae
+                  ConceptSource: LPSN
+                  Id: 1815
+                  LpsnRecordNumber: 773747
+                - Name: Bacillus pulvifaciens
+                  ConceptId: species/bacillus-pulvifaciens
+                  ConceptSource: LPSN
+                  Id: 33
+                  LpsnRecordNumber: 773819
+              - Name: Paenibacillus lentimorbus
+                ConceptType: Species
+                ConceptId: species/paenibacillus-lentimorbus
+                ConceptSource: LPSN
+                Id: 1504
+                LpsnRecordNumber: 779081
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus lentimorbus
+                  ConceptId: species/bacillus-lentimorbus
+                  ConceptSource: LPSN
+                  Id: 991
+                  LpsnRecordNumber: 773750
+              - Name: Paenibacillus macerans
+                ConceptType: Species
+                ConceptId: species/paenibacillus-macerans
+                ConceptSource: LPSN
+                Id: 470
+                LpsnRecordNumber: 779082
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus macerans
+                  ConceptId: species/bacillus-macerans
+                  ConceptSource: LPSN
+                  Id: 2399
+                  LpsnRecordNumber: 773760
+              - Name: Paenibacillus mucilaginosus
+                ConceptType: Species
+                ConceptId: species/paenibacillus-mucilaginosus
+                ConceptSource: LPSN
+                Id: 3149
+                LpsnRecordNumber: 788339
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus mucilaginosus
+                  ConceptId: species/bacillus-mucilaginosus
+                  ConceptSource: LPSN
+                  Id: 2277
+                  LpsnRecordNumber: 773777
+              - Name: Paenibacillus pabuli
+                ConceptType: Species
+                ConceptId: species/paenibacillus-pabuli
+                ConceptSource: LPSN
+                Id: 543
+                LpsnRecordNumber: 779089
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus pabuli
+                  ConceptId: species/bacillus-pabuli
+                  ConceptSource: LPSN
+                  Id: 192
+                  LpsnRecordNumber: 773794
+              - Name: Paenibacillus polymyxa
+                ConceptType: Species
+                ConceptId: species/paenibacillus-polymyxa
+                ConceptSource: LPSN
+                Id: 2517
+                LpsnRecordNumber: 779092
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus polymyxa
+                  ConceptId: species/bacillus-polymyxa
+                  ConceptSource: LPSN
+                  Id: 1328
+                  LpsnRecordNumber: 773808
+              - Name: Paenibacillus popilliae
+                ConceptType: Species
+                ConceptId: species/paenibacillus-popilliae
+                ConceptSource: LPSN
+                Id: 1547
+                LpsnRecordNumber: 779093
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus popilliae
+                  ConceptId: species/bacillus-popilliae
+                  ConceptSource: LPSN
+                  Id: 2455
+                  LpsnRecordNumber: 773809
+              - Name: Paenibacillus provencensis
+                ConceptType: Species
+                ConceptId: species/paenibacillus-provencensis
+                ConceptSource: LPSN
+                Id: 2130
+                LpsnRecordNumber: 787248
+                CommonCommensal: true
+              - Name: Paenibacillus thiaminolyticus
+                ConceptType: Species
+                ConceptId: species/paenibacillus-thiaminolyticus
+                ConceptSource: LPSN
+                Id: 579
+                LpsnRecordNumber: 779101
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus thiaminolyticus
+                  ConceptId: species/bacillus-thiaminolyticus
+                  ConceptSource: LPSN
+                  Id: 1924
+                  LpsnRecordNumber: 773868
+              - Name: Paenibacillus urinalis
+                ConceptType: Species
+                ConceptId: species/paenibacillus-urinalis
+                ConceptSource: LPSN
+                Id: 960
+                LpsnRecordNumber: 787247
+                CommonCommensal: true
+              - Name: Paenibacillus validus
+                ConceptType: Species
+                ConceptId: species/paenibacillus-validus
+                ConceptSource: LPSN
+                Id: 87
+                LpsnRecordNumber: 779104
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus validus
+                  ConceptId: species/bacillus-validus
+                  ConceptSource: LPSN
+                  Id: 1544
+                  LpsnRecordNumber: 773902
+                - Name: Paenibacillus gordonae
+                  ConceptId: species/paenibacillus-gordonae
+                  ConceptSource: LPSN
+                  Id: 1376
+                  LpsnRecordNumber: 779070
+          - Name: Sporolactobacillaceae
+            ConceptType: Family
+            ConceptId: family/sporolactobacillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1322
+            Children:
+            - Name: Pullulanibacillus
+              ConceptType: Genus
+              ConceptId: genus/pullulanibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517474
+              Children:
+              - Name: Pullulanibacillus naganoensis
+                ConceptType: Species
+                ConceptId: species/pullulanibacillus-naganoensis
+                ConceptSource: LPSN
+                Id: 2972
+                LpsnRecordNumber: 773782
+                CommonCommensal: true
+                Synonyms:
+                - Name: Bacillus naganoensis
+                  ConceptId: species/bacillus-naganoensis
+                  ConceptSource: LPSN
+                  Id: 1409
+                  LpsnRecordNumber: 785652
+            - Name: Sporolactobacillus
+              ConceptType: Genus
+              ConceptId: genus/sporolactobacillus
+              ConceptSource: LPSN
+              Id: 2529
+              LpsnRecordNumber: 516653
+              Children:
+              - Name: Sporolactobacillus laevolacticus
+                ConceptType: Species
+                ConceptId: species/sporolactobacillus-laevolacticus
+                ConceptSource: LPSN
+                Id: 436
+                LpsnRecordNumber: 773746
+                Synonyms:
+                - Name: Bacillus laevolacticus
+                  ConceptId: species/bacillus-laevolacticus
+                  ConceptSource: LPSN
+                  Id: 792
+                  LpsnRecordNumber: 785657
+          - Name: Staphylococcaceae
+            ConceptType: Family
+            ConceptId: family/staphylococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1330
+            Children:
+            - Name: Macrococcus
+              ConceptType: Genus
+              ConceptId: genus/macrococcus
+              ConceptSource: LPSN
+              Id: 2218
+              LpsnRecordNumber: 515988
+              Children:
+              - Name: Macrococcus bovicus
+                ConceptType: Species
+                ConceptId: species/macrococcus-bovicus
+                ConceptSource: LPSN
+                Id: 2134
+                LpsnRecordNumber: 777632
+              - Name: Macrococcus carouselicus
+                ConceptType: Species
+                ConceptId: species/macrococcus-carouselicus
+                ConceptSource: LPSN
+                Id: 1307
+                LpsnRecordNumber: 777633
+              - Name: Macrococcus caseolyticus
+                ConceptType: Species
+                ConceptId: species/macrococcus-caseolyticus
+                ConceptSource: LPSN
+                Id: 1692
+                LpsnRecordNumber: 777634
+                Synonyms:
+                - Name: Staphylococcus caseolyticus
+                  ConceptId: species/staphylococcus-caseolyticus
+                  ConceptSource: LPSN
+                  Id: 2556
+                  LpsnRecordNumber: 781178
+              - Name: Macrococcus equipercicus
+                ConceptType: Species
+                ConceptId: species/macrococcus-equipercicus
+                ConceptSource: LPSN
+                Id: 818
+                LpsnRecordNumber: 777635
+            - Name: Staphylococcus
+              ConceptType: Genus
+              ConceptId: genus/staphylococcus
+              ConceptSource: LPSN
+              Id: 481
+              LpsnRecordNumber: 516664
+              Children:
+              - Name: Coagulase-negative staphylococci
+                ConceptType: Group
+                ConceptId: 63
+                ConceptSource: NeoIPC
+                Id: 2776
+                Children:
+                - Name: Staphylococcus arlettae
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-arlettae
+                  ConceptSource: LPSN
+                  Id: 1835
+                  LpsnRecordNumber: 781167
+                  CommonCommensal: true
+                - Name: Staphylococcus auricularis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-auricularis
+                  ConceptSource: LPSN
+                  Id: 780
+                  LpsnRecordNumber: 781171
+                  CommonCommensal: true
+                - Name: Staphylococcus borealis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-borealis
+                  ConceptSource: LPSN
+                  Id: 2779
+                  LpsnRecordNumber: 14689
+                  CommonCommensal: true
+                - Name: Staphylococcus capitis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-capitis
+                  ConceptSource: LPSN
+                  Id: 1193
+                  LpsnRecordNumber: 784962
+                  CommonCommensal: true
+                  Children:
+                  - Name: Staphylococcus capitis subsp. capitis
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-capitis-capitis
+                    ConceptSource: LPSN
+                    Id: 6
+                    LpsnRecordNumber: 781172
+                    CommonCommensal: true
+                  - Name: Staphylococcus capitis subsp. urealyticus
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-capitis-urealyticus
+                    ConceptSource: LPSN
+                    Id: 2246
+                    LpsnRecordNumber: 781173
+                    CommonCommensal: true
+                - Name: Staphylococcus caprae
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-caprae
+                  ConceptSource: LPSN
+                  Id: 791
+                  LpsnRecordNumber: 781174
+                  CommonCommensal: true
+                - Name: Staphylococcus carnosus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-carnosus
+                  ConceptSource: LPSN
+                  Id: 2223
+                  LpsnRecordNumber: 781175
+                  CommonCommensal: true
+                  Children:
+                  - Name: Staphylococcus carnosus subsp. carnosus
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-carnosus-carnosus
+                    ConceptSource: LPSN
+                    Id: 1298
+                    LpsnRecordNumber: 781176
+                    CommonCommensal: true
+                  Synonyms:
+                  - Name: Staphylococcus carnosus subsp. utilis
+                    ConceptId: subspecies/staphylococcus-carnosus-utilis
+                    ConceptSource: LPSN
+                    Id: 2006
+                    LpsnRecordNumber: 781177
+                - Name: Staphylococcus casei
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-casei
+                  ConceptSource: LPSN
+                  Id: 3330
+                  LpsnRecordNumber: 14797
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Staphylococcus succinus subsp. casei
+                    ConceptId: subspecies/staphylococcus-succinus-casei
+                    ConceptSource: LPSN
+                    Id: 1216
+                    LpsnRecordNumber: 781225
+                - Name: Staphylococcus cohnii
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-cohnii
+                  ConceptSource: LPSN
+                  Id: 815
+                  LpsnRecordNumber: 781180
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Staphylococcus cohnii subsp. cohnii
+                    ConceptId: subspecies/staphylococcus-cohnii-cohnii
+                    ConceptSource: LPSN
+                    Id: 546
+                    LpsnRecordNumber: 781181
+                - Name: Staphylococcus condimenti
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-condimenti
+                  ConceptSource: LPSN
+                  Id: 946
+                  LpsnRecordNumber: 781183
+                  CommonCommensal: true
+                - Name: Staphylococcus epidermidis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-epidermidis
+                  ConceptSource: LPSN
+                  Id: 810
+                  LpsnRecordNumber: 781185
+                  CommonCommensal: true
+                - Name: Staphylococcus equorum
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-equorum
+                  ConceptSource: LPSN
+                  Id: 2059
+                  LpsnRecordNumber: 781186
+                  CommonCommensal: true
+                  Children:
+                  - Name: Staphylococcus equorum subsp. equorum
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-equorum-equorum
+                    ConceptSource: LPSN
+                    Id: 2458
+                    LpsnRecordNumber: 781187
+                    CommonCommensal: true
+                  - Name: Staphylococcus equorum subsp. linens
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-equorum-linens
+                    ConceptSource: LPSN
+                    Id: 808
+                    LpsnRecordNumber: 781188
+                    CommonCommensal: true
+                - Name: Staphylococcus felis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-felis
+                  ConceptSource: LPSN
+                  Id: 2514
+                  LpsnRecordNumber: 781189
+                  CommonCommensal: true
+                - Name: Staphylococcus fleurettii
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-fleurettii
+                  ConceptSource: LPSN
+                  Id: 2365
+                  LpsnRecordNumber: 781190
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Mammaliicoccus fleurettii
+                    ConceptId: species/mammaliicoccus-fleurettii
+                    ConceptSource: LPSN
+                    Id: 2993
+                    LpsnRecordNumber: 14762
+                - Name: Staphylococcus gallinarum
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-gallinarum
+                  ConceptSource: LPSN
+                  Id: 153
+                  LpsnRecordNumber: 781191
+                  CommonCommensal: true
+                - Name: Staphylococcus haemolyticus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-haemolyticus
+                  ConceptSource: LPSN
+                  Id: 1603
+                  LpsnRecordNumber: 781192
+                  CommonCommensal: true
+                - Name: Staphylococcus hominis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-hominis
+                  ConceptSource: LPSN
+                  Id: 1156
+                  LpsnRecordNumber: 781193
+                  CommonCommensal: true
+                  Children:
+                  - Name: Staphylococcus hominis subsp. hominis
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-hominis-hominis
+                    ConceptSource: LPSN
+                    Id: 1447
+                    LpsnRecordNumber: 781194
+                    CommonCommensal: true
+                  - Name: Staphylococcus hominis subsp. novobiosepticus
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-hominis-novobiosepticus
+                    ConceptSource: LPSN
+                    Id: 110
+                    LpsnRecordNumber: 781195
+                    CommonCommensal: true
+                - Name: Staphylococcus kloosii
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-kloosii
+                  ConceptSource: LPSN
+                  Id: 24
+                  LpsnRecordNumber: 781199
+                  CommonCommensal: true
+                - Name: Staphylococcus lentus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-lentus
+                  ConceptSource: LPSN
+                  Id: 964
+                  LpsnRecordNumber: 781201
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Mammaliicoccus lentus
+                    ConceptId: species/mammaliicoccus-lentus
+                    ConceptSource: LPSN
+                    Id: 3055
+                    LpsnRecordNumber: 14763
+                  - Name: Staphylococcus sciuri subsp. lentus
+                    ConceptId: subspecies/staphylococcus-sciuri-lentus
+                    ConceptSource: LPSN
+                    Id: 2407
+                    LpsnRecordNumber: 781218
+                - Name: Staphylococcus lugdunensis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-lugdunensis
+                  ConceptSource: LPSN
+                  Id: 1842
+                  LpsnRecordNumber: 781202
+                  CommonCommensal: true
+                - Name: Staphylococcus massiliensis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-massiliensis
+                  ConceptSource: LPSN
+                  Id: 2781
+                  LpsnRecordNumber: 788534
+                  CommonCommensal: true
+                - Name: Staphylococcus muscae
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-muscae
+                  ConceptSource: LPSN
+                  Id: 1463
+                  LpsnRecordNumber: 781204
+                  CommonCommensal: true
+                - Name: Staphylococcus nepalensis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-nepalensis
+                  ConceptSource: LPSN
+                  Id: 155
+                  LpsnRecordNumber: 781205
+                  CommonCommensal: true
+                - Name: Staphylococcus pasteuri
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-pasteuri
+                  ConceptSource: LPSN
+                  Id: 978
+                  LpsnRecordNumber: 781207
+                  CommonCommensal: true
+                - Name: Staphylococcus pettenkoferi
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-pettenkoferi
+                  ConceptSource: LPSN
+                  Id: 823
+                  LpsnRecordNumber: 786500
+                  CommonCommensal: true
+                - Name: Staphylococcus piscifermentans
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-piscifermentans
+                  ConceptSource: LPSN
+                  Id: 457
+                  LpsnRecordNumber: 781208
+                  CommonCommensal: true
+                - Name: Staphylococcus pseudolugdunensis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-pseudolugdunensis
+                  ConceptSource: LPSN
+                  Id: 2782
+                  LpsnRecordNumber: 801159
+                  CommonCommensal: true
+                - Name: Staphylococcus saccharolyticus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-saccharolyticus
+                  ConceptSource: LPSN
+                  Id: 19
+                  LpsnRecordNumber: 781211
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Peptococcus saccharolyticus
+                    ConceptId: species/peptococcus-saccharolyticus
+                    ConceptSource: LPSN
+                    Id: 784
+                    LpsnRecordNumber: 779371
+                - Name: Staphylococcus saprophyticus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-saprophyticus
+                  ConceptSource: LPSN
+                  Id: 739
+                  LpsnRecordNumber: 781212
+                  CommonCommensal: true
+                  Children:
+                  - Name: Staphylococcus saprophyticus subsp. saprophyticus
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-saprophyticus-saprophyticus
+                    ConceptSource: LPSN
+                    Id: 500
+                    LpsnRecordNumber: 781213
+                    CommonCommensal: true
+                  Synonyms:
+                  - Name: Staphylococcus saprophyticus subsp. bovis
+                    ConceptId: subspecies/staphylococcus-saprophyticus-bovis
+                    ConceptSource: LPSN
+                    Id: 16
+                    LpsnRecordNumber: 784965
+                - Name: Staphylococcus sciuri
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-sciuri
+                  ConceptSource: LPSN
+                  Id: 1158
+                  LpsnRecordNumber: 781216
+                  CommonCommensal: true
+                  Children:
+                  - Name: Staphylococcus sciuri subsp. sciuri
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/staphylococcus-sciuri-sciuri
+                    ConceptSource: LPSN
+                    Id: 2775
+                    LpsnRecordNumber: 781220
+                    CommonCommensal: true
+                  Synonyms:
+                  - Name: Mammaliicoccus sciuri
+                    ConceptId: species/mammaliicoccus-sciuri
+                    ConceptSource: LPSN
+                    Id: 2969
+                    LpsnRecordNumber: 14764
+                  - Name: Staphylococcus sciuri subsp. carnaticus
+                    ConceptId: subspecies/staphylococcus-sciuri-carnaticus
+                    ConceptSource: LPSN
+                    Id: 2232
+                    LpsnRecordNumber: 781217
+                  - Name: Staphylococcus sciuri subsp. rodentium
+                    ConceptId: subspecies/staphylococcus-sciuri-rodentium
+                    ConceptSource: LPSN
+                    Id: 260
+                    LpsnRecordNumber: 781219
+                - Name: Staphylococcus simulans
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-simulans
+                  ConceptSource: LPSN
+                  Id: 2028
+                  LpsnRecordNumber: 781222
+                  CommonCommensal: true
+                - Name: Staphylococcus succinus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-succinus
+                  ConceptSource: LPSN
+                  Id: 1026
+                  LpsnRecordNumber: 784967
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Staphylococcus succinus subsp. succinus
+                    ConceptId: subspecies/staphylococcus-succinus-succinus
+                    ConceptSource: LPSN
+                    Id: 1282
+                    LpsnRecordNumber: 781226
+                - Name: Staphylococcus ureilyticus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-ureilyticus
+                  ConceptSource: LPSN
+                  Id: 3026
+                  LpsnRecordNumber: 14801
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Staphylococcus cohnii subsp. urealyticus
+                    ConceptId: subspecies/staphylococcus-cohnii-urealyticus
+                    ConceptSource: LPSN
+                    Id: 2125
+                    LpsnRecordNumber: 781182
+                - Name: Staphylococcus vitulinus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-vitulinus
+                  ConceptSource: LPSN
+                  Id: 595
+                  LpsnRecordNumber: 781227
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Mammaliicoccus vitulinus
+                    ConceptId: species/mammaliicoccus-vitulinus
+                    ConceptSource: LPSN
+                    Id: 2987
+                    LpsnRecordNumber: 14766
+                  - Name: Staphylococcus pulvereri
+                    ConceptId: species/staphylococcus-pulvereri
+                    ConceptSource: LPSN
+                    Id: 2532
+                    LpsnRecordNumber: 781209
+                - Name: Staphylococcus warneri
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-warneri
+                  ConceptSource: LPSN
+                  Id: 375
+                  LpsnRecordNumber: 781228
+                  CommonCommensal: true
+                - Name: Staphylococcus xylosus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-xylosus
+                  ConceptSource: LPSN
+                  Id: 1416
+                  LpsnRecordNumber: 781229
+                  CommonCommensal: true
+              - Name: Coagulase-positive staphylococci
+                ConceptType: Group
+                ConceptId: 64
+                ConceptSource: NeoIPC
+                Id: 2777
+                Children:
+                - Name: Staphylococcus argenteus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-argenteus
+                  ConceptSource: LPSN
+                  Id: 2778
+                  LpsnRecordNumber: 792442
+                - Name: Staphylococcus aureus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-aureus
+                  ConceptSource: LPSN
+                  Id: 934
+                  LpsnRecordNumber: 781168
+                  MRSA: true
+                - Name: Staphylococcus coagulans
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-coagulans
+                  ConceptSource: LPSN
+                  Id: 2999
+                  LpsnRecordNumber: 14798
+                  Synonyms:
+                  - Name: Staphylococcus schleiferi subsp. coagulans
+                    ConceptId: subspecies/staphylococcus-schleiferi-coagulans
+                    ConceptSource: LPSN
+                    Id: 1015
+                    LpsnRecordNumber: 781214
+                - Name: Staphylococcus cornubiensis
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-cornubiensis
+                  ConceptSource: LPSN
+                  Id: 2780
+                  LpsnRecordNumber: 797949
+                - Name: Staphylococcus delphini
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-delphini
+                  ConceptSource: LPSN
+                  Id: 1816
+                  LpsnRecordNumber: 781184
+                - Name: Staphylococcus intermedius
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-intermedius
+                  ConceptSource: LPSN
+                  Id: 393
+                  LpsnRecordNumber: 781198
+                - Name: Staphylococcus lutrae
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-lutrae
+                  ConceptSource: LPSN
+                  Id: 708
+                  LpsnRecordNumber: 781203
+                - Name: Staphylococcus pseudintermedius
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-pseudintermedius
+                  ConceptSource: LPSN
+                  Id: 2272
+                  LpsnRecordNumber: 785516
+                - Name: Staphylococcus schleiferi
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-schleiferi
+                  ConceptSource: LPSN
+                  Id: 741
+                  LpsnRecordNumber: 784966
+                  Synonyms:
+                  - Name: Staphylococcus schleiferi subsp. schleiferi
+                    ConceptId: subspecies/staphylococcus-schleiferi-schleiferi
+                    ConceptSource: LPSN
+                    Id: 1748
+                    LpsnRecordNumber: 781215
+              - Name: Coagulase-variable staphylococci
+                ConceptType: Group
+                ConceptId: 86
+                ConceptSource: NeoIPC
+                Children:
+                - Name: Staphylococcus chromogenes
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-chromogenes
+                  ConceptSource: LPSN
+                  Id: 2342
+                  LpsnRecordNumber: 781179
+                  CommonCommensal: true
+                  Synonyms:
+                  - Name: Staphylococcus hyicus subsp. chromogenes
+                    ConceptId: subspecies/staphylococcus-hyicus-chromogenes
+                    ConceptSource: LPSN
+                    Id: 188
+                    LpsnRecordNumber: 781197
+                - Name: Staphylococcus hyicus
+                  ConceptType: Species
+                  ConceptId: species/staphylococcus-hyicus
+                  ConceptSource: LPSN
+                  Id: 2496
+                  LpsnRecordNumber: 781196
+                  Synonyms:
+                  - Name: Staphylococcus hyicus subsp. hyicus
+                    ConceptId: subspecies/staphylococcus-hyicus-hyicus
+                    ConceptSource: LPSN
+                    Id: 1615
+                    LpsnRecordNumber: 784964
+          - Name: Thermoactinomycetaceae
+            ConceptType: Family
+            ConceptId: family/thermoactinomycetaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1424
+            Children:
+            - Name: Kroppenstedtia
+              ConceptType: Genus
+              ConceptId: genus/kroppenstedtia
+              ConceptSource: LPSN
+              Id: 2423
+              LpsnRecordNumber: 518123
+              Children:
+              - Name: Kroppenstedtia eburnea
+                ConceptType: Species
+                ConceptId: species/kroppenstedtia-eburnea
+                ConceptSource: LPSN
+                Id: 2574
+                LpsnRecordNumber: 789419
+            - Name: Thermoactinomyces
+              ConceptType: Genus
+              ConceptId: genus/thermoactinomyces
+              ConceptSource: LPSN
+              Id: 1096
+              LpsnRecordNumber: 516776
+        - Name: Lactobacillales
+          ConceptType: Order
+          ConceptId: order/lactobacillales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5123
+          Children:
+          - Name: Aerococcaceae
+            ConceptType: Family
+            ConceptId: family/aerococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 57
+            Children:
+            - Name: Abiotrophia
+              ConceptType: Genus
+              ConceptId: genus/abiotrophia
+              ConceptSource: LPSN
+              Id: 1436
+              LpsnRecordNumber: 514986
+              Children:
+              - Name: Abiotrophia defectiva
+                ConceptType: Species
+                ConceptId: species/abiotrophia-defectiva
+                ConceptSource: LPSN
+                Id: 108
+                LpsnRecordNumber: 772468
+                Synonyms:
+                - Name: Streptococcus defectivus
+                  ConceptId: species/streptococcus-defectivus
+                  ConceptSource: LPSN
+                  Id: 649
+                  LpsnRecordNumber: 781315
+            - Name: Aerococcus
+              ConceptType: Genus
+              ConceptId: genus/aerococcus
+              ConceptSource: LPSN
+              Id: 1628
+              LpsnRecordNumber: 515050
+              CommonCommensal: true
+              Children:
+              - Name: Aerococcus christensenii
+                ConceptType: Species
+                ConceptId: species/aerococcus-christensenii
+                ConceptSource: LPSN
+                Id: 1668
+                LpsnRecordNumber: 772877
+                CommonCommensal: true
+              - Name: Aerococcus sanguinicola
+                ConceptType: Species
+                ConceptId: species/aerococcus-sanguinicola
+                ConceptSource: LPSN
+                Id: 1333
+                LpsnRecordNumber: 772879
+                CommonCommensal: true
+              - Name: Aerococcus urinae
+                ConceptType: Species
+                ConceptId: species/aerococcus-urinae
+                ConceptSource: LPSN
+                Id: 1672
+                LpsnRecordNumber: 772880
+                CommonCommensal: true
+              - Name: Aerococcus urinaeequi
+                ConceptType: Species
+                ConceptId: species/aerococcus-urinaeequi
+                ConceptSource: LPSN
+                Id: 813
+                LpsnRecordNumber: 772881
+                CommonCommensal: true
+                Synonyms:
+                - Name: Pediococcus urinaeequi
+                  ConceptId: species/pediococcus-urinaeequi
+                  ConceptSource: LPSN
+                  Id: 2097
+                  LpsnRecordNumber: 779220
+              - Name: Aerococcus urinaehominis
+                ConceptType: Species
+                ConceptId: species/aerococcus-urinaehominis
+                ConceptSource: LPSN
+                Id: 2019
+                LpsnRecordNumber: 772882
+                CommonCommensal: true
+              - Name: Aerococcus viridans
+                ConceptType: Species
+                ConceptId: species/aerococcus-viridans
+                ConceptSource: LPSN
+                Id: 945
+                LpsnRecordNumber: 772883
+                CommonCommensal: true
+            - Name: Dolosicoccus
+              ConceptType: Genus
+              ConceptId: genus/dolosicoccus
+              ConceptSource: LPSN
+              Id: 2148
+              LpsnRecordNumber: 515549
+              Children:
+              - Name: Dolosicoccus paucivorans
+                ConceptType: Species
+                ConceptId: species/dolosicoccus-paucivorans
+                ConceptSource: LPSN
+                Id: 1999
+                LpsnRecordNumber: 775813
+            - Name: Facklamia
+              ConceptType: Genus
+              ConceptId: genus/facklamia
+              ConceptSource: LPSN
+              Id: 1509
+              LpsnRecordNumber: 517231
+              Children:
+              - Name: Facklamia hominis
+                ConceptType: Species
+                ConceptId: species/facklamia-hominis
+                ConceptSource: LPSN
+                Id: 821
+                LpsnRecordNumber: 783825
+              - Name: Facklamia ignava
+                ConceptType: Species
+                ConceptId: species/facklamia-ignava
+                ConceptSource: LPSN
+                Id: 2077
+                LpsnRecordNumber: 783826
+              - Name: Facklamia languida
+                ConceptType: Species
+                ConceptId: species/facklamia-languida
+                ConceptSource: LPSN
+                Id: 335
+                LpsnRecordNumber: 783827
+              - Name: Facklamia sourekii
+                ConceptType: Species
+                ConceptId: species/facklamia-sourekii
+                ConceptSource: LPSN
+                Id: 895
+                LpsnRecordNumber: 783829
+            - Name: Globicatella
+              ConceptType: Genus
+              ConceptId: genus/globicatella
+              ConceptSource: LPSN
+              Id: 2572
+              LpsnRecordNumber: 515707
+              Children:
+              - Name: Globicatella sanguinis
+                ConceptType: Species
+                ConceptId: species/globicatella-sanguinis
+                ConceptSource: LPSN
+                Id: 80
+                LpsnRecordNumber: 776521
+              - Name: Globicatella sulfidifaciens
+                ConceptType: Species
+                ConceptId: species/globicatella-sulfidifaciens
+                ConceptSource: LPSN
+                Id: 60
+                LpsnRecordNumber: 776522
+            - Name: Ignavigranum
+              ConceptType: Genus
+              ConceptId: genus/ignavigranum
+              ConceptSource: LPSN
+              Id: 1363
+              LpsnRecordNumber: 515845
+              Children:
+              - Name: Ignavigranum ruoffiae
+                ConceptType: Species
+                ConceptId: species/ignavigranum-ruoffiae
+                ConceptSource: LPSN
+                Id: 1103
+                LpsnRecordNumber: 777018
+            - Name: Ruoffia
+              ConceptType: Genus
+              ConceptId: genus/ruoffia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 20029
+              Children:
+              - Name: Ruoffia tabacinasalis
+                ConceptType: Species
+                ConceptId: species/ruoffia-tabacinasalis
+                ConceptSource: LPSN
+                Id: 3498
+                LpsnRecordNumber: 20043
+                Synonyms:
+                - Name: Facklamia tabacinasalis
+                  ConceptId: species/facklamia-tabacinasalis
+                  ConceptSource: LPSN
+                  Id: 1481
+                  LpsnRecordNumber: 783830
+          - Name: Carnobacteriaceae
+            ConceptType: Family
+            ConceptId: family/carnobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 279
+            Children:
+            - Name: Alloiococcus
+              ConceptType: Genus
+              ConceptId: genus/alloiococcus
+              ConceptSource: LPSN
+              Id: 1384
+              LpsnRecordNumber: 515092
+              Children:
+              - Name: Alloiococcus otitis
+                ConceptType: Species
+                ConceptId: species/alloiococcus-otitis
+                ConceptSource: LPSN
+                Id: 134
+                LpsnRecordNumber: 773087
+            - Name: Dolosigranulum
+              ConceptType: Genus
+              ConceptId: genus/dolosigranulum
+              ConceptSource: LPSN
+              Id: 2577
+              LpsnRecordNumber: 517222
+              Children:
+              - Name: Dolosigranulum pigrum
+                ConceptType: Species
+                ConceptId: species/dolosigranulum-pigrum
+                ConceptSource: LPSN
+                Id: 1071
+                LpsnRecordNumber: 783747
+            - Name: Granulicatella
+              ConceptType: Genus
+              ConceptId: genus/granulicatella
+              ConceptSource: LPSN
+              Id: 487
+              LpsnRecordNumber: 515722
+              Children:
+              - Name: Granulicatella adiacens
+                ConceptType: Species
+                ConceptId: species/granulicatella-adiacens
+                ConceptSource: LPSN
+                Id: 201
+                LpsnRecordNumber: 776611
+                Synonyms:
+                - Name: Abiotrophia adiacens
+                  ConceptId: species/abiotrophia-adiacens
+                  ConceptSource: LPSN
+                  Id: 1230
+                  LpsnRecordNumber: 772466
+                - Name: Streptococcus adjacens
+                  ConceptId: species/streptococcus-adjacens
+                  ConceptSource: LPSN
+                  Id: 1325
+                  LpsnRecordNumber: 781296
+              - Name: Granulicatella elegans
+                ConceptType: Species
+                ConceptId: species/granulicatella-elegans
+                ConceptSource: LPSN
+                Id: 99
+                LpsnRecordNumber: 776613
+                Synonyms:
+                - Name: Abiotrophia elegans
+                  ConceptId: species/abiotrophia-elegans
+                  ConceptSource: LPSN
+                  Id: 1195
+                  LpsnRecordNumber: 772469
+          - Name: Enterococcaceae
+            ConceptType: Family
+            ConceptId: family/enterococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 483
+            Children:
+            - Name: Enterococcus
+              ConceptType: Genus
+              ConceptId: genus/enterococcus
+              ConceptSource: LPSN
+              Id: 503
+              LpsnRecordNumber: 517033
+              VRE: true
+              Children:
+              - Name: Enterococcus asini
+                ConceptType: Species
+                ConceptId: species/enterococcus-asini
+                ConceptSource: LPSN
+                Id: 196
+                LpsnRecordNumber: 775956
+                VRE: true
+              - Name: Enterococcus avium
+                ConceptType: Species
+                ConceptId: species/enterococcus-avium
+                ConceptSource: LPSN
+                Id: 1720
+                LpsnRecordNumber: 775957
+                VRE: true
+              - Name: Enterococcus canis
+                ConceptType: Species
+                ConceptId: species/enterococcus-canis
+                ConceptSource: LPSN
+                Id: 297
+                LpsnRecordNumber: 775958
+                VRE: true
+              - Name: Enterococcus casseliflavus
+                ConceptType: Species
+                ConceptId: species/enterococcus-casseliflavus
+                ConceptSource: LPSN
+                Id: 2001
+                LpsnRecordNumber: 775959
+                Synonyms:
+                - Name: Enterococcus flavescens
+                  ConceptId: species/enterococcus-flavescens
+                  ConceptSource: LPSN
+                  Id: 2453
+                  LpsnRecordNumber: 775966
+              - Name: Enterococcus cecorum
+                ConceptType: Species
+                ConceptId: species/enterococcus-cecorum
+                ConceptSource: LPSN
+                Id: 369
+                LpsnRecordNumber: 775960
+                VRE: true
+                Synonyms:
+                - Name: Streptococcus cecorum
+                  ConceptId: species/streptococcus-cecorum
+                  ConceptSource: LPSN
+                  Id: 1401
+                  LpsnRecordNumber: 781306
+              - Name: Enterococcus dispar
+                ConceptType: Species
+                ConceptId: species/enterococcus-dispar
+                ConceptSource: LPSN
+                Id: 522
+                LpsnRecordNumber: 775962
+                VRE: true
+              - Name: Enterococcus durans
+                ConceptType: Species
+                ConceptId: species/enterococcus-durans
+                ConceptSource: LPSN
+                Id: 1236
+                LpsnRecordNumber: 775963
+                VRE: true
+                Synonyms:
+                - Name: Streptococcus durans
+                  ConceptId: species/streptococcus-durans
+                  ConceptSource: LPSN
+                  Id: 2027
+                  LpsnRecordNumber: 784980
+              - Name: Enterococcus faecalis
+                ConceptType: Species
+                ConceptId: species/enterococcus-faecalis
+                ConceptSource: LPSN
+                Id: 2345
+                LpsnRecordNumber: 775964
+                VRE: true
+                Synonyms:
+                - Name: Streptococcus faecalis
+                  ConceptId: species/streptococcus-faecalis
+                  ConceptSource: LPSN
+                  Id: 878
+                  LpsnRecordNumber: 781330
+              - Name: Enterococcus faecium
+                ConceptType: Species
+                ConceptId: species/enterococcus-faecium
+                ConceptSource: LPSN
+                Id: 1865
+                LpsnRecordNumber: 775965
+                VRE: true
+                Synonyms:
+                - Name: Streptococcus faecium
+                  ConceptId: species/streptococcus-faecium
+                  ConceptSource: LPSN
+                  Id: 2362
+                  LpsnRecordNumber: 781333
+              - Name: Enterococcus gallinarum
+                ConceptType: Species
+                ConceptId: species/enterococcus-gallinarum
+                ConceptSource: LPSN
+                Id: 1908
+                LpsnRecordNumber: 775967
+                Synonyms:
+                - Name: Streptococcus gallinarum
+                  ConceptId: species/streptococcus-gallinarum
+                  ConceptSource: LPSN
+                  Id: 2410
+                  LpsnRecordNumber: 781336
+              - Name: Enterococcus gilvus
+                ConceptType: Species
+                ConceptId: species/enterococcus-gilvus
+                ConceptSource: LPSN
+                Id: 2213
+                LpsnRecordNumber: 775968
+                VRE: true
+              - Name: Enterococcus haemoperoxidus
+                ConceptType: Species
+                ConceptId: species/enterococcus-haemoperoxidus
+                ConceptSource: LPSN
+                Id: 626
+                LpsnRecordNumber: 775969
+                VRE: true
+              - Name: Enterococcus hermanniensis
+                ConceptType: Species
+                ConceptId: species/enterococcus-hermanniensis
+                ConceptSource: LPSN
+                Id: 2057
+                LpsnRecordNumber: 775970
+                VRE: true
+              - Name: Enterococcus hirae
+                ConceptType: Species
+                ConceptId: species/enterococcus-hirae
+                ConceptSource: LPSN
+                Id: 1339
+                LpsnRecordNumber: 775971
+                VRE: true
+              - Name: Enterococcus italicus
+                ConceptType: Species
+                ConceptId: species/enterococcus-italicus
+                ConceptSource: LPSN
+                Id: 1505
+                LpsnRecordNumber: 775973
+                VRE: true
+                Synonyms:
+                - Name: Enterococcus saccharominimus
+                  ConceptId: species/enterococcus-saccharominimus
+                  ConceptSource: LPSN
+                  Id: 849
+                  LpsnRecordNumber: 783775
+              - Name: Enterococcus malodoratus
+                ConceptType: Species
+                ConceptId: species/enterococcus-malodoratus
+                ConceptSource: LPSN
+                Id: 871
+                LpsnRecordNumber: 775974
+                VRE: true
+              - Name: Enterococcus moraviensis
+                ConceptType: Species
+                ConceptId: species/enterococcus-moraviensis
+                ConceptSource: LPSN
+                Id: 1108
+                LpsnRecordNumber: 775975
+                VRE: true
+              - Name: Enterococcus mundtii
+                ConceptType: Species
+                ConceptId: species/enterococcus-mundtii
+                ConceptSource: LPSN
+                Id: 1780
+                LpsnRecordNumber: 775976
+                VRE: true
+              - Name: Enterococcus pallens
+                ConceptType: Species
+                ConceptId: species/enterococcus-pallens
+                ConceptSource: LPSN
+                Id: 77
+                LpsnRecordNumber: 775977
+                VRE: true
+              - Name: Enterococcus phoeniculicola
+                ConceptType: Species
+                ConceptId: species/enterococcus-phoeniculicola
+                ConceptSource: LPSN
+                Id: 243
+                LpsnRecordNumber: 775978
+                VRE: true
+              - Name: Enterococcus pseudoavium
+                ConceptType: Species
+                ConceptId: species/enterococcus-pseudoavium
+                ConceptSource: LPSN
+                Id: 1320
+                LpsnRecordNumber: 775980
+                VRE: true
+              - Name: Enterococcus raffinosus
+                ConceptType: Species
+                ConceptId: species/enterococcus-raffinosus
+                ConceptSource: LPSN
+                Id: 850
+                LpsnRecordNumber: 775981
+                VRE: true
+              - Name: Enterococcus ratti
+                ConceptType: Species
+                ConceptId: species/enterococcus-ratti
+                ConceptSource: LPSN
+                Id: 865
+                LpsnRecordNumber: 775982
+                VRE: true
+              - Name: Enterococcus saccharolyticus
+                ConceptType: Species
+                ConceptId: species/enterococcus-saccharolyticus
+                ConceptSource: LPSN
+                Id: 303
+                LpsnRecordNumber: 775983
+                VRE: true
+                Synonyms:
+                - Name: Streptococcus saccharolyticus
+                  ConceptId: species/streptococcus-saccharolyticus
+                  ConceptSource: LPSN
+                  Id: 1453
+                  LpsnRecordNumber: 781382
+              - Name: Enterococcus sulfureus
+                ConceptType: Species
+                ConceptId: species/enterococcus-sulfureus
+                ConceptSource: LPSN
+                Id: 908
+                LpsnRecordNumber: 775987
+                VRE: true
+              - Name: Enterococcus villorum
+                ConceptType: Species
+                ConceptId: species/enterococcus-villorum
+                ConceptSource: LPSN
+                Id: 1205
+                LpsnRecordNumber: 775988
+                VRE: true
+            - Name: Tetragenococcus
+              ConceptType: Genus
+              ConceptId: genus/tetragenococcus
+              ConceptSource: LPSN
+              Id: 2158
+              LpsnRecordNumber: 516757
+              Children:
+              - Name: Tetragenococcus halophilus
+                ConceptType: Species
+                ConceptId: species/tetragenococcus-halophilus
+                ConceptSource: LPSN
+                Id: 629
+                LpsnRecordNumber: 782430
+              - Name: Tetragenococcus solitarius
+                ConceptType: Species
+                ConceptId: species/tetragenococcus-solitarius
+                ConceptSource: LPSN
+                Id: 2292
+                LpsnRecordNumber: 782433
+                Synonyms:
+                - Name: Enterococcus solitarius
+                  ConceptId: species/enterococcus-solitarius
+                  ConceptSource: LPSN
+                  Id: 750
+                  LpsnRecordNumber: 775985
+            - Name: Vagococcus
+              ConceptType: Genus
+              ConceptId: genus/vagococcus
+              ConceptSource: LPSN
+              Id: 1936
+              LpsnRecordNumber: 516889
+              Children:
+              - Name: Vagococcus fluvialis
+                ConceptType: Species
+                ConceptId: species/vagococcus-fluvialis
+                ConceptSource: LPSN
+                Id: 2200
+                LpsnRecordNumber: 782940
+          - Name: Lactobacillaceae
+            ConceptType: Family
+            ConceptId: family/lactobacillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 728
+            Children:
+            - Name: Lacticaseibacillus
+              ConceptType: Genus
+              ConceptId: genus/lacticaseibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 10543
+              Children:
+              - Name: Lacticaseibacillus casei
+                ConceptType: Species
+                ConceptId: species/lacticaseibacillus-casei
+                ConceptSource: LPSN
+                Id: 3027
+                LpsnRecordNumber: 10711
+                Synonyms:
+                - Name: Lactobacillus casei
+                  ConceptId: species/lactobacillus-casei
+                  ConceptSource: LPSN
+                  Id: 551
+                  LpsnRecordNumber: 777268
+              - Name: Lacticaseibacillus paracasei
+                ConceptType: Species
+                ConceptId: species/lacticaseibacillus-paracasei
+                ConceptSource: LPSN
+                Id: 2994
+                LpsnRecordNumber: 10793
+                Synonyms:
+                - Name: Lactobacillus paracasei
+                  ConceptId: species/lactobacillus-paracasei
+                  ConceptSource: LPSN
+                  Id: 462
+                  LpsnRecordNumber: 784066
+            - Name: Lactiplantibacillus
+              ConceptType: Genus
+              ConceptId: genus/lactiplantibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 10492
+              Children:
+              - Name: Lactiplantibacillus plantarum
+                ConceptType: Species
+                ConceptId: species/lactiplantibacillus-plantarum
+                ConceptSource: LPSN
+                Id: 3157
+                LpsnRecordNumber: 10708
+                Synonyms:
+                - Name: Lactobacillus arizonensis
+                  ConceptId: species/lactobacillus-arizonensis
+                  ConceptSource: LPSN
+                  Id: 279
+                  LpsnRecordNumber: 777255
+                - Name: Lactobacillus plantarum
+                  ConceptId: species/lactobacillus-plantarum
+                  ConceptSource: LPSN
+                  Id: 1986
+                  LpsnRecordNumber: 777375
+            - Name: Lactobacillus
+              ConceptType: Genus
+              ConceptId: genus/lactobacillus
+              ConceptSource: LPSN
+              Id: 314
+              LpsnRecordNumber: 517058
+              Children:
+              - Name: Lactobacillus acidophilus
+                ConceptType: Species
+                ConceptId: species/lactobacillus-acidophilus
+                ConceptSource: LPSN
+                Id: 286
+                LpsnRecordNumber: 777244
+              - Name: Lactobacillus amylovorus
+                ConceptType: Species
+                ConceptId: species/lactobacillus-amylovorus
+                ConceptSource: LPSN
+                Id: 559
+                LpsnRecordNumber: 777250
+              - Name: Lactobacillus crispatus
+                ConceptType: Species
+                ConceptId: species/lactobacillus-crispatus
+                ConceptSource: LPSN
+                Id: 367
+                LpsnRecordNumber: 777285
+              - Name: Lactobacillus delbrueckii
+                ConceptType: Species
+                ConceptId: species/lactobacillus-delbrueckii
+                ConceptSource: LPSN
+                Id: 2426
+                LpsnRecordNumber: 777291
+              - Name: Lactobacillus gasseri
+                ConceptType: Species
+                ConceptId: species/lactobacillus-gasseri
+                ConceptSource: LPSN
+                Id: 816
+                LpsnRecordNumber: 777311
+              - Name: Lactobacillus iners
+                ConceptType: Species
+                ConceptId: species/lactobacillus-iners
+                ConceptSource: LPSN
+                Id: 259
+                LpsnRecordNumber: 777324
+              - Name: Lactobacillus jensenii
+                ConceptType: Species
+                ConceptId: species/lactobacillus-jensenii
+                ConceptSource: LPSN
+                Id: 1679
+                LpsnRecordNumber: 777327
+              - Name: Lactobacillus johnsonii
+                ConceptType: Species
+                ConceptId: species/lactobacillus-johnsonii
+                ConceptSource: LPSN
+                Id: 1110
+                LpsnRecordNumber: 777328
+              - Name: Lactobacillus kalixensis
+                ConceptType: Species
+                ConceptId: species/lactobacillus-kalixensis
+                ConceptSource: LPSN
+                Id: 1043
+                LpsnRecordNumber: 777329
+              - Name: Lactobacillus rhamnosus
+                ConceptType: Species
+                ConceptId: species/lactobacillus-rhamnosus
+                ConceptSource: LPSN
+                Id: 2221
+                LpsnRecordNumber: 777383
+                Synonyms:
+                - Name: Lacticaseibacillus rhamnosus
+                  ConceptId: species/lacticaseibacillus-rhamnosus
+                  ConceptSource: LPSN
+                  Id: 3277
+                  LpsnRecordNumber: 10740
+              - Name: Lactobacillus ultunensis
+                ConceptType: Species
+                ConceptId: species/lactobacillus-ultunensis
+                ConceptSource: LPSN
+                Id: 2156
+                LpsnRecordNumber: 777404
+            - Name: Latilactobacillus
+              ConceptType: Genus
+              ConceptId: genus/latilactobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 10544
+              Children:
+              - Name: Latilactobacillus sakei
+                ConceptType: Species
+                ConceptId: species/latilactobacillus-sakei
+                ConceptSource: LPSN
+                Id: 3268
+                LpsnRecordNumber: 10710
+                Synonyms:
+                - Name: Lactobacillus sakei
+                  ConceptId: species/lactobacillus-sakei
+                  ConceptSource: LPSN
+                  Id: 1342
+                  LpsnRecordNumber: 777388
+            - Name: Lentilactobacillus
+              ConceptType: Genus
+              ConceptId: genus/lentilactobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 10545
+              Children:
+              - Name: Lentilactobacillus buchneri
+                ConceptType: Species
+                ConceptId: species/lentilactobacillus-buchneri
+                ConceptSource: LPSN
+                Id: 3167
+                LpsnRecordNumber: 10715
+                Synonyms:
+                - Name: Lactobacillus buchneri
+                  ConceptId: species/lactobacillus-buchneri
+                  ConceptSource: LPSN
+                  Id: 2185
+                  LpsnRecordNumber: 777265
+            - Name: Leuconostoc
+              ConceptType: Genus
+              ConceptId: genus/leuconostoc
+              ConceptSource: LPSN
+              Id: 2366
+              LpsnRecordNumber: 18094
+              Children:
+              - Name: Leuconostoc citreum
+                ConceptType: Species
+                ConceptId: species/leuconostoc-citreum
+                ConceptSource: LPSN
+                Id: 2545
+                LpsnRecordNumber: 777537
+                Synonyms:
+                - Name: Leuconostoc amelibiosum
+                  ConceptId: species/leuconostoc-amelibiosum
+                  ConceptSource: LPSN
+                  Id: 1033
+                  LpsnRecordNumber: 777534
+              - Name: Leuconostoc lactis
+                ConceptType: Species
+                ConceptId: species/leuconostoc-lactis
+                ConceptSource: LPSN
+                Id: 1147
+                LpsnRecordNumber: 777548
+              - Name: Leuconostoc mesenteroides
+                ConceptType: Species
+                ConceptId: species/leuconostoc-mesenteroides
+                ConceptSource: LPSN
+                Id: 1258
+                LpsnRecordNumber: 777549
+              - Name: Leuconostoc pseudomesenteroides
+                ConceptType: Species
+                ConceptId: species/leuconostoc-pseudomesenteroides
+                ConceptSource: LPSN
+                Id: 1060
+                LpsnRecordNumber: 777558
+            - Name: Levilactobacillus
+              ConceptType: Genus
+              ConceptId: genus/levilactobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 9197
+              Children:
+              - Name: Levilactobacillus brevis
+                ConceptType: Species
+                ConceptId: species/levilactobacillus-brevis
+                ConceptSource: LPSN
+                Id: 3227
+                LpsnRecordNumber: 10875
+                Synonyms:
+                - Name: Lactobacillus brevis
+                  ConceptId: species/lactobacillus-brevis
+                  ConceptSource: LPSN
+                  Id: 2429
+                  LpsnRecordNumber: 777263
+            - Name: Ligilactobacillus
+              ConceptType: Genus
+              ConceptId: genus/ligilactobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 10546
+              Children:
+              - Name: Ligilactobacillus salivarius
+                ConceptType: Species
+                ConceptId: species/ligilactobacillus-salivarius
+                ConceptSource: LPSN
+                Id: 3234
+                LpsnRecordNumber: 10714
+                Synonyms:
+                - Name: Lactobacillus salivarius
+                  ConceptId: species/lactobacillus-salivarius
+                  ConceptSource: LPSN
+                  Id: 1442
+                  LpsnRecordNumber: 784072
+            - Name: Limosilactobacillus
+              ConceptType: Genus
+              ConceptId: genus/limosilactobacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 10508
+              Children:
+              - Name: Limosilactobacillus antri
+                ConceptType: Species
+                ConceptId: species/limosilactobacillus-antri
+                ConceptSource: LPSN
+                Id: 3318
+                LpsnRecordNumber: 10730
+                Synonyms:
+                - Name: Lactobacillus antri
+                  ConceptId: species/lactobacillus-antri
+                  ConceptSource: LPSN
+                  Id: 515
+                  LpsnRecordNumber: 777252
+              - Name: Limosilactobacillus fermentum
+                ConceptType: Species
+                ConceptId: species/limosilactobacillus-fermentum
+                ConceptSource: LPSN
+                Id: 3094
+                LpsnRecordNumber: 10741
+                Synonyms:
+                - Name: Lactobacillus cellobiosus
+                  ConceptId: species/lactobacillus-cellobiosus
+                  ConceptSource: LPSN
+                  Id: 552
+                  LpsnRecordNumber: 777277
+                - Name: Lactobacillus fermentum
+                  ConceptId: species/lactobacillus-fermentum
+                  ConceptSource: LPSN
+                  Id: 1299
+                  LpsnRecordNumber: 777303
+              - Name: Limosilactobacillus gastricus
+                ConceptType: Species
+                ConceptId: species/limosilactobacillus-gastricus
+                ConceptSource: LPSN
+                Id: 3133
+                LpsnRecordNumber: 10761
+                Synonyms:
+                - Name: Lactobacillus gastricus
+                  ConceptId: species/lactobacillus-gastricus
+                  ConceptSource: LPSN
+                  Id: 2310
+                  LpsnRecordNumber: 777312
+              - Name: Limosilactobacillus oris
+                ConceptType: Species
+                ConceptId: species/limosilactobacillus-oris
+                ConceptSource: LPSN
+                Id: 2997
+                LpsnRecordNumber: 10787
+                Synonyms:
+                - Name: Lactobacillus oris
+                  ConceptId: species/lactobacillus-oris
+                  ConceptSource: LPSN
+                  Id: 1399
+                  LpsnRecordNumber: 777356
+              - Name: Limosilactobacillus reuteri
+                ConceptType: Species
+                ConceptId: species/limosilactobacillus-reuteri
+                ConceptSource: LPSN
+                Id: 3309
+                LpsnRecordNumber: 10805
+                Synonyms:
+                - Name: Lactobacillus reuteri
+                  ConceptId: species/lactobacillus-reuteri
+                  ConceptSource: LPSN
+                  Id: 428
+                  LpsnRecordNumber: 777382
+              - Name: Limosilactobacillus vaginalis
+                ConceptType: Species
+                ConceptId: species/limosilactobacillus-vaginalis
+                ConceptSource: LPSN
+                Id: 3199
+                LpsnRecordNumber: 10824
+                Synonyms:
+                - Name: Lactobacillus vaginalis
+                  ConceptId: species/lactobacillus-vaginalis
+                  ConceptSource: LPSN
+                  Id: 703
+                  LpsnRecordNumber: 777406
+            - Name: Pediococcus
+              ConceptType: Genus
+              ConceptId: genus/pediococcus
+              ConceptSource: LPSN
+              Id: 1100
+              LpsnRecordNumber: 516274
+              Children:
+              - Name: Pediococcus acidilactici
+                ConceptType: Species
+                ConceptId: species/pediococcus-acidilactici
+                ConceptSource: LPSN
+                Id: 937
+                LpsnRecordNumber: 779204
+              - Name: Pediococcus pentosaceus
+                ConceptType: Species
+                ConceptId: species/pediococcus-pentosaceus
+                ConceptSource: LPSN
+                Id: 844
+                LpsnRecordNumber: 779214
+            - Name: Weissella
+              ConceptType: Genus
+              ConceptId: genus/weissella
+              ConceptSource: LPSN
+              Id: 1253
+              LpsnRecordNumber: 517159
+              Children:
+              - Name: Weissella confusa
+                ConceptType: Species
+                ConceptId: species/weissella-confusa
+                ConceptSource: LPSN
+                Id: 1464
+                LpsnRecordNumber: 783090
+                Synonyms:
+                - Name: Lactobacillus confusus
+                  ConceptId: species/lactobacillus-confusus
+                  ConceptSource: LPSN
+                  Id: 305
+                  LpsnRecordNumber: 777282
+          - Name: Streptococcaceae
+            ConceptType: Family
+            ConceptId: family/streptococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1344
+            Children:
+            - Name: Lactococcus
+              ConceptType: Genus
+              ConceptId: genus/lactococcus
+              ConceptSource: LPSN
+              Id: 1245
+              LpsnRecordNumber: 517059
+              Children:
+              - Name: Lactococcus garvieae
+                ConceptType: Species
+                ConceptId: species/lactococcus-garvieae
+                ConceptSource: LPSN
+                Id: 374
+                LpsnRecordNumber: 777418
+                Synonyms:
+                - Name: Enterococcus seriolicida
+                  ConceptId: species/enterococcus-seriolicida
+                  ConceptSource: LPSN
+                  Id: 2302
+                  LpsnRecordNumber: 775984
+              - Name: Lactococcus lactis
+                ConceptType: Species
+                ConceptId: species/lactococcus-lactis
+                ConceptSource: LPSN
+                Id: 1887
+                LpsnRecordNumber: 777420
+                Synonyms:
+                - Name: Streptococcus lactis
+                  ConceptId: species/streptococcus-lactis
+                  ConceptSource: LPSN
+                  Id: 379
+                  LpsnRecordNumber: 781353
+            - Name: Streptococcus
+              ConceptType: Genus
+              ConceptId: genus/streptococcus
+              ConceptSource: LPSN
+              Id: 1642
+              LpsnRecordNumber: 517118
+              Children:
+              - Name: Alpha-hemolytic streptococci
+                ConceptType: Group
+                ConceptId: Alpha-hemolytic streptococci
+                ConceptSource: NeoIPC
+                Id: 2795
+              - Name: Beta-hemolytic streptococci
+                ConceptType: Group
+                ConceptId: Beta-hemolytic streptococci
+                ConceptSource: NeoIPC
+                Id: 2796
+              - Name: Gamma-hemolytic streptococci
+                ConceptType: Group
+                ConceptId: Gamma-hemolytic streptococci
+                ConceptSource: NeoIPC
+                Id: 2797
+              - Name: Viridans streptococci
+                ConceptType: Group
+                ConceptId: 68
+                ConceptSource: NeoIPC
+                Id: 2798
+                Children:
+                - Name: Streptococcus anginosus group
+                  ConceptType: Group
+                  ConceptId: 69
+                  ConceptSource: NeoIPC
+                  Id: 2799
+                  Children:
+                  - Name: Streptococcus anginosus
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-anginosus
+                    ConceptSource: LPSN
+                    Id: 1711
+                    LpsnRecordNumber: 781299
+                    CommonCommensal: true
+                  - Name: Streptococcus constellatus
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-constellatus
+                    ConceptSource: LPSN
+                    Id: 751
+                    LpsnRecordNumber: 784976
+                    CommonCommensal: true
+                    Children:
+                    - Name: Streptococcus constellatus subsp. constellatus
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-constellatus-constellatus
+                      ConceptSource: LPSN
+                      Id: 2203
+                      LpsnRecordNumber: 781308
+                      CommonCommensal: true
+                    - Name: Streptococcus constellatus subsp. pharyngis
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-constellatus-pharyngis
+                      ConceptSource: LPSN
+                      Id: 918
+                      LpsnRecordNumber: 781309
+                      CommonCommensal: true
+                  - Name: Streptococcus intermedius
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-intermedius
+                    ConceptSource: LPSN
+                    Id: 802
+                    LpsnRecordNumber: 781351
+                    CommonCommensal: true
+                  Synonyms:
+                  - Name: Streptococcus milleri group
+                    ConceptId: "70"
+                    ConceptSource: NeoIPC
+                    Id: 2800
+                - Name: Streptococcus bovis group
+                  ConceptType: Group
+                  ConceptId: 71
+                  ConceptSource: NeoIPC
+                  Id: 2801
+                  Children:
+                  - Name: Streptococcus equinus
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-equinus
+                    ConceptSource: LPSN
+                    Id: 2323
+                    LpsnRecordNumber: 781328
+                    CommonCommensal: true
+                    Synonyms:
+                    - Name: Streptococcus bovis
+                      ConceptId: species/streptococcus-bovis
+                      ConceptSource: LPSN
+                      Id: 2783
+                      LpsnRecordNumber: 781302
+                  - Name: Streptococcus gallolyticus
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-gallolyticus
+                    ConceptSource: LPSN
+                    Id: 1163
+                    LpsnRecordNumber: 781337
+                    CommonCommensal: true
+                    Children:
+                    - Name: Streptococcus gallolyticus subsp. gallolyticus
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-gallolyticus-gallolyticus
+                      ConceptSource: LPSN
+                      Id: 1390
+                      LpsnRecordNumber: 781338
+                      CommonCommensal: true
+                    - Name: Streptococcus gallolyticus subsp. macedonicus
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-gallolyticus-macedonicus
+                      ConceptSource: LPSN
+                      Id: 1201
+                      LpsnRecordNumber: 781339
+                      CommonCommensal: true
+                    - Name: Streptococcus gallolyticus subsp. pasteurianus
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-gallolyticus-pasteurianus
+                      ConceptSource: LPSN
+                      Id: 1613
+                      LpsnRecordNumber: 781340
+                      CommonCommensal: true
+                      Synonyms:
+                      - Name: Streptococcus pasteurianus
+                        ConceptId: species/streptococcus-pasteurianus
+                        ConceptSource: LPSN
+                        Id: 1894
+                        LpsnRecordNumber: 781371
+                    Synonyms:
+                    - Name: Streptococcus caprinus
+                      ConceptId: species/streptococcus-caprinus
+                      ConceptSource: LPSN
+                      Id: 2256
+                      LpsnRecordNumber: 784975
+                  - Name: Streptococcus infantarius
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-infantarius
+                    ConceptSource: LPSN
+                    Id: 1783
+                    LpsnRecordNumber: 784982
+                    CommonCommensal: true
+                    Children:
+                    - Name: Streptococcus infantarius subsp. coli
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-infantarius-coli
+                      ConceptSource: LPSN
+                      Id: 2338
+                      LpsnRecordNumber: 784983
+                      CommonCommensal: true
+                    - Name: Streptococcus infantarius subsp. infantarius
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-infantarius-infantarius
+                      ConceptSource: LPSN
+                      Id: 1514
+                      LpsnRecordNumber: 784984
+                      CommonCommensal: true
+                - Name: Streptococcus mitis group
+                  ConceptType: Group
+                  ConceptId: 72
+                  ConceptSource: NeoIPC
+                  Id: 2802
+                  Children:
+                  - Name: Streptococcus cristatus
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-cristatus
+                    ConceptSource: LPSN
+                    Id: 1583
+                    LpsnRecordNumber: 781313
+                    CommonCommensal: true
+                    Synonyms:
+                    - Name: Streptococcus oligofermentans
+                      ConceptId: species/streptococcus-oligofermentans
+                      ConceptSource: LPSN
+                      Id: 501
+                      LpsnRecordNumber: 784988
+                  - Name: Streptococcus infantis
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-infantis
+                    ConceptSource: LPSN
+                    Id: 1470
+                    LpsnRecordNumber: 781349
+                    CommonCommensal: true
+                  - Name: Streptococcus mitis
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-mitis
+                    ConceptSource: LPSN
+                    Id: 668
+                    LpsnRecordNumber: 781361
+                    CommonCommensal: true
+                  - Name: Streptococcus oralis
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-oralis
+                    ConceptSource: LPSN
+                    Id: 1066
+                    LpsnRecordNumber: 781364
+                    CommonCommensal: true
+                    Children:
+                    - Name: Streptococcus oralis subsp. dentisani
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-oralis-dentisani
+                      ConceptSource: LPSN
+                      Id: 3064
+                      LpsnRecordNumber: 794814
+                      CommonCommensal: true
+                      Synonyms:
+                      - Name: Streptococcus dentisani
+                        ConceptId: species/streptococcus-dentisani
+                        ConceptSource: LPSN
+                        Id: 2131
+                        LpsnRecordNumber: 791468
+                    - Name: Streptococcus oralis subsp. tigurinus
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-oralis-tigurinus
+                      ConceptSource: LPSN
+                      Id: 3179
+                      LpsnRecordNumber: 794815
+                      CommonCommensal: true
+                      Synonyms:
+                      - Name: Streptococcus tigurinus
+                        ConceptId: species/streptococcus-tigurinus
+                        ConceptSource: LPSN
+                        Id: 2038
+                        LpsnRecordNumber: 790334
+                  - Name: Streptococcus peroris
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-peroris
+                    ConceptSource: LPSN
+                    Id: 1932
+                    LpsnRecordNumber: 781372
+                    CommonCommensal: true
+                  - Name: Streptococcus pseudopneumoniae
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-pseudopneumoniae
+                    ConceptSource: LPSN
+                    Id: 261
+                    LpsnRecordNumber: 784991
+                    CommonCommensal: true
+                - Name: Streptococcus mutans group
+                  ConceptType: Group
+                  ConceptId: 73
+                  ConceptSource: NeoIPC
+                  Id: 2803
+                  Children:
+                  - Name: Streptococcus hyovaginalis
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-hyovaginalis
+                    ConceptSource: LPSN
+                    Id: 2004
+                    LpsnRecordNumber: 781348
+                    CommonCommensal: true
+                  - Name: Streptococcus mutans
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-mutans
+                    ConceptSource: LPSN
+                    Id: 621
+                    LpsnRecordNumber: 781363
+                    CommonCommensal: true
+                  - Name: Streptococcus ratti
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-ratti
+                    ConceptSource: LPSN
+                    Id: 1818
+                    LpsnRecordNumber: 781381
+                    CommonCommensal: true
+                  - Name: Streptococcus sobrinus
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-sobrinus
+                    ConceptSource: LPSN
+                    Id: 226
+                    LpsnRecordNumber: 781387
+                    CommonCommensal: true
+                - Name: Streptococcus salivarius group
+                  ConceptType: Group
+                  ConceptId: 74
+                  ConceptSource: NeoIPC
+                  Id: 2804
+                  Children:
+                  - Name: Streptococcus salivarius
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-salivarius
+                    ConceptSource: LPSN
+                    Id: 1126
+                    LpsnRecordNumber: 781383
+                    CommonCommensal: true
+                    Children:
+                    - Name: Streptococcus salivarius subsp. salivarius
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-salivarius-salivarius
+                      ConceptSource: LPSN
+                      Id: 1882
+                      LpsnRecordNumber: 788218
+                      CommonCommensal: true
+                    - Name: Streptococcus salivarius subsp. thermophilus
+                      ConceptType: Subspecies
+                      ConceptId: subspecies/streptococcus-salivarius-thermophilus
+                      ConceptSource: LPSN
+                      Id: 2132
+                      LpsnRecordNumber: 781384
+                      CommonCommensal: true
+                      Synonyms:
+                      - Name: Streptococcus thermophilus
+                        ConceptId: species/streptococcus-thermophilus
+                        ConceptSource: LPSN
+                        Id: 2175
+                        LpsnRecordNumber: 781390
+                  - Name: Streptococcus vestibularis
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-vestibularis
+                    ConceptSource: LPSN
+                    Id: 867
+                    LpsnRecordNumber: 781394
+                    CommonCommensal: true
+                - Name: Streptococcus sanguinis group
+                  ConceptType: Group
+                  ConceptId: 75
+                  ConceptSource: NeoIPC
+                  Id: 2805
+                  Children:
+                  - Name: Streptococcus gordonii
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-gordonii
+                    ConceptSource: LPSN
+                    Id: 388
+                    LpsnRecordNumber: 781342
+                    CommonCommensal: true
+                  - Name: Streptococcus parasanguinis
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-parasanguinis
+                    ConceptSource: LPSN
+                    Id: 764
+                    LpsnRecordNumber: 781368
+                    CommonCommensal: true
+                  - Name: Streptococcus sanguinis
+                    ConceptType: Species
+                    ConceptId: species/streptococcus-sanguinis
+                    ConceptSource: LPSN
+                    Id: 537
+                    LpsnRecordNumber: 781385
+                    CommonCommensal: true
+                    Synonyms:
+                    - Name: Streptococcus sanguis
+                      ConceptId: species/streptococcus-sanguis
+                      ConceptSource: LPSN
+                      Id: 2792
+                      LpsnRecordNumber: 784993
+              - Name: Streptococcus acidominimus
+                ConceptType: Species
+                ConceptId: species/streptococcus-acidominimus
+                ConceptSource: LPSN
+                Id: 474
+                LpsnRecordNumber: 781295
+              - Name: Streptococcus agalactiae
+                ConceptType: Species
+                ConceptId: species/streptococcus-agalactiae
+                ConceptSource: LPSN
+                Id: 2600
+                LpsnRecordNumber: 781297
+                Synonyms:
+                - Name: Group B streptococcus
+                  ConceptId: "4"
+                  ConceptSource: NeoIPC
+                  Id: 2602
+              - Name: Streptococcus alactolyticus
+                ConceptType: Species
+                ConceptId: species/streptococcus-alactolyticus
+                ConceptSource: LPSN
+                Id: 2255
+                LpsnRecordNumber: 781298
+                CommonCommensal: true
+                Synonyms:
+                - Name: Streptococcus intestinalis
+                  ConceptId: species/streptococcus-intestinalis
+                  ConceptSource: LPSN
+                  Id: 1537
+                  LpsnRecordNumber: 781352
+              - Name: Streptococcus australis
+                ConceptType: Species
+                ConceptId: species/streptococcus-australis
+                ConceptSource: LPSN
+                Id: 2488
+                LpsnRecordNumber: 781300
+                CommonCommensal: true
+              - Name: Streptococcus canis
+                ConceptType: Species
+                ConceptId: species/streptococcus-canis
+                ConceptSource: LPSN
+                Id: 2405
+                LpsnRecordNumber: 781303
+              - Name: Streptococcus criceti
+                ConceptType: Species
+                ConceptId: species/streptococcus-criceti
+                ConceptSource: LPSN
+                Id: 644
+                LpsnRecordNumber: 781311
+                CommonCommensal: true
+              - Name: Streptococcus devriesei
+                ConceptType: Species
+                ConceptId: species/streptococcus-devriesei
+                ConceptSource: LPSN
+                Id: 2784
+                LpsnRecordNumber: 784978
+                CommonCommensal: true
+              - Name: Streptococcus downei
+                ConceptType: Species
+                ConceptId: species/streptococcus-downei
+                ConceptSource: LPSN
+                Id: 289
+                LpsnRecordNumber: 781319
+                CommonCommensal: true
+              - Name: Streptococcus dysgalactiae
+                ConceptType: Species
+                ConceptId: species/streptococcus-dysgalactiae
+                ConceptSource: LPSN
+                Id: 1701
+                LpsnRecordNumber: 781320
+                Children:
+                - Name: Streptococcus dysgalactiae subsp. dysgalactiae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/streptococcus-dysgalactiae-dysgalactiae
+                  ConceptSource: LPSN
+                  Id: 1751
+                  LpsnRecordNumber: 781321
+                - Name: Streptococcus dysgalactiae subsp. equisimilis
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/streptococcus-dysgalactiae-equisimilis
+                  ConceptSource: LPSN
+                  Id: 744
+                  LpsnRecordNumber: 781322
+              - Name: Streptococcus entericus
+                ConceptType: Species
+                ConceptId: species/streptococcus-entericus
+                ConceptSource: LPSN
+                Id: 1479
+                LpsnRecordNumber: 781323
+              - Name: Streptococcus equi
+                ConceptType: Species
+                ConceptId: species/streptococcus-equi
+                ConceptSource: LPSN
+                Id: 2493
+                LpsnRecordNumber: 781324
+                Children:
+                - Name: Streptococcus equi subsp. equi
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/streptococcus-equi-equi
+                  ConceptSource: LPSN
+                  Id: 2153
+                  LpsnRecordNumber: 781325
+                - Name: Streptococcus equi subsp. zooepidemicus
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/streptococcus-equi-zooepidemicus
+                  ConceptSource: LPSN
+                  Id: 148
+                  LpsnRecordNumber: 781327
+              - Name: Streptococcus ferus
+                ConceptType: Species
+                ConceptId: species/streptococcus-ferus
+                ConceptSource: LPSN
+                Id: 1313
+                LpsnRecordNumber: 781334
+                CommonCommensal: true
+              - Name: Streptococcus gallinaceus
+                ConceptType: Species
+                ConceptId: species/streptococcus-gallinaceus
+                ConceptSource: LPSN
+                Id: 2785
+                LpsnRecordNumber: 781335
+                CommonCommensal: true
+              - Name: Streptococcus halichoeri
+                ConceptType: Species
+                ConceptId: species/streptococcus-halichoeri
+                ConceptSource: LPSN
+                Id: 2786
+                LpsnRecordNumber: 781344
+              - Name: Streptococcus hongkongensis
+                ConceptType: Species
+                ConceptId: species/streptococcus-hongkongensis
+                ConceptSource: LPSN
+                Id: 2787
+                LpsnRecordNumber: 790926
+              - Name: Streptococcus iniae
+                ConceptType: Species
+                ConceptId: species/streptococcus-iniae
+                ConceptSource: LPSN
+                Id: 2222
+                LpsnRecordNumber: 781350
+                Synonyms:
+                - Name: Streptococcus shiloi
+                  ConceptId: species/streptococcus-shiloi
+                  ConceptSource: LPSN
+                  Id: 650
+                  LpsnRecordNumber: 784994
+              - Name: Streptococcus lactarius
+                ConceptType: Species
+                ConceptId: species/streptococcus-lactarius
+                ConceptSource: LPSN
+                Id: 2788
+                LpsnRecordNumber: 789217
+                CommonCommensal: true
+              - Name: Streptococcus lutetiensis
+                ConceptType: Species
+                ConceptId: species/streptococcus-lutetiensis
+                ConceptSource: LPSN
+                Id: 1661
+                LpsnRecordNumber: 781355
+                CommonCommensal: true
+              - Name: Streptococcus macacae
+                ConceptType: Species
+                ConceptId: species/streptococcus-macacae
+                ConceptSource: LPSN
+                Id: 2391
+                LpsnRecordNumber: 781356
+                CommonCommensal: true
+              - Name: Streptococcus massiliensis
+                ConceptType: Species
+                ConceptId: species/streptococcus-massiliensis
+                ConceptSource: LPSN
+                Id: 2789
+                LpsnRecordNumber: 784987
+              - Name: Streptococcus merionis
+                ConceptType: Species
+                ConceptId: species/streptococcus-merionis
+                ConceptSource: LPSN
+                Id: 2790
+                LpsnRecordNumber: 787808
+              - Name: Streptococcus minor
+                ConceptType: Species
+                ConceptId: species/streptococcus-minor
+                ConceptSource: LPSN
+                Id: 2791
+                LpsnRecordNumber: 781360
+                CommonCommensal: true
+              - Name: Streptococcus ovis
+                ConceptType: Species
+                ConceptId: species/streptococcus-ovis
+                ConceptSource: LPSN
+                Id: 217
+                LpsnRecordNumber: 781366
+              - Name: Streptococcus parauberis
+                ConceptType: Species
+                ConceptId: species/streptococcus-parauberis
+                ConceptSource: LPSN
+                Id: 1981
+                LpsnRecordNumber: 781369
+              - Name: Streptococcus pluranimalium
+                ConceptType: Species
+                ConceptId: species/streptococcus-pluranimalium
+                ConceptSource: LPSN
+                Id: 98
+                LpsnRecordNumber: 781376
+              - Name: Streptococcus pneumoniae
+                ConceptType: Species
+                ConceptId: species/streptococcus-pneumoniae
+                ConceptSource: LPSN
+                Id: 126
+                LpsnRecordNumber: 781377
+              - Name: Streptococcus porcinus
+                ConceptType: Species
+                ConceptId: species/streptococcus-porcinus
+                ConceptSource: LPSN
+                Id: 450
+                LpsnRecordNumber: 781378
+              - Name: Streptococcus pseudoporcinus
+                ConceptType: Species
+                ConceptId: species/streptococcus-pseudoporcinus
+                ConceptSource: LPSN
+                Id: 1792
+                LpsnRecordNumber: 785273
+              - Name: Streptococcus pyogenes
+                ConceptType: Species
+                ConceptId: species/streptococcus-pyogenes
+                ConceptSource: LPSN
+                Id: 1599
+                LpsnRecordNumber: 781379
+                Synonyms:
+                - Name: Group A streptococcus
+                  ConceptId: "3"
+                  ConceptSource: NeoIPC
+                  Id: 2601
+              - Name: Streptococcus sinensis
+                ConceptType: Species
+                ConceptId: species/streptococcus-sinensis
+                ConceptSource: LPSN
+                Id: 1011
+                LpsnRecordNumber: 781386
+                CommonCommensal: true
+              - Name: Streptococcus suis
+                ConceptType: Species
+                ConceptId: species/streptococcus-suis
+                ConceptSource: LPSN
+                Id: 1025
+                LpsnRecordNumber: 781389
+              - Name: Streptococcus thoraltensis
+                ConceptType: Species
+                ConceptId: species/streptococcus-thoraltensis
+                ConceptSource: LPSN
+                Id: 2793
+                LpsnRecordNumber: 781391
+                CommonCommensal: true
+              - Name: Streptococcus uberis
+                ConceptType: Species
+                ConceptId: species/streptococcus-uberis
+                ConceptSource: LPSN
+                Id: 1094
+                LpsnRecordNumber: 781392
+              - Name: Streptococcus urinalis
+                ConceptType: Species
+                ConceptId: species/streptococcus-urinalis
+                ConceptSource: LPSN
+                Id: 2794
+                LpsnRecordNumber: 781393
+      - Name: Clostridia
+        ConceptType: Class
+        ConceptId: class/clostridia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 4793
+        Children:
+        - Name: Eubacteriales
+          ConceptType: Order
+          ConceptId: order/eubacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5019
+          Children:
+          - Name: Christensenellaceae
+            ConceptType: Family
+            ConceptId: family/christensenellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1935
+            Children:
+            - Name: Catabacter
+              ConceptType: Genus
+              ConceptId: genus/catabacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517521
+              Children:
+              - Name: Catabacter hongkongensis
+                ConceptType: Species
+                ConceptId: species/catabacter-hongkongensis
+                ConceptSource: LPSN
+                Id: 1823
+                LpsnRecordNumber: 798690
+                Synonyms:
+                - Name: Christensenella hongkongensis
+                  ConceptId: species/christensenella-hongkongensis
+                  ConceptSource: LPSN
+                  Id: 3163
+                  LpsnRecordNumber: 2988
+            - Name: Christensenella
+              ConceptType: Genus
+              ConceptId: genus/christensenella
+              ConceptSource: LPSN
+              Id: 3020
+              LpsnRecordNumber: 518159
+              Synonyms:
+              - Name: Catabacter
+                ConceptId: genus/catabacter
+                ConceptSource: LPSN
+                Id: 1101
+                LpsnRecordNumber: 517521
+          - Name: Clostridiaceae
+            ConceptType: Family
+            ConceptId: family/clostridiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 328
+            Children:
+            - Name: Clostridium
+              ConceptType: Genus
+              ConceptId: genus/clostridium
+              ConceptSource: LPSN
+              Id: 1098
+              LpsnRecordNumber: 517000
+              Children:
+              - Name: Clostridium argentinense
+                ConceptType: Species
+                ConceptId: species/clostridium-argentinense
+                ConceptSource: LPSN
+                Id: 2278
+                LpsnRecordNumber: 783657
+              - Name: Clostridium baratii
+                ConceptType: Species
+                ConceptId: species/clostridium-baratii
+                ConceptSource: LPSN
+                Id: 1511
+                LpsnRecordNumber: 774832
+                Synonyms:
+                - Name: Clostridium barati
+                  ConceptId: species/clostridium-barati
+                  ConceptSource: LPSN
+                  Id: 1990
+                  LpsnRecordNumber: 783658
+                - Name: Clostridium paraperfringens
+                  ConceptId: species/clostridium-paraperfringens
+                  ConceptSource: LPSN
+                  Id: 1870
+                  LpsnRecordNumber: 774944
+                - Name: Clostridium perenne
+                  ConceptId: species/clostridium-perenne
+                  ConceptSource: LPSN
+                  Id: 796
+                  LpsnRecordNumber: 774950
+              - Name: Clostridium beijerinckii
+                ConceptType: Species
+                ConceptId: species/clostridium-beijerinckii
+                ConceptSource: LPSN
+                Id: 1654
+                LpsnRecordNumber: 774835
+              - Name: Clostridium botulinum
+                ConceptType: Species
+                ConceptId: species/clostridium-botulinum
+                ConceptSource: LPSN
+                Id: 142
+                LpsnRecordNumber: 783659
+              - Name: Clostridium budayi
+                ConceptType: Species
+                ConceptId: species/clostridium-budayi
+                ConceptSource: LPSN
+                Id: 3170
+                LpsnRecordNumber: 798388
+                Synonyms:
+                - Name: Eubacterium budayi
+                  ConceptId: species/eubacterium-budayi
+                  ConceptSource: LPSN
+                  Id: 455
+                  LpsnRecordNumber: 776072
+              - Name: Clostridium butyricum
+                ConceptType: Species
+                ConceptId: species/clostridium-butyricum
+                ConceptSource: LPSN
+                Id: 1538
+                LpsnRecordNumber: 774842
+              - Name: Clostridium cadaveris
+                ConceptType: Species
+                ConceptId: species/clostridium-cadaveris
+                ConceptSource: LPSN
+                Id: 2018
+                LpsnRecordNumber: 774843
+              - Name: Clostridium carnis
+                ConceptType: Species
+                ConceptId: species/clostridium-carnis
+                ConceptSource: LPSN
+                Id: 21
+                LpsnRecordNumber: 774848
+              - Name: Clostridium celatum
+                ConceptType: Species
+                ConceptId: species/clostridium-celatum
+                ConceptSource: LPSN
+                Id: 2819
+                LpsnRecordNumber: 774849
+              - Name: Clostridium chauvoei
+                ConceptType: Species
+                ConceptId: species/clostridium-chauvoei
+                ConceptSource: LPSN
+                Id: 2820
+                LpsnRecordNumber: 774855
+              - Name: Clostridium cochlearium
+                ConceptType: Species
+                ConceptId: species/clostridium-cochlearium
+                ConceptSource: LPSN
+                Id: 1490
+                LpsnRecordNumber: 774859
+                Synonyms:
+                - Name: Clostridium lentoputrescens
+                  ConceptId: species/clostridium-lentoputrescens
+                  ConceptSource: LPSN
+                  Id: 1857
+                  LpsnRecordNumber: 774916
+              - Name: Clostridium cocleatum
+                ConceptType: Species
+                ConceptId: species/clostridium-cocleatum
+                ConceptSource: LPSN
+                Id: 253
+                LpsnRecordNumber: 774860
+              - Name: Clostridium combesii
+                ConceptType: Species
+                ConceptId: species/clostridium-combesii
+                ConceptSource: LPSN
+                Id: 2823
+                LpsnRecordNumber: 798389
+                Synonyms:
+                - Name: Eubacterium combesii
+                  ConceptId: species/eubacterium-combesii
+                  ConceptSource: LPSN
+                  Id: 34
+                  LpsnRecordNumber: 776074
+              - Name: Clostridium disporicum
+                ConceptType: Species
+                ConceptId: species/clostridium-disporicum
+                ConceptSource: LPSN
+                Id: 1612
+                LpsnRecordNumber: 774869
+              - Name: Clostridium fallax
+                ConceptType: Species
+                ConceptId: species/clostridium-fallax
+                ConceptSource: LPSN
+                Id: 224
+                LpsnRecordNumber: 774874
+              - Name: Clostridium haemolyticum
+                ConceptType: Species
+                ConceptId: species/clostridium-haemolyticum
+                ConceptSource: LPSN
+                Id: 714
+                LpsnRecordNumber: 774890
+              - Name: Clostridium hydrogeniformans
+                ConceptType: Species
+                ConceptId: species/clostridium-hydrogeniformans
+                ConceptSource: LPSN
+                Id: 2824
+                LpsnRecordNumber: 788357
+              - Name: Clostridium innocuum
+                ConceptType: Species
+                ConceptId: species/clostridium-innocuum
+                ConceptSource: LPSN
+                Id: 1682
+                LpsnRecordNumber: 774902
+              - Name: Clostridium intestinale
+                ConceptType: Species
+                ConceptId: species/clostridium-intestinale
+                ConceptSource: LPSN
+                Id: 2249
+                LpsnRecordNumber: 774903
+              - Name: Clostridium leptum
+                ConceptType: Species
+                ConceptId: species/clostridium-leptum
+                ConceptSource: LPSN
+                Id: 1426
+                LpsnRecordNumber: 774917
+              - Name: Clostridium malenominatum
+                ConceptType: Species
+                ConceptId: species/clostridium-malenominatum
+                ConceptSource: LPSN
+                Id: 1629
+                LpsnRecordNumber: 774926
+              - Name: Clostridium moniliforme
+                ConceptType: Species
+                ConceptId: species/clostridium-moniliforme
+                ConceptSource: LPSN
+                Id: 3111
+                LpsnRecordNumber: 793809
+                Synonyms:
+                - Name: Eubacterium moniliforme
+                  ConceptId: species/eubacterium-moniliforme
+                  ConceptSource: LPSN
+                  Id: 756
+                  LpsnRecordNumber: 776089
+              - Name: Clostridium neonatale
+                ConceptType: Species
+                ConceptId: species/clostridium-neonatale
+                ConceptSource: LPSN
+                Id: 2827
+                LpsnRecordNumber: 797718
+              - Name: Clostridium novyi
+                ConceptType: Species
+                ConceptId: species/clostridium-novyi
+                ConceptSource: LPSN
+                Id: 1078
+                LpsnRecordNumber: 774936
+              - Name: Clostridium paraputrificum
+                ConceptType: Species
+                ConceptId: species/clostridium-paraputrificum
+                ConceptSource: LPSN
+                Id: 284
+                LpsnRecordNumber: 774945
+              - Name: Clostridium perfringens
+                ConceptType: Species
+                ConceptId: species/clostridium-perfringens
+                ConceptSource: LPSN
+                Id: 430
+                LpsnRecordNumber: 774951
+              - Name: Clostridium putrefaciens
+                ConceptType: Species
+                ConceptId: species/clostridium-putrefaciens
+                ConceptSource: LPSN
+                Id: 999
+                LpsnRecordNumber: 774962
+              - Name: Clostridium ramosum
+                ConceptType: Species
+                ConceptId: species/clostridium-ramosum
+                ConceptSource: LPSN
+                Id: 1091
+                LpsnRecordNumber: 774967
+              - Name: Clostridium sardiniense
+                ConceptType: Species
+                ConceptId: species/clostridium-sardiniense
+                ConceptSource: LPSN
+                Id: 833
+                LpsnRecordNumber: 774976
+                Synonyms:
+                - Name: Clostridium absonum
+                  ConceptId: species/clostridium-absonum
+                  ConceptSource: LPSN
+                  Id: 394
+                  LpsnRecordNumber: 774807
+              - Name: Clostridium septicum
+                ConceptType: Species
+                ConceptId: species/clostridium-septicum
+                ConceptSource: LPSN
+                Id: 1462
+                LpsnRecordNumber: 774981
+              - Name: Clostridium spiroforme
+                ConceptType: Species
+                ConceptId: species/clostridium-spiroforme
+                ConceptSource: LPSN
+                Id: 1966
+                LpsnRecordNumber: 774985
+              - Name: Clostridium sporogenes
+                ConceptType: Species
+                ConceptId: species/clostridium-sporogenes
+                ConceptSource: LPSN
+                Id: 1129
+                LpsnRecordNumber: 774986
+              - Name: Clostridium subterminale
+                ConceptType: Species
+                ConceptId: species/clostridium-subterminale
+                ConceptSource: LPSN
+                Id: 2312
+                LpsnRecordNumber: 774993
+              - Name: Clostridium symbiosum
+                ConceptType: Species
+                ConceptId: species/clostridium-symbiosum
+                ConceptSource: LPSN
+                Id: 454
+                LpsnRecordNumber: 774995
+              - Name: Clostridium tertium
+                ConceptType: Species
+                ConceptId: species/clostridium-tertium
+                ConceptSource: LPSN
+                Id: 519
+                LpsnRecordNumber: 774998
+              - Name: Clostridium tetani
+                ConceptType: Species
+                ConceptId: species/clostridium-tetani
+                ConceptSource: LPSN
+                Id: 42
+                LpsnRecordNumber: 774999
+            - Name: Hathewaya
+              ConceptType: Genus
+              ConceptId: genus/hathewaya
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518884
+              Children:
+              - Name: Hathewaya histolytica
+                ConceptType: Species
+                ConceptId: species/hathewaya-histolytica
+                ConceptSource: LPSN
+                Id: 3263
+                LpsnRecordNumber: 793805
+                Synonyms:
+                - Name: Clostridium histolyticum
+                  ConceptId: species/clostridium-histolyticum
+                  ConceptSource: LPSN
+                  Id: 679
+                  LpsnRecordNumber: 774896
+              - Name: Hathewaya limosa
+                ConceptType: Species
+                ConceptId: species/hathewaya-limosa
+                ConceptSource: LPSN
+                Id: 3021
+                LpsnRecordNumber: 793806
+                Synonyms:
+                - Name: Clostridium limosum
+                  ConceptId: species/clostridium-limosum
+                  ConceptSource: LPSN
+                  Id: 1930
+                  LpsnRecordNumber: 774918
+            - Name: Hungatella
+              ConceptType: Genus
+              ConceptId: genus/hungatella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518513
+              Children:
+              - Name: Hungatella hathewayi
+                ConceptType: Species
+                ConceptId: species/hungatella-hathewayi
+                ConceptSource: LPSN
+                Id: 3306
+                LpsnRecordNumber: 791622
+                Synonyms:
+                - Name: Clostridium hathewayi
+                  ConceptId: species/clostridium-hathewayi
+                  ConceptSource: LPSN
+                  Id: 238
+                  LpsnRecordNumber: 774893
+            - Name: Sarcina
+              ConceptType: Genus
+              ConceptId: genus/sarcina
+              ConceptSource: LPSN
+              Id: 930
+              LpsnRecordNumber: 516554
+              Children:
+              - Name: Sarcina ventriculi
+                ConceptType: Species
+                ConceptId: species/sarcina-ventriculi
+                ConceptSource: LPSN
+                Id: 2459
+                LpsnRecordNumber: 780795
+                Synonyms:
+                - Name: Clostridium ventriculi
+                  ConceptId: species/clostridium-ventriculi
+                  ConceptSource: LPSN
+                  Id: 2828
+                  LpsnRecordNumber: 793811
+          - Name: Eubacteriaceae
+            ConceptType: Family
+            ConceptId: family/eubacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 497
+            Children:
+            - Name: Eubacterium
+              ConceptType: Genus
+              ConceptId: genus/eubacterium
+              ConceptSource: LPSN
+              Id: 490
+              LpsnRecordNumber: 515603
+              Children:
+              - Name: Eubacterium barkeri
+                ConceptType: Species
+                ConceptId: species/eubacterium-barkeri
+                ConceptSource: LPSN
+                Id: 1589
+                LpsnRecordNumber: 776069
+                Synonyms:
+                - Name: Clostridium barkeri
+                  ConceptId: species/clostridium-barkeri
+                  ConceptSource: LPSN
+                  Id: 1375
+                  LpsnRecordNumber: 774833
+              - Name: Eubacterium brachy
+                ConceptType: Species
+                ConceptId: species/eubacterium-brachy
+                ConceptSource: LPSN
+                Id: 2439
+                LpsnRecordNumber: 776071
+              - Name: Eubacterium callanderi
+                ConceptType: Species
+                ConceptId: species/eubacterium-callanderi
+                ConceptSource: LPSN
+                Id: 1419
+                LpsnRecordNumber: 776073
+              - Name: Eubacterium infirmum
+                ConceptType: Species
+                ConceptId: species/eubacterium-infirmum
+                ConceptSource: LPSN
+                Id: 596
+                LpsnRecordNumber: 783809
+              - Name: Eubacterium limosum
+                ConceptType: Species
+                ConceptId: species/eubacterium-limosum
+                ConceptSource: LPSN
+                Id: 765
+                LpsnRecordNumber: 776088
+              - Name: Eubacterium minutum
+                ConceptType: Species
+                ConceptId: species/eubacterium-minutum
+                ConceptSource: LPSN
+                Id: 939
+                LpsnRecordNumber: 783810
+              - Name: Eubacterium nodatum
+                ConceptType: Species
+                ConceptId: species/eubacterium-nodatum
+                ConceptSource: LPSN
+                Id: 2268
+                LpsnRecordNumber: 776092
+              - Name: Eubacterium ramulus
+                ConceptType: Species
+                ConceptId: species/eubacterium-ramulus
+                ConceptSource: LPSN
+                Id: 588
+                LpsnRecordNumber: 776097
+              - Name: Eubacterium saphenum
+                ConceptType: Species
+                ConceptId: species/eubacterium-saphenum
+                ConceptSource: LPSN
+                Id: 597
+                LpsnRecordNumber: 783814
+              - Name: Eubacterium siraeum
+                ConceptType: Species
+                ConceptId: species/eubacterium-siraeum
+                ConceptSource: LPSN
+                Id: 359
+                LpsnRecordNumber: 776101
+              - Name: Eubacterium sulci
+                ConceptType: Species
+                ConceptId: species/eubacterium-sulci
+                ConceptSource: LPSN
+                Id: 1275
+                LpsnRecordNumber: 783815
+                Synonyms:
+                - Name: Fusobacterium sulci
+                  ConceptId: species/fusobacterium-sulci
+                  ConceptSource: LPSN
+                  Id: 1473
+                  LpsnRecordNumber: 783891
+              - Name: Eubacterium tenue
+                ConceptType: Species
+                ConceptId: species/eubacterium-tenue
+                ConceptSource: LPSN
+                Id: 53
+                LpsnRecordNumber: 776105
+              - Name: Eubacterium ventriosum
+                ConceptType: Species
+                ConceptId: species/eubacterium-ventriosum
+                ConceptSource: LPSN
+                Id: 576
+                LpsnRecordNumber: 776108
+              - Name: Eubacterium yurii
+                ConceptType: Species
+                ConceptId: species/eubacterium-yurii
+                ConceptSource: LPSN
+                Id: 1358
+                LpsnRecordNumber: 783820
+            - Name: Pseudoramibacter
+              ConceptType: Genus
+              ConceptId: genus/pseudoramibacter
+              ConceptSource: LPSN
+              Id: 1884
+              LpsnRecordNumber: 516422
+              Children:
+              - Name: Pseudoramibacter alactolyticus
+                ConceptType: Species
+                ConceptId: species/pseudoramibacter-alactolyticus
+                ConceptSource: LPSN
+                Id: 2565
+                LpsnRecordNumber: 780192
+                Synonyms:
+                - Name: Eubacterium alactolyticum
+                  ConceptId: species/eubacterium-alactolyticum
+                  ConceptSource: LPSN
+                  Id: 2212
+                  LpsnRecordNumber: 776067
+          - Name: Lachnospiraceae
+            ConceptType: Family
+            ConceptId: family/lachnospiraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 726
+            Children:
+            - Name: Agathobacter
+              ConceptType: Genus
+              ConceptId: genus/agathobacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518887
+              Children:
+              - Name: Agathobacter rectalis
+                ConceptType: Species
+                ConceptId: species/agathobacter-rectalis
+                ConceptSource: LPSN
+                Id: 3182
+                LpsnRecordNumber: 793828
+                Synonyms:
+                - Name: Eubacterium rectale
+                  ConceptId: species/eubacterium-rectale
+                  ConceptSource: LPSN
+                  Id: 575
+                  LpsnRecordNumber: 776098
+            - Name: Anaerobutyricum
+              ConceptType: Genus
+              ConceptId: genus/anaerobutyricum
+              ConceptSource: LPSN
+              LpsnRecordNumber: 521512
+              Children:
+              - Name: Anaerobutyricum hallii
+                ConceptType: Species
+                ConceptId: species/anaerobutyricum-hallii
+                ConceptSource: LPSN
+                Id: 3180
+                LpsnRecordNumber: 799910
+                Synonyms:
+                - Name: Eubacterium hallii
+                  ConceptId: species/eubacterium-hallii
+                  ConceptSource: LPSN
+                  Id: 1909
+                  LpsnRecordNumber: 776086
+            - Name: Anaerostipes
+              ConceptType: Genus
+              ConceptId: genus/anaerostipes
+              ConceptSource: LPSN
+              LpsnRecordNumber: 515129
+              Children:
+              - Name: Anaerostipes hadrus
+                ConceptType: Species
+                ConceptId: species/anaerostipes-hadrus
+                ConceptSource: LPSN
+                Id: 3058
+                LpsnRecordNumber: 791209
+                Synonyms:
+                - Name: Eubacterium hadrum
+                  ConceptId: species/eubacterium-hadrum
+                  ConceptSource: LPSN
+                  Id: 1737
+                  LpsnRecordNumber: 776085
+            - Name: Blautia
+              ConceptType: Genus
+              ConceptId: genus/blautia
+              ConceptSource: LPSN
+              Id: 1685
+              LpsnRecordNumber: 517686
+              Children:
+              - Name: Blautia coccoides
+                ConceptType: Species
+                ConceptId: species/blautia-coccoides
+                ConceptSource: LPSN
+                Id: 667
+                LpsnRecordNumber: 787479
+              - Name: Blautia hansenii
+                ConceptType: Species
+                ConceptId: species/blautia-hansenii
+                ConceptSource: LPSN
+                Id: 168
+                LpsnRecordNumber: 787480
+                Synonyms:
+                - Name: Ruminococcus hansenii
+                  ConceptId: species/ruminococcus-hansenii
+                  ConceptSource: LPSN
+                  Id: 883
+                  LpsnRecordNumber: 780613
+                - Name: Streptococcus hansenii
+                  ConceptId: species/streptococcus-hansenii
+                  ConceptSource: LPSN
+                  Id: 1240
+                  LpsnRecordNumber: 781345
+              - Name: Blautia producta
+                ConceptType: Species
+                ConceptId: species/blautia-producta
+                ConceptSource: LPSN
+                Id: 631
+                LpsnRecordNumber: 787483
+                Synonyms:
+                - Name: Peptostreptococcus productus
+                  ConceptId: species/peptostreptococcus-productus
+                  ConceptSource: LPSN
+                  Id: 2533
+                  LpsnRecordNumber: 779393
+                - Name: Ruminococcus productus
+                  ConceptId: species/ruminococcus-productus
+                  ConceptSource: LPSN
+                  Id: 1087
+                  LpsnRecordNumber: 780618
+            - Name: Butyrivibrio
+              ConceptType: Genus
+              ConceptId: genus/butyrivibrio
+              ConceptSource: LPSN
+              Id: 1965
+              LpsnRecordNumber: 515284
+              Children:
+              - Name: Butyrivibrio fibrisolvens
+                ConceptType: Species
+                ConceptId: species/butyrivibrio-fibrisolvens
+                ConceptSource: LPSN
+                Id: 1022
+                LpsnRecordNumber: 774324
+              - Name: Butyrivibrio hungatei
+                ConceptType: Species
+                ConceptId: species/butyrivibrio-hungatei
+                ConceptSource: LPSN
+                Id: 1171
+                LpsnRecordNumber: 774325
+            - Name: Catonella
+              ConceptType: Genus
+              ConceptId: genus/catonella
+              ConceptSource: LPSN
+              Id: 935
+              LpsnRecordNumber: 517714
+              Children:
+              - Name: Catonella morbi
+                ConceptType: Species
+                ConceptId: species/catonella-morbi
+                ConceptSource: LPSN
+                Id: 91
+                LpsnRecordNumber: 783612
+            - Name: Coprococcus
+              ConceptType: Genus
+              ConceptId: genus/coprococcus
+              ConceptSource: LPSN
+              Id: 882
+              LpsnRecordNumber: 517207
+              Children:
+              - Name: Coprococcus eutactus
+                ConceptType: Species
+                ConceptId: species/coprococcus-eutactus
+                ConceptSource: LPSN
+                Id: 669
+                LpsnRecordNumber: 783693
+            - Name: Dorea
+              ConceptType: Genus
+              ConceptId: genus/dorea
+              ConceptSource: LPSN
+              Id: 910
+              LpsnRecordNumber: 515553
+              Children:
+              - Name: Dorea formicigenerans
+                ConceptType: Species
+                ConceptId: species/dorea-formicigenerans
+                ConceptSource: LPSN
+                Id: 1730
+                LpsnRecordNumber: 775818
+              - Name: Dorea longicatena
+                ConceptType: Species
+                ConceptId: species/dorea-longicatena
+                ConceptSource: LPSN
+                Id: 614
+                LpsnRecordNumber: 775819
+            - Name: Enterocloster
+              ConceptType: Genus
+              ConceptId: genus/enterocloster
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4938
+              Children:
+              - Name: Enterocloster aldenensis
+                ConceptType: Species
+                ConceptId: species/enterocloster-aldenensis
+                ConceptSource: LPSN
+                Id: 3486
+                LpsnRecordNumber: 7396
+                Synonyms:
+                - Name: Clostridium aldenense
+                  ConceptId: species/clostridium-aldenense
+                  ConceptSource: LPSN
+                  Id: 2817
+                  LpsnRecordNumber: 786179
+              - Name: Enterocloster bolteae
+                ConceptType: Species
+                ConceptId: species/enterocloster-bolteae
+                ConceptSource: LPSN
+                Id: 3067
+                LpsnRecordNumber: 5946
+                Synonyms:
+                - Name: Clostridium bolteae
+                  ConceptId: species/clostridium-bolteae
+                  ConceptSource: LPSN
+                  Id: 55
+                  LpsnRecordNumber: 774838
+              - Name: Enterocloster citroniae
+                ConceptType: Species
+                ConceptId: species/enterocloster-citroniae
+                ConceptSource: LPSN
+                Id: 2821
+                LpsnRecordNumber: 5948
+                Synonyms:
+                - Name: Clostridium citroniae
+                  ConceptId: species/clostridium-citroniae
+                  ConceptSource: LPSN
+                  Id: 2822
+                  LpsnRecordNumber: 786178
+              - Name: Enterocloster clostridioformis
+                ConceptType: Species
+                ConceptId: species/enterocloster-clostridioformis
+                ConceptSource: LPSN
+                Id: 3136
+                LpsnRecordNumber: 5950
+                Synonyms:
+                - Name: Clostridium clostridioforme
+                  ConceptId: species/clostridium-clostridioforme
+                  ConceptSource: LPSN
+                  Id: 790
+                  LpsnRecordNumber: 774857
+              - Name: Enterocloster lavalensis
+                ConceptType: Species
+                ConceptId: species/enterocloster-lavalensis
+                ConceptSource: LPSN
+                Id: 2825
+                LpsnRecordNumber: 5952
+                Synonyms:
+                - Name: Clostridium lavalense
+                  ConceptId: species/clostridium-lavalense
+                  ConceptSource: LPSN
+                  Id: 2826
+                  LpsnRecordNumber: 786867
+            - Name: Faecalicatena
+              ConceptType: Genus
+              ConceptId: genus/faecalicatena
+              ConceptSource: LPSN
+              LpsnRecordNumber: 519173
+              Children:
+              - Name: Faecalicatena contorta
+                ConceptType: Species
+                ConceptId: species/faecalicatena-contorta
+                ConceptSource: LPSN
+                Id: 3028
+                LpsnRecordNumber: 795294
+                Synonyms:
+                - Name: Eubacterium contortum
+                  ConceptId: species/eubacterium-contortum
+                  ConceptSource: LPSN
+                  Id: 2137
+                  LpsnRecordNumber: 776075
+              - Name: Faecalicatena orotica
+                ConceptType: Species
+                ConceptId: species/faecalicatena-orotica
+                ConceptSource: LPSN
+                Id: 3168
+                LpsnRecordNumber: 795296
+                Synonyms:
+                - Name: Clostridium oroticum
+                  ConceptId: species/clostridium-oroticum
+                  ConceptSource: LPSN
+                  Id: 1721
+                  LpsnRecordNumber: 774940
+            - Name: Lachnoanaerobaculum
+              ConceptType: Genus
+              ConceptId: genus/lachnoanaerobaculum
+              ConceptSource: LPSN
+              Id: 1567
+              LpsnRecordNumber: 518276
+              Children:
+              - Name: Lachnoanaerobaculum orale
+                ConceptType: Species
+                ConceptId: species/lachnoanaerobaculum-orale
+                ConceptSource: LPSN
+                Id: 2
+                LpsnRecordNumber: 790293
+              - Name: Lachnoanaerobaculum saburreum
+                ConceptType: Species
+                ConceptId: species/lachnoanaerobaculum-saburreum
+                ConceptSource: LPSN
+                Id: 3328
+                LpsnRecordNumber: 790294
+                Synonyms:
+                - Name: Eubacterium saburreum
+                  ConceptId: species/eubacterium-saburreum
+                  ConceptSource: LPSN
+                  Id: 995
+                  LpsnRecordNumber: 776100
+            - Name: Lachnospira
+              ConceptType: Genus
+              ConceptId: genus/lachnospira
+              ConceptSource: LPSN
+              LpsnRecordNumber: 515911
+              Children:
+              - Name: Lachnospira eligens
+                ConceptType: Species
+                ConceptId: species/lachnospira-eligens
+                ConceptSource: LPSN
+                Id: 3148
+                LpsnRecordNumber: 7862
+                Synonyms:
+                - Name: Eubacterium eligens
+                  ConceptId: species/eubacterium-eligens
+                  ConceptSource: LPSN
+                  Id: 228
+                  LpsnRecordNumber: 776079
+            - Name: Lacrimispora
+              ConceptType: Genus
+              ConceptId: genus/lacrimispora
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4941
+              Children:
+              - Name: Lacrimispora amygdalina
+                ConceptType: Species
+                ConceptId: species/lacrimispora-amygdalina
+                ConceptSource: LPSN
+                Id: 3487
+                LpsnRecordNumber: 5944
+                Synonyms:
+                - Name: Clostridium amygdalinum
+                  ConceptId: species/clostridium-amygdalinum
+                  ConceptSource: LPSN
+                  Id: 2818
+                  LpsnRecordNumber: 774828
+              - Name: Lacrimispora celerecrescens
+                ConceptType: Species
+                ConceptId: species/lacrimispora-celerecrescens
+                ConceptSource: LPSN
+                Id: 3205
+                LpsnRecordNumber: 5947
+                Synonyms:
+                - Name: Clostridium celerecrescens
+                  ConceptId: species/clostridium-celerecrescens
+                  ConceptSource: LPSN
+                  Id: 1034
+                  LpsnRecordNumber: 774850
+              - Name: Lacrimispora indolis
+                ConceptType: Species
+                ConceptId: species/lacrimispora-indolis
+                ConceptSource: LPSN
+                Id: 3310
+                LpsnRecordNumber: 5951
+                Synonyms:
+                - Name: Clostridium indolis
+                  ConceptId: species/clostridium-indolis
+                  ConceptSource: LPSN
+                  Id: 2291
+                  LpsnRecordNumber: 774901
+              - Name: Lacrimispora sphenoides
+                ConceptType: Species
+                ConceptId: species/lacrimispora-sphenoides
+                ConceptSource: LPSN
+                Id: 3249
+                LpsnRecordNumber: 5954
+                Synonyms:
+                - Name: Clostridium sphenoides
+                  ConceptId: species/clostridium-sphenoides
+                  ConceptSource: LPSN
+                  Id: 613
+                  LpsnRecordNumber: 774984
+            - Name: Mediterraneibacter
+              ConceptType: Genus
+              ConceptId: genus/mediterraneibacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520459
+              Children:
+              - Name: Mediterraneibacter gnavus
+                ConceptType: Species
+                ConceptId: species/mediterraneibacter-gnavus
+                ConceptSource: LPSN
+                Id: 3545
+                LpsnRecordNumber: 40587
+                Synonyms:
+                - Name: Ruminococcus gnavus
+                  ConceptId: species/ruminococcus-gnavus
+                  ConceptSource: LPSN
+                  Id: 2361
+                  LpsnRecordNumber: 784836
+            - Name: Robinsoniella
+              ConceptType: Genus
+              ConceptId: genus/robinsoniella
+              ConceptSource: LPSN
+              Id: 345
+              LpsnRecordNumber: 517837
+              Children:
+              - Name: Robinsoniella peoriensis
+                ConceptType: Species
+                ConceptId: species/robinsoniella-peoriensis
+                ConceptSource: LPSN
+                Id: 1800
+                LpsnRecordNumber: 787699
+          - Name: Oscillospiraceae
+            ConceptType: Family
+            ConceptId: family/oscillospiraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1005
+            Children:
+            - Name: Faecalibacterium
+              ConceptType: Genus
+              ConceptId: genus/faecalibacterium
+              ConceptSource: LPSN
+              Id: 1046
+              LpsnRecordNumber: 515613
+              Children:
+              - Name: Faecalibacterium prausnitzii
+                ConceptType: Species
+                ConceptId: species/faecalibacterium-prausnitzii
+                ConceptSource: LPSN
+                Id: 1570
+                LpsnRecordNumber: 776172
+                Synonyms:
+                - Name: Fusobacterium prausnitzii
+                  ConceptId: species/fusobacterium-prausnitzii
+                  ConceptSource: LPSN
+                  Id: 889
+                  LpsnRecordNumber: 783887
+            - Name: Faecalispora
+              ConceptType: Genus
+              ConceptId: genus/faecalispora
+              ConceptSource: LPSN
+              LpsnRecordNumber: 43221
+              Children:
+              - Name: Faecalispora sporosphaeroides
+                ConceptType: Species
+                ConceptId: species/faecalispora-sporosphaeroides
+                ConceptSource: LPSN
+                Id: 3488
+                LpsnRecordNumber: 43269
+                Synonyms:
+                - Name: Clostridium sporosphaeroides
+                  ConceptId: species/clostridium-sporosphaeroides
+                  ConceptSource: LPSN
+                  Id: 726
+                  LpsnRecordNumber: 774987
+            - Name: Flavonifractor
+              ConceptType: Genus
+              ConceptId: genus/flavonifractor
+              ConceptSource: LPSN
+              Id: 1763
+              LpsnRecordNumber: 517953
+              Children:
+              - Name: Flavonifractor plautii
+                ConceptType: Species
+                ConceptId: species/flavonifractor-plautii
+                ConceptSource: LPSN
+                Id: 257
+                LpsnRecordNumber: 788422
+                Synonyms:
+                - Name: Clostridium orbiscindens
+                  ConceptId: species/clostridium-orbiscindens
+                  ConceptSource: LPSN
+                  Id: 1220
+                  LpsnRecordNumber: 774939
+                - Name: Eubacterium plautii
+                  ConceptId: species/eubacterium-plautii
+                  ConceptSource: LPSN
+                  Id: 270
+                  LpsnRecordNumber: 776095
+                - Name: Fusobacterium plauti
+                  ConceptId: species/fusobacterium-plauti
+                  ConceptSource: LPSN
+                  Id: 1149
+                  LpsnRecordNumber: 783886
+                - Name: Fusobacterium plautii
+                  ConceptId: species/fusobacterium-plautii
+                  ConceptSource: LPSN
+                  Id: 3248
+                  LpsnRecordNumber: 776410
+            - Name: Pseudoflavonifractor
+              ConceptType: Genus
+              ConceptId: genus/pseudoflavonifractor
+              ConceptSource: LPSN
+              Id: 806
+              LpsnRecordNumber: 517954
+              Children:
+              - Name: Pseudoflavonifractor capillosus
+                ConceptType: Species
+                ConceptId: species/pseudoflavonifractor-capillosus
+                ConceptSource: LPSN
+                Id: 2415
+                LpsnRecordNumber: 788423
+                Synonyms:
+                - Name: Bacteroides capillosus
+                  ConceptId: species/bacteroides-capillosus
+                  ConceptSource: LPSN
+                  Id: 370
+                  LpsnRecordNumber: 783440
+            - Name: Ruminococcus
+              ConceptType: Genus
+              ConceptId: genus/ruminococcus
+              ConceptSource: LPSN
+              Id: 1840
+              LpsnRecordNumber: 516518
+          - Name: Peptococcaceae
+            ConceptType: Family
+            ConceptId: family/peptococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1050
+            Children:
+            - Name: Peptococcus
+              ConceptType: Genus
+              ConceptId: genus/peptococcus
+              ConceptSource: LPSN
+              Id: 1391
+              LpsnRecordNumber: 516286
+              Children:
+              - Name: Peptococcus niger
+                ConceptType: Species
+                ConceptId: species/peptococcus-niger
+                ConceptSource: LPSN
+                Id: 1077
+                LpsnRecordNumber: 779369
+          - Name: Peptoniphilaceae
+            ConceptType: Family
+            ConceptId: family/peptoniphilaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1985
+            Children:
+            - Name: Anaerococcus
+              ConceptType: Genus
+              ConceptId: genus/anaerococcus
+              ConceptSource: LPSN
+              Id: 1925
+              LpsnRecordNumber: 515119
+              Children:
+              - Name: Anaerococcus hydrogenalis
+                ConceptType: Species
+                ConceptId: species/anaerococcus-hydrogenalis
+                ConceptSource: LPSN
+                Id: 814
+                LpsnRecordNumber: 773244
+                Synonyms:
+                - Name: Peptostreptococcus hydrogenalis
+                  ConceptId: species/peptostreptococcus-hydrogenalis
+                  ConceptSource: LPSN
+                  Id: 2487
+                  LpsnRecordNumber: 779383
+              - Name: Anaerococcus lactolyticus
+                ConceptType: Species
+                ConceptId: species/anaerococcus-lactolyticus
+                ConceptSource: LPSN
+                Id: 1772
+                LpsnRecordNumber: 773245
+                Synonyms:
+                - Name: Peptostreptococcus lactolyticus
+                  ConceptId: species/peptostreptococcus-lactolyticus
+                  ConceptSource: LPSN
+                  Id: 2431
+                  LpsnRecordNumber: 779387
+              - Name: Anaerococcus octavius
+                ConceptType: Species
+                ConceptId: species/anaerococcus-octavius
+                ConceptSource: LPSN
+                Id: 2382
+                LpsnRecordNumber: 773246
+                Synonyms:
+                - Name: Peptostreptococcus octavius
+                  ConceptId: species/peptostreptococcus-octavius
+                  ConceptSource: LPSN
+                  Id: 1053
+                  LpsnRecordNumber: 779390
+              - Name: Anaerococcus prevotii
+                ConceptType: Species
+                ConceptId: species/anaerococcus-prevotii
+                ConceptSource: LPSN
+                Id: 37
+                LpsnRecordNumber: 773247
+                Synonyms:
+                - Name: Peptostreptococcus prevotii
+                  ConceptId: species/peptostreptococcus-prevotii
+                  ConceptSource: LPSN
+                  Id: 306
+                  LpsnRecordNumber: 779392
+              - Name: Anaerococcus tetradius
+                ConceptType: Species
+                ConceptId: species/anaerococcus-tetradius
+                ConceptSource: LPSN
+                Id: 1388
+                LpsnRecordNumber: 773248
+                Synonyms:
+                - Name: Peptostreptococcus tetradius
+                  ConceptId: species/peptostreptococcus-tetradius
+                  ConceptSource: LPSN
+                  Id: 774
+                  LpsnRecordNumber: 779396
+              - Name: Anaerococcus vaginalis
+                ConceptType: Species
+                ConceptId: species/anaerococcus-vaginalis
+                ConceptSource: LPSN
+                Id: 2031
+                LpsnRecordNumber: 773249
+                Synonyms:
+                - Name: Peptostreptococcus vaginalis
+                  ConceptId: species/peptostreptococcus-vaginalis
+                  ConceptSource: LPSN
+                  Id: 826
+                  LpsnRecordNumber: 779397
+            - Name: Ezakiella
+              ConceptType: Genus
+              ConceptId: genus/ezakiella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518722
+              Children:
+              - Name: Ezakiella coagulans
+                ConceptType: Species
+                ConceptId: species/ezakiella-coagulans
+                ConceptSource: LPSN
+                Id: 3311
+                LpsnRecordNumber: 7832
+                Carbapenems: true
+                Synonyms:
+                - Name: Bacteroides coagulans
+                  ConceptId: species/bacteroides-coagulans
+                  ConceptSource: LPSN
+                  Id: 2010
+                  LpsnRecordNumber: 773935
+            - Name: Finegoldia
+              ConceptType: Genus
+              ConceptId: genus/finegoldia
+              ConceptSource: LPSN
+              Id: 2416
+              LpsnRecordNumber: 515633
+              Children:
+              - Name: Finegoldia magna
+                ConceptType: Species
+                ConceptId: species/finegoldia-magna
+                ConceptSource: LPSN
+                Id: 103
+                LpsnRecordNumber: 776212
+                Synonyms:
+                - Name: Peptostreptococcus magnus
+                  ConceptId: species/peptostreptococcus-magnus
+                  ConceptSource: LPSN
+                  Id: 1317
+                  LpsnRecordNumber: 779388
+            - Name: Gallicola
+              ConceptType: Genus
+              ConceptId: genus/gallicola
+              ConceptSource: LPSN
+              Id: 992
+              LpsnRecordNumber: 515674
+              Children:
+              - Name: Gallicola barnesae
+                ConceptType: Species
+                ConceptId: species/gallicola-barnesae
+                ConceptSource: LPSN
+                Id: 1435
+                LpsnRecordNumber: 776421
+            - Name: Helcococcus
+              ConceptType: Genus
+              ConceptId: genus/helcococcus
+              ConceptSource: LPSN
+              Id: 161
+              LpsnRecordNumber: 515783
+              Children:
+              - Name: Helcococcus kunzii
+                ConceptType: Species
+                ConceptId: species/helcococcus-kunzii
+                ConceptSource: LPSN
+                Id: 511
+                LpsnRecordNumber: 776862
+              - Name: Helcococcus sueciensis
+                ConceptType: Species
+                ConceptId: species/helcococcus-sueciensis
+                ConceptSource: LPSN
+                Id: 256
+                LpsnRecordNumber: 776864
+            - Name: Parvimonas
+              ConceptType: Genus
+              ConceptId: genus/parvimonas
+              ConceptSource: LPSN
+              Id: 1822
+              LpsnRecordNumber: 517468
+              Children:
+              - Name: Parvimonas micra
+                ConceptType: Species
+                ConceptId: species/parvimonas-micra
+                ConceptSource: LPSN
+                Id: 1480
+                LpsnRecordNumber: 785693
+                Synonyms:
+                - Name: Peptostreptococcus micros
+                  ConceptId: species/peptostreptococcus-micros
+                  ConceptSource: LPSN
+                  Id: 1745
+                  LpsnRecordNumber: 779389
+            - Name: Peptoniphilus
+              ConceptType: Genus
+              ConceptId: genus/peptoniphilus
+              ConceptSource: LPSN
+              Id: 2073
+              LpsnRecordNumber: 516287
+              Children:
+              - Name: Peptoniphilus asaccharolyticus
+                ConceptType: Species
+                ConceptId: species/peptoniphilus-asaccharolyticus
+                ConceptSource: LPSN
+                Id: 2341
+                LpsnRecordNumber: 779373
+                Synonyms:
+                - Name: Peptococcus asaccharolyticus
+                  ConceptId: species/peptococcus-asaccharolyticus
+                  ConceptSource: LPSN
+                  Id: 2080
+                  LpsnRecordNumber: 779364
+                - Name: Peptostreptococcus asaccharolyticus
+                  ConceptId: species/peptostreptococcus-asaccharolyticus
+                  ConceptSource: LPSN
+                  Id: 2143
+                  LpsnRecordNumber: 779379
+              - Name: Peptoniphilus harei
+                ConceptType: Species
+                ConceptId: species/peptoniphilus-harei
+                ConceptSource: LPSN
+                Id: 2558
+                LpsnRecordNumber: 779374
+              - Name: Peptoniphilus ivorii
+                ConceptType: Species
+                ConceptId: species/peptoniphilus-ivorii
+                ConceptSource: LPSN
+                Id: 2370
+                LpsnRecordNumber: 779376
+              - Name: Peptoniphilus lacrimalis
+                ConceptType: Species
+                ConceptId: species/peptoniphilus-lacrimalis
+                ConceptSource: LPSN
+                Id: 116
+                LpsnRecordNumber: 779377
+        - Name: Peptostreptococcales
+          ConceptType: Order
+          ConceptId: order/peptostreptococcales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 43692
+          Children:
+          - Name: Anaerovoracaceae
+            ConceptType: Family
+            ConceptId: family/anaerovoracaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 43787
+            Children:
+            - Name: Mogibacterium
+              ConceptType: Genus
+              ConceptId: genus/mogibacterium
+              ConceptSource: LPSN
+              Id: 601
+              LpsnRecordNumber: 516112
+              Children:
+              - Name: Mogibacterium diversum
+                ConceptType: Species
+                ConceptId: species/mogibacterium-diversum
+                ConceptSource: LPSN
+                Id: 2186
+                LpsnRecordNumber: 784274
+              - Name: Mogibacterium neglectum
+                ConceptType: Species
+                ConceptId: species/mogibacterium-neglectum
+                ConceptSource: LPSN
+                Id: 2347
+                LpsnRecordNumber: 784275
+              - Name: Mogibacterium timidum
+                ConceptType: Species
+                ConceptId: species/mogibacterium-timidum
+                ConceptSource: LPSN
+                Id: 641
+                LpsnRecordNumber: 778281
+                Synonyms:
+                - Name: Eubacterium timidum
+                  ConceptId: species/eubacterium-timidum
+                  ConceptSource: LPSN
+                  Id: 1180
+                  LpsnRecordNumber: 776106
+              - Name: Mogibacterium vescum
+                ConceptType: Species
+                ConceptId: species/mogibacterium-vescum
+                ConceptSource: LPSN
+                Id: 2017
+                LpsnRecordNumber: 784277
+          - Name: Peptostreptococcaceae
+            ConceptType: Family
+            ConceptId: family/peptostreptococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1053
+            Children:
+            - Name: Asaccharospora
+              ConceptType: Genus
+              ConceptId: genus/asaccharospora
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518556
+              Children:
+              - Name: Asaccharospora irregularis
+                ConceptType: Species
+                ConceptId: species/asaccharospora-irregularis
+                ConceptSource: LPSN
+                Id: 3116
+                LpsnRecordNumber: 791851
+                Synonyms:
+                - Name: Clostridium irregulare
+                  ConceptId: species/clostridium-irregulare
+                  ConceptSource: LPSN
+                  Id: 2319
+                  LpsnRecordNumber: 774904
+                - Name: Clostridium irregularis
+                  ConceptId: species/clostridium-irregularis
+                  ConceptSource: LPSN
+                  Id: 277
+                  LpsnRecordNumber: 783668
+            - Name: Clostridioides
+              ConceptType: Genus
+              ConceptId: genus/clostridioides
+              ConceptSource: LPSN
+              Id: 1382
+              LpsnRecordNumber: 518997
+              Children:
+              - Name: Clostridioides difficile
+                ConceptType: Species
+                ConceptId: species/clostridioides-difficile
+                ConceptSource: LPSN
+                Id: 594
+                LpsnRecordNumber: 794449
+                Synonyms:
+                - Name: Clostridium difficile
+                  ConceptId: species/clostridium-difficile
+                  ConceptSource: LPSN
+                  Id: 219
+                  LpsnRecordNumber: 774867
+            - Name: Filifactor
+              ConceptType: Genus
+              ConceptId: genus/filifactor
+              ConceptSource: LPSN
+              Id: 132
+              LpsnRecordNumber: 515628
+              Children:
+              - Name: Filifactor alocis
+                ConceptType: Species
+                ConceptId: species/filifactor-alocis
+                ConceptSource: LPSN
+                Id: 922
+                LpsnRecordNumber: 783838
+                Synonyms:
+                - Name: Fusobacterium alocis
+                  ConceptId: species/fusobacterium-alocis
+                  ConceptSource: LPSN
+                  Id: 1551
+                  LpsnRecordNumber: 783876
+              - Name: Filifactor villosus
+                ConceptType: Species
+                ConceptId: species/filifactor-villosus
+                ConceptSource: LPSN
+                Id: 371
+                LpsnRecordNumber: 776204
+                Synonyms:
+                - Name: Clostridium villosum
+                  ConceptId: species/clostridium-villosum
+                  ConceptSource: LPSN
+                  Id: 1285
+                  LpsnRecordNumber: 775022
+            - Name: Intestinibacter
+              ConceptType: Genus
+              ConceptId: genus/intestinibacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518554
+              Children:
+              - Name: Intestinibacter bartlettii
+                ConceptType: Species
+                ConceptId: species/intestinibacter-bartlettii
+                ConceptSource: LPSN
+                Id: 3045
+                LpsnRecordNumber: 791848
+                Synonyms:
+                - Name: Clostridium bartlettii
+                  ConceptId: species/clostridium-bartlettii
+                  ConceptSource: LPSN
+                  Id: 2392
+                  LpsnRecordNumber: 774834
+            - Name: Paeniclostridium
+              ConceptType: Genus
+              ConceptId: genus/paeniclostridium
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518915
+              Children:
+              - Name: Paeniclostridium ghonii
+                ConceptType: Species
+                ConceptId: species/paeniclostridium-ghonii
+                ConceptSource: LPSN
+                Id: 3138
+                LpsnRecordNumber: 793947
+                Synonyms:
+                - Name: Clostridium ghoni
+                  ConceptId: species/clostridium-ghoni
+                  ConceptSource: LPSN
+                  Id: 1440
+                  LpsnRecordNumber: 774885
+                - Name: Clostridium ghonii
+                  ConceptId: species/clostridium-ghonii
+                  ConceptSource: LPSN
+                  Id: 824
+                  LpsnRecordNumber: 774886
+              - Name: Paeniclostridium sordellii
+                ConceptType: Species
+                ConceptId: species/paeniclostridium-sordellii
+                ConceptSource: LPSN
+                Id: 2995
+                LpsnRecordNumber: 793946
+                Synonyms:
+                - Name: Clostridium sordellii
+                  ConceptId: species/clostridium-sordellii
+                  ConceptSource: LPSN
+                  Id: 1459
+                  LpsnRecordNumber: 774982
+            - Name: Paraclostridium
+              ConceptType: Genus
+              ConceptId: genus/paraclostridium
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518914
+              Children:
+              - Name: Paraclostridium bifermentans
+                ConceptType: Species
+                ConceptId: species/paraclostridium-bifermentans
+                ConceptSource: LPSN
+                Id: 3078
+                LpsnRecordNumber: 793944
+                Synonyms:
+                - Name: Clostridium bifermentans
+                  ConceptId: species/clostridium-bifermentans
+                  ConceptSource: LPSN
+                  Id: 687
+                  LpsnRecordNumber: 774836
+            - Name: Peptostreptococcus
+              ConceptType: Genus
+              ConceptId: genus/peptostreptococcus
+              ConceptSource: LPSN
+              Id: 2296
+              LpsnRecordNumber: 516288
+              Children:
+              - Name: Peptostreptococcus anaerobius
+                ConceptType: Species
+                ConceptId: species/peptostreptococcus-anaerobius
+                ConceptSource: LPSN
+                Id: 1938
+                LpsnRecordNumber: 779378
+            - Name: Terrisporobacter
+              ConceptType: Genus
+              ConceptId: genus/terrisporobacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518555
+              Children:
+              - Name: Terrisporobacter glycolicus
+                ConceptType: Species
+                ConceptId: species/terrisporobacter-glycolicus
+                ConceptSource: LPSN
+                Id: 3323
+                LpsnRecordNumber: 791849
+                Synonyms:
+                - Name: Clostridium glycolicum
+                  ConceptId: species/clostridium-glycolicum
+                  ConceptSource: LPSN
+                  Id: 1092
+                  LpsnRecordNumber: 774887
+        - Name: Tissierellales
+          ConceptType: Order
+          ConceptId: order/tissierellales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 11163
+          Children:
+          - Name: Tissierellaceae
+            ConceptType: Family
+            ConceptId: family/tissierellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 7749
+            Children:
+            - Name: Tissierella
+              ConceptType: Genus
+              ConceptId: genus/tissierella
+              ConceptSource: LPSN
+              Id: 1681
+              LpsnRecordNumber: 516848
+              Children:
+              - Name: Tissierella praeacuta
+                ConceptType: Species
+                ConceptId: species/tissierella-praeacuta
+                ConceptSource: LPSN
+                Id: 1021
+                LpsnRecordNumber: 782797
+                Synonyms:
+                - Name: Bacteroides praeacutus
+                  ConceptId: species/bacteroides-praeacutus
+                  ConceptSource: LPSN
+                  Id: 1340
+                  LpsnRecordNumber: 783457
+                - Name: Clostridium hastiforme
+                  ConceptId: species/clostridium-hastiforme
+                  ConceptSource: LPSN
+                  Id: 1167
+                  LpsnRecordNumber: 774892
+      - Name: Erysipelotrichia
+        ConceptType: Class
+        ConceptId: class/erysipelotrichia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 36
+        Children:
+        - Name: Erysipelotrichales
+          ConceptType: Order
+          ConceptId: order/erysipelotrichales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5122
+          Children:
+          - Name: Coprobacillaceae
+            ConceptType: Family
+            ConceptId: family/coprobacillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 13792
+            Children:
+            - Name: Catenibacterium
+              ConceptType: Genus
+              ConceptId: genus/catenibacterium
+              ConceptSource: LPSN
+              Id: 177
+              LpsnRecordNumber: 515320
+              Children:
+              - Name: Catenibacterium mitsuokai
+                ConceptType: Species
+                ConceptId: species/catenibacterium-mitsuokai
+                ConceptSource: LPSN
+                Id: 384
+                LpsnRecordNumber: 774509
+            - Name: Eggerthia
+              ConceptType: Genus
+              ConceptId: genus/eggerthia
+              ConceptSource: LPSN
+              Id: 1273
+              LpsnRecordNumber: 518138
+              Children:
+              - Name: Eggerthia catenaformis
+                ConceptType: Species
+                ConceptId: species/eggerthia-catenaformis
+                ConceptSource: LPSN
+                Id: 1825
+                LpsnRecordNumber: 789495
+                Synonyms:
+                - Name: Lactobacillus catenaformis
+                  ConceptId: species/lactobacillus-catenaformis
+                  ConceptSource: LPSN
+                  Id: 466
+                  LpsnRecordNumber: 777275
+            - Name: Kandleria
+              ConceptType: Genus
+              ConceptId: genus/kandleria
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518139
+              Children:
+              - Name: Kandleria vitulina
+                ConceptType: Species
+                ConceptId: species/kandleria-vitulina
+                ConceptSource: LPSN
+                Id: 3001
+                LpsnRecordNumber: 789498
+                Synonyms:
+                - Name: Lactobacillus vitulinus
+                  ConceptId: species/lactobacillus-vitulinus
+                  ConceptSource: LPSN
+                  Id: 1353
+                  LpsnRecordNumber: 777413
+          - Name: Erysipelotrichaceae
+            ConceptType: Family
+            ConceptId: family/erysipelotrichaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 492
+            Children:
+            - Name: Amedibacillus
+              ConceptType: Genus
+              ConceptId: genus/amedibacillus
+              ConceptSource: LPSN
+              LpsnRecordNumber: 8285
+              Children:
+              - Name: Amedibacillus dolichus
+                ConceptType: Species
+                ConceptId: species/amedibacillus-dolichus
+                ConceptSource: LPSN
+                Id: 3244
+                LpsnRecordNumber: 8290
+                Synonyms:
+                - Name: Eubacterium dolichum
+                  ConceptId: species/eubacterium-dolichum
+                  ConceptSource: LPSN
+                  Id: 1051
+                  LpsnRecordNumber: 776078
+            - Name: Anaerorhabdus
+              ConceptType: Genus
+              ConceptId: genus/anaerorhabdus
+              ConceptSource: LPSN
+              Id: 767
+              LpsnRecordNumber: 517176
+              Children:
+              - Name: Anaerorhabdus furcosa
+                ConceptType: Species
+                ConceptId: species/anaerorhabdus-furcosa
+                ConceptSource: LPSN
+                Id: 3051
+                LpsnRecordNumber: 783371
+                Synonyms:
+                - Name: Anaerorhabdus furcosus
+                  ConceptId: species/anaerorhabdus-furcosus
+                  ConceptSource: LPSN
+                  Id: 1659
+                  LpsnRecordNumber: 783372
+                - Name: Bacteroides furcosus
+                  ConceptId: species/bacteroides-furcosus
+                  ConceptSource: LPSN
+                  Id: 1190
+                  LpsnRecordNumber: 783445
+            - Name: Bulleidia
+              ConceptType: Genus
+              ConceptId: genus/bulleidia
+              ConceptSource: LPSN
+              Id: 2419
+              LpsnRecordNumber: 515278
+              Children:
+              - Name: Bulleidia extructa
+                ConceptType: Species
+                ConceptId: species/bulleidia-extructa
+                ConceptSource: LPSN
+                Id: 147
+                LpsnRecordNumber: 774261
+            - Name: Erysipelothrix
+              ConceptType: Genus
+              ConceptId: genus/erysipelothrix
+              ConceptSource: LPSN
+              Id: 1740
+              LpsnRecordNumber: 515597
+              Children:
+              - Name: Erysipelothrix inopinata
+                ConceptType: Species
+                ConceptId: species/erysipelothrix-inopinata
+                ConceptSource: LPSN
+                Id: 567
+                LpsnRecordNumber: 776037
+              - Name: Erysipelothrix rhusiopathiae
+                ConceptType: Species
+                ConceptId: species/erysipelothrix-rhusiopathiae
+                ConceptSource: LPSN
+                Id: 438
+                LpsnRecordNumber: 776038
+              - Name: Erysipelothrix tonsillarum
+                ConceptType: Species
+                ConceptId: species/erysipelothrix-tonsillarum
+                ConceptSource: LPSN
+                Id: 600
+                LpsnRecordNumber: 776039
+            - Name: Faecalitalea
+              ConceptType: Genus
+              ConceptId: genus/faecalitalea
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518634
+              Children:
+              - Name: Faecalitalea cylindroides
+                ConceptType: Species
+                ConceptId: species/faecalitalea-cylindroides
+                ConceptSource: LPSN
+                Id: 3049
+                LpsnRecordNumber: 792305
+                Synonyms:
+                - Name: Eubacterium cylindroides
+                  ConceptId: species/eubacterium-cylindroides
+                  ConceptSource: LPSN
+                  Id: 682
+                  LpsnRecordNumber: 776077
+            - Name: Holdemanella
+              ConceptType: Genus
+              ConceptId: genus/holdemanella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518633
+              Children:
+              - Name: Holdemanella biformis
+                ConceptType: Species
+                ConceptId: species/holdemanella-biformis
+                ConceptSource: LPSN
+                Id: 3293
+                LpsnRecordNumber: 792304
+                Synonyms:
+                - Name: Eubacterium biforme
+                  ConceptId: species/eubacterium-biforme
+                  ConceptSource: LPSN
+                  Id: 1483
+                  LpsnRecordNumber: 776070
+            - Name: Holdemania
+              ConceptType: Genus
+              ConceptId: genus/holdemania
+              ConceptSource: LPSN
+              Id: 469
+              LpsnRecordNumber: 515805
+              Children:
+              - Name: Holdemania filiformis
+                ConceptType: Species
+                ConceptId: species/holdemania-filiformis
+                ConceptSource: LPSN
+                Id: 1646
+                LpsnRecordNumber: 776911
+            - Name: Solobacterium
+              ConceptType: Genus
+              ConceptId: genus/solobacterium
+              ConceptSource: LPSN
+              Id: 2589
+              LpsnRecordNumber: 517349
+              Children:
+              - Name: Solobacterium moorei
+                ConceptType: Species
+                ConceptId: species/solobacterium-moorei
+                ConceptSource: LPSN
+                Id: 1996
+                LpsnRecordNumber: 784913
+          - Name: Turicibacteraceae
+            ConceptType: Family
+            ConceptId: family/turicibacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 13793
+            Children:
+            - Name: Turicibacter
+              ConceptType: Genus
+              ConceptId: genus/turicibacter
+              ConceptSource: LPSN
+              Id: 1037
+              LpsnRecordNumber: 516877
+              Children:
+              - Name: Turicibacter sanguinis
+                ConceptType: Species
+                ConceptId: species/turicibacter-sanguinis
+                ConceptSource: LPSN
+                Id: 416
+                LpsnRecordNumber: 782902
+      - Name: Negativicutes
+        ConceptType: Class
+        ConceptId: class/negativicutes
+        ConceptSource: LPSN
+        LpsnRecordNumber: 56
+        Children:
+        - Name: Acidaminococcales
+          ConceptType: Order
+          ConceptId: order/acidaminococcales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5175
+          Children:
+          - Name: Acidaminococcaceae
+            ConceptType: Family
+            ConceptId: family/acidaminococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 19
+            Children:
+            - Name: Acidaminococcus
+              ConceptType: Genus
+              ConceptId: genus/acidaminococcus
+              ConceptSource: LPSN
+              Id: 2521
+              LpsnRecordNumber: 515006
+              Children:
+              - Name: Acidaminococcus fermentans
+                ConceptType: Species
+                ConceptId: species/acidaminococcus-fermentans
+                ConceptSource: LPSN
+                Id: 746
+                LpsnRecordNumber: 772571
+        - Name: Selenomonadales
+          ConceptType: Order
+          ConceptId: order/selenomonadales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5117
+          Children:
+          - Name: Selenomonadaceae
+            ConceptType: Family
+            ConceptId: family/selenomonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2042
+            Children:
+            - Name: Centipeda
+              ConceptType: Genus
+              ConceptId: genus/centipeda
+              ConceptSource: LPSN
+              Id: 2014
+              LpsnRecordNumber: 515335
+              Children:
+              - Name: Centipeda periodontii
+                ConceptType: Species
+                ConceptId: species/centipeda-periodontii
+                ConceptSource: LPSN
+                Id: 179
+                LpsnRecordNumber: 774585
+            - Name: Megamonas
+              ConceptType: Genus
+              ConceptId: genus/megamonas
+              ConceptSource: LPSN
+              Id: 160
+              LpsnRecordNumber: 516029
+              Children:
+              - Name: Megamonas hypermegale
+                ConceptType: Species
+                ConceptId: species/megamonas-hypermegale
+                ConceptSource: LPSN
+                Id: 1476
+                LpsnRecordNumber: 777743
+                Synonyms:
+                - Name: Bacteroides hypermegas
+                  ConceptId: species/bacteroides-hypermegas
+                  ConceptSource: LPSN
+                  Id: 1640
+                  LpsnRecordNumber: 773950
+                - Name: Megamonas hypermegas
+                  ConceptId: species/megamonas-hypermegas
+                  ConceptSource: LPSN
+                  Id: 1590
+                  LpsnRecordNumber: 784191
+            - Name: Mitsuokella
+              ConceptType: Genus
+              ConceptId: genus/mitsuokella
+              ConceptSource: LPSN
+              Id: 1543
+              LpsnRecordNumber: 516108
+              Children:
+              - Name: Mitsuokella multacida
+                ConceptType: Species
+                ConceptId: species/mitsuokella-multacida
+                ConceptSource: LPSN
+                Id: 915
+                LpsnRecordNumber: 778274
+                Synonyms:
+                - Name: Bacteroides multiacidus
+                  ConceptId: species/bacteroides-multiacidus
+                  ConceptSource: LPSN
+                  Id: 2523
+                  LpsnRecordNumber: 773962
+            - Name: Selenomonas
+              ConceptType: Genus
+              ConceptId: genus/selenomonas
+              ConceptSource: LPSN
+              Id: 619
+              LpsnRecordNumber: 516580
+              Children:
+              - Name: Selenomonas artemidis
+                ConceptType: Species
+                ConceptId: species/selenomonas-artemidis
+                ConceptSource: LPSN
+                Id: 748
+                LpsnRecordNumber: 784867
+              - Name: Selenomonas dianae
+                ConceptType: Species
+                ConceptId: species/selenomonas-dianae
+                ConceptSource: LPSN
+                Id: 1656
+                LpsnRecordNumber: 784868
+              - Name: Selenomonas flueggei
+                ConceptType: Species
+                ConceptId: species/selenomonas-flueggei
+                ConceptSource: LPSN
+                Id: 1609
+                LpsnRecordNumber: 784869
+              - Name: Selenomonas infelix
+                ConceptType: Species
+                ConceptId: species/selenomonas-infelix
+                ConceptSource: LPSN
+                Id: 165
+                LpsnRecordNumber: 784870
+              - Name: Selenomonas noxia
+                ConceptType: Species
+                ConceptId: species/selenomonas-noxia
+                ConceptSource: LPSN
+                Id: 1221
+                LpsnRecordNumber: 784872
+              - Name: Selenomonas sputigena
+                ConceptType: Species
+                ConceptId: species/selenomonas-sputigena
+                ConceptSource: LPSN
+                Id: 2029
+                LpsnRecordNumber: 780853
+        - Name: Veillonellales
+          ConceptType: Order
+          ConceptId: order/veillonellales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5176
+          Children:
+          - Name: Veillonellaceae
+            ConceptType: Family
+            ConceptId: family/veillonellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1538
+            Children:
+            - Name: Dialister
+              ConceptType: Genus
+              ConceptId: genus/dialister
+              ConceptSource: LPSN
+              Id: 1781
+              LpsnRecordNumber: 515522
+              Children:
+              - Name: Dialister micraerophilus
+                ConceptType: Species
+                ConceptId: species/dialister-micraerophilus
+                ConceptSource: LPSN
+                Id: 1337
+                LpsnRecordNumber: 783743
+              - Name: Dialister pneumosintes
+                ConceptType: Species
+                ConceptId: species/dialister-pneumosintes
+                ConceptSource: LPSN
+                Id: 2270
+                LpsnRecordNumber: 775758
+            - Name: Megasphaera
+              ConceptType: Genus
+              ConceptId: genus/megasphaera
+              ConceptSource: LPSN
+              Id: 483
+              LpsnRecordNumber: 516031
+              Children:
+              - Name: Megasphaera elsdenii
+                ConceptType: Species
+                ConceptId: species/megasphaera-elsdenii
+                ConceptSource: LPSN
+                Id: 1144
+                LpsnRecordNumber: 777746
+            - Name: Veillonella
+              ConceptType: Genus
+              ConceptId: genus/veillonella
+              ConceptSource: LPSN
+              Id: 2566
+              LpsnRecordNumber: 516893
+              Children:
+              - Name: Veillonella atypica
+                ConceptType: Species
+                ConceptId: species/veillonella-atypica
+                ConceptSource: LPSN
+                Id: 1987
+                LpsnRecordNumber: 782957
+              - Name: Veillonella caviae
+                ConceptType: Species
+                ConceptId: species/veillonella-caviae
+                ConceptSource: LPSN
+                Id: 928
+                LpsnRecordNumber: 782958
+              - Name: Veillonella criceti
+                ConceptType: Species
+                ConceptId: species/veillonella-criceti
+                ConceptSource: LPSN
+                Id: 2176
+                LpsnRecordNumber: 782959
+              - Name: Veillonella dispar
+                ConceptType: Species
+                ConceptId: species/veillonella-dispar
+                ConceptSource: LPSN
+                Id: 64
+                LpsnRecordNumber: 782960
+              - Name: Veillonella montpellierensis
+                ConceptType: Species
+                ConceptId: species/veillonella-montpellierensis
+                ConceptSource: LPSN
+                Id: 7
+                LpsnRecordNumber: 782961
+              - Name: Veillonella parvula
+                ConceptType: Species
+                ConceptId: species/veillonella-parvula
+                ConceptSource: LPSN
+                Id: 674
+                LpsnRecordNumber: 782962
+                Synonyms:
+                - Name: Veillonella alcalescens
+                  ConceptId: species/veillonella-alcalescens
+                  ConceptSource: LPSN
+                  Id: 1169
+                  LpsnRecordNumber: 785140
+              - Name: Veillonella ratti
+                ConceptType: Species
+                ConceptId: species/veillonella-ratti
+                ConceptSource: LPSN
+                Id: 1489
+                LpsnRecordNumber: 782965
+              - Name: Veillonella rodentium
+                ConceptType: Species
+                ConceptId: species/veillonella-rodentium
+                ConceptSource: LPSN
+                Id: 2047
+                LpsnRecordNumber: 782966
+    - Name: Mycoplasmatota
+      ConceptType: Phylum
+      ConceptId: phylum/mycoplasmatota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 25904
+      Children:
+      - Name: Mollicutes
+        ConceptType: Class
+        ConceptId: class/mollicutes
+        ConceptSource: LPSN
+        LpsnRecordNumber: 55
+        Children:
+        - Name: Acholeplasmatales
+          ConceptType: Order
+          ConceptId: order/acholeplasmatales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5033
+          Children:
+          - Name: Acholeplasmataceae
+            ConceptType: Family
+            ConceptId: family/acholeplasmataceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 14
+            Children:
+            - Name: Acholeplasma
+              ConceptType: Genus
+              ConceptId: genus/acholeplasma
+              ConceptSource: LPSN
+              Id: 57
+              LpsnRecordNumber: 515002
+              Children:
+              - Name: Acholeplasma laidlawii
+                ConceptType: Species
+                ConceptId: species/acholeplasma-laidlawii
+                ConceptSource: LPSN
+                Id: 829
+                LpsnRecordNumber: 772547
+              - Name: Acholeplasma oculi
+                ConceptType: Species
+                ConceptId: species/acholeplasma-oculi
+                ConceptSource: LPSN
+                Id: 1347
+                LpsnRecordNumber: 783257
+        - Name: Mycoplasmatales
+          ConceptType: Order
+          ConceptId: order/mycoplasmatales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 4994
+          Children:
+          - Name: Mycoplasmataceae
+            ConceptType: Family
+            ConceptId: family/mycoplasmataceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 916
+            Children:
+            - Name: Mycoplasma
+              ConceptType: Genus
+              ConceptId: genus/mycoplasma
+              ConceptSource: LPSN
+              Id: 2378
+              LpsnRecordNumber: 517290
+              Children:
+              - Name: Mycoplasma spermatophilum
+                ConceptType: Species
+                ConceptId: species/mycoplasma-spermatophilum
+                ConceptSource: LPSN
+                Id: 101
+                LpsnRecordNumber: 784435
+        - Name: Mycoplasmoidales
+          ConceptType: Order
+          ConceptId: order/mycoplasmoidales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 4984
+          Children:
+          - Name: Metamycoplasmataceae
+            ConceptType: Family
+            ConceptId: family/metamycoplasmataceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 4819
+            Children:
+            - Name: Metamycoplasma
+              ConceptType: Genus
+              ConceptId: genus/metamycoplasma
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520439
+              Children:
+              - Name: Metamycoplasma buccale
+                ConceptType: Species
+                ConceptId: species/metamycoplasma-buccale
+                ConceptSource: LPSN
+                Id: 3059
+                LpsnRecordNumber: 798564
+                Synonyms:
+                - Name: Mycoplasma buccale
+                  ConceptId: species/mycoplasma-buccale
+                  ConceptSource: LPSN
+                  Id: 2290
+                  LpsnRecordNumber: 784333
+              - Name: Metamycoplasma faucium
+                ConceptType: Species
+                ConceptId: species/metamycoplasma-faucium
+                ConceptSource: LPSN
+                Id: 3037
+                LpsnRecordNumber: 798580
+                Synonyms:
+                - Name: Mycoplasma faucium
+                  ConceptId: species/mycoplasma-faucium
+                  ConceptSource: LPSN
+                  Id: 1093
+                  LpsnRecordNumber: 784364
+              - Name: Metamycoplasma hominis
+                ConceptType: Species
+                ConceptId: species/metamycoplasma-hominis
+                ConceptSource: LPSN
+                Id: 2983
+                LpsnRecordNumber: 798591
+                Synonyms:
+                - Name: Mycoplasma hominis
+                  ConceptId: species/mycoplasma-hominis
+                  ConceptSource: LPSN
+                  Id: 1124
+                  LpsnRecordNumber: 784382
+              - Name: Metamycoplasma orale
+                ConceptType: Species
+                ConceptId: species/metamycoplasma-orale
+                ConceptSource: LPSN
+                Id: 3002
+                LpsnRecordNumber: 798612
+                Synonyms:
+                - Name: Mycoplasma orale
+                  ConceptId: species/mycoplasma-orale
+                  ConceptSource: LPSN
+                  Id: 509
+                  LpsnRecordNumber: 784415
+              - Name: Metamycoplasma salivarium
+                ConceptType: Species
+                ConceptId: species/metamycoplasma-salivarium
+                ConceptSource: LPSN
+                Id: 3280
+                LpsnRecordNumber: 798622
+                Synonyms:
+                - Name: Mycoplasma salivarium
+                  ConceptId: species/mycoplasma-salivarium
+                  ConceptSource: LPSN
+                  Id: 919
+                  LpsnRecordNumber: 784432
+            - Name: Mycoplasmopsis
+              ConceptType: Genus
+              ConceptId: genus/mycoplasmopsis
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520442
+              Children:
+              - Name: Mycoplasmopsis fermentans
+                ConceptType: Species
+                ConceptId: species/mycoplasmopsis-fermentans
+                ConceptSource: LPSN
+                Id: 3047
+                LpsnRecordNumber: 798582
+                Synonyms:
+                - Name: Mycoplasma fermentans
+                  ConceptId: species/mycoplasma-fermentans
+                  ConceptSource: LPSN
+                  Id: 1478
+                  LpsnRecordNumber: 784368
+              - Name: Mycoplasmopsis lipophila
+                ConceptType: Species
+                ConceptId: species/mycoplasmopsis-lipophila
+                ConceptSource: LPSN
+                Id: 3071
+                LpsnRecordNumber: 798600
+                Synonyms:
+                - Name: Mycoplasma lipophilum
+                  ConceptId: species/mycoplasma-lipophilum
+                  ConceptSource: LPSN
+                  Id: 2106
+                  LpsnRecordNumber: 784398
+              - Name: Mycoplasmopsis primatum
+                ConceptType: Species
+                ConceptId: species/mycoplasmopsis-primatum
+                ConceptSource: LPSN
+                Id: 2998
+                LpsnRecordNumber: 798619
+                Synonyms:
+                - Name: Mycoplasma primatum
+                  ConceptId: species/mycoplasma-primatum
+                  ConceptSource: LPSN
+                  Id: 717
+                  LpsnRecordNumber: 784428
+          - Name: Mycoplasmoidaceae
+            ConceptType: Family
+            ConceptId: family/mycoplasmoidaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 4820
+            Children:
+            - Name: Malacoplasma
+              ConceptType: Genus
+              ConceptId: genus/malacoplasma
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520437
+              Children:
+              - Name: Malacoplasma penetrans
+                ConceptType: Species
+                ConceptId: species/malacoplasma-penetrans
+                ConceptSource: LPSN
+                Id: 3246
+                LpsnRecordNumber: 798614
+                Synonyms:
+                - Name: Mycoplasma penetrans
+                  ConceptId: species/mycoplasma-penetrans
+                  ConceptSource: LPSN
+                  Id: 1961
+                  LpsnRecordNumber: 784419
+            - Name: Mycoplasmoides
+              ConceptType: Genus
+              ConceptId: genus/mycoplasmoides
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520441
+              Children:
+              - Name: Mycoplasmoides genitalium
+                ConceptType: Species
+                ConceptId: species/mycoplasmoides-genitalium
+                ConceptSource: LPSN
+                Id: 3072
+                LpsnRecordNumber: 798589
+                Synonyms:
+                - Name: Mycoplasma genitalium
+                  ConceptId: species/mycoplasma-genitalium
+                  ConceptSource: LPSN
+                  Id: 229
+                  LpsnRecordNumber: 784375
+              - Name: Mycoplasmoides pirum
+                ConceptType: Species
+                ConceptId: species/mycoplasmoides-pirum
+                ConceptSource: LPSN
+                Id: 3118
+                LpsnRecordNumber: 798617
+                Synonyms:
+                - Name: Mycoplasma pirum
+                  ConceptId: species/mycoplasma-pirum
+                  ConceptSource: LPSN
+                  Id: 1787
+                  LpsnRecordNumber: 784426
+              - Name: Mycoplasmoides pneumoniae
+                ConceptType: Species
+                ConceptId: species/mycoplasmoides-pneumoniae
+                ConceptSource: LPSN
+                Id: 2986
+                LpsnRecordNumber: 798618
+                Synonyms:
+                - Name: Mycoplasma pneumoniae
+                  ConceptId: species/mycoplasma-pneumoniae
+                  ConceptSource: LPSN
+                  Id: 2136
+                  LpsnRecordNumber: 784427
+            - Name: Ureaplasma
+              ConceptType: Genus
+              ConceptId: genus/ureaplasma
+              ConceptSource: LPSN
+              Id: 158
+              LpsnRecordNumber: 517383
+              Children:
+              - Name: Ureaplasma parvum
+                ConceptType: Species
+                ConceptId: species/ureaplasma-parvum
+                ConceptSource: LPSN
+                Id: 2344
+                LpsnRecordNumber: 785137
+              - Name: Ureaplasma urealyticum
+                ConceptType: Species
+                ConceptId: species/ureaplasma-urealyticum
+                ConceptSource: LPSN
+                Id: 1572
+                LpsnRecordNumber: 785138
+  - Name: Fusobacteriati
+    ConceptType: Kingdom
+    ConceptId: kingdom/fusobacteriati
+    ConceptSource: LPSN
+    LpsnRecordNumber: 43125
+    Children:
+    - Name: Fusobacteriota
+      ConceptType: Phylum
+      ConceptId: phylum/fusobacteriota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 44962
+      Children:
+      - Name: Fusobacteriia
+        ConceptType: Class
+        ConceptId: class/fusobacteriia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 83
+        Children:
+        - Name: Fusobacteriales
+          ConceptType: Order
+          ConceptId: order/fusobacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5131
+          Children:
+          - Name: Fusobacteriaceae
+            ConceptType: Family
+            ConceptId: family/fusobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 545
+            Children:
+            - Name: Fusobacterium
+              ConceptType: Genus
+              ConceptId: genus/fusobacterium
+              ConceptSource: LPSN
+              Id: 1359
+              LpsnRecordNumber: 515666
+              Children:
+              - Name: Fusobacterium canifelinum
+                ConceptType: Species
+                ConceptId: species/fusobacterium-canifelinum
+                ConceptSource: LPSN
+                Id: 941
+                LpsnRecordNumber: 776401
+              - Name: Fusobacterium gonidiaformans
+                ConceptType: Species
+                ConceptId: species/fusobacterium-gonidiaformans
+                ConceptSource: LPSN
+                Id: 1534
+                LpsnRecordNumber: 783877
+                Synonyms:
+                - Name: Fusobacterium equinum
+                  ConceptId: species/fusobacterium-equinum
+                  ConceptSource: LPSN
+                  Id: 662
+                  LpsnRecordNumber: 776402
+              - Name: Fusobacterium mortiferum
+                ConceptType: Species
+                ConceptId: species/fusobacterium-mortiferum
+                ConceptSource: LPSN
+                Id: 907
+                LpsnRecordNumber: 783878
+              - Name: Fusobacterium naviforme
+                ConceptType: Species
+                ConceptId: species/fusobacterium-naviforme
+                ConceptSource: LPSN
+                Id: 1959
+                LpsnRecordNumber: 776403
+              - Name: Fusobacterium necrogenes
+                ConceptType: Species
+                ConceptId: species/fusobacterium-necrogenes
+                ConceptSource: LPSN
+                Id: 504
+                LpsnRecordNumber: 783879
+              - Name: Fusobacterium necrophorum
+                ConceptType: Species
+                ConceptId: species/fusobacterium-necrophorum
+                ConceptSource: LPSN
+                Id: 1165
+                LpsnRecordNumber: 783880
+                Children:
+                - Name: Fusobacterium necrophorum subsp. necrophorum
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/fusobacterium-necrophorum-necrophorum
+                  ConceptSource: LPSN
+                  Id: 1404
+                  LpsnRecordNumber: 776404
+                Synonyms:
+                - Name: Fusobacterium necrophorum subsp. funduliforme
+                  ConceptId: subspecies/fusobacterium-necrophorum-funduliforme
+                  ConceptSource: LPSN
+                  Id: 2945
+                  LpsnRecordNumber: 783881
+              - Name: Fusobacterium nucleatum
+                ConceptType: Species
+                ConceptId: species/fusobacterium-nucleatum
+                ConceptSource: LPSN
+                Id: 4
+                LpsnRecordNumber: 783882
+                Children:
+                - Name: Fusobacterium nucleatum subsp. nucleatum
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/fusobacterium-nucleatum-nucleatum
+                  ConceptSource: LPSN
+                  Id: 1988
+                  LpsnRecordNumber: 776408
+                - Name: Fusobacterium nucleatum subsp. polymorphum
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/fusobacterium-nucleatum-polymorphum
+                  ConceptSource: LPSN
+                  Id: 699
+                  LpsnRecordNumber: 776409
+                  Synonyms:
+                  - Name: Fusobacterium polymorphum
+                    ConceptId: species/fusobacterium-polymorphum
+                    ConceptSource: LPSN
+                    Id: 940
+                    LpsnRecordNumber: 28163
+                Synonyms:
+                - Name: Fusobacterium nucleatum subsp. fusiforme
+                  ConceptId: subspecies/fusobacterium-nucleatum-fusiforme
+                  ConceptSource: LPSN
+                  Id: 202
+                  LpsnRecordNumber: 776407
+                - Name: Fusobacterium vincentii
+                  ConceptId: species/fusobacterium-vincentii
+                  ConceptSource: LPSN
+                  Id: 2989
+                  LpsnRecordNumber: 28103
+              - Name: Fusobacterium periodonticum
+                ConceptType: Species
+                ConceptId: species/fusobacterium-periodonticum
+                ConceptSource: LPSN
+                Id: 591
+                LpsnRecordNumber: 783885
+              - Name: Fusobacterium russii
+                ConceptType: Species
+                ConceptId: species/fusobacterium-russii
+                ConceptSource: LPSN
+                Id: 2036
+                LpsnRecordNumber: 783889
+              - Name: Fusobacterium ulcerans
+                ConceptType: Species
+                ConceptId: species/fusobacterium-ulcerans
+                ConceptSource: LPSN
+                Id: 1851
+                LpsnRecordNumber: 783892
+              - Name: Fusobacterium varium
+                ConceptType: Species
+                ConceptId: species/fusobacterium-varium
+                ConceptSource: LPSN
+                Id: 125
+                LpsnRecordNumber: 783893
+          - Name: Leptotrichiaceae
+            ConceptType: Family
+            ConceptId: family/leptotrichiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1912
+            Children:
+            - Name: Leptotrichia
+              ConceptType: Genus
+              ConceptId: genus/leptotrichia
+              ConceptSource: LPSN
+              Id: 1777
+              LpsnRecordNumber: 515952
+              Children:
+              - Name: Leptotrichia buccalis
+                ConceptType: Species
+                ConceptId: species/leptotrichia-buccalis
+                ConceptSource: LPSN
+                Id: 1622
+                LpsnRecordNumber: 777518
+              - Name: Leptotrichia trevisanii
+                ConceptType: Species
+                ConceptId: species/leptotrichia-trevisanii
+                ConceptSource: LPSN
+                Id: 1259
+                LpsnRecordNumber: 784152
+              - Name: Leptotrichia wadei
+                ConceptType: Species
+                ConceptId: species/leptotrichia-wadei
+                ConceptSource: LPSN
+                Id: 250
+                LpsnRecordNumber: 784153
+            - Name: Pseudoleptotrichia
+              ConceptType: Genus
+              ConceptId: genus/pseudoleptotrichia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 4896
+              Children:
+              - Name: Pseudoleptotrichia goodfellowii
+                ConceptType: Species
+                ConceptId: species/pseudoleptotrichia-goodfellowii
+                ConceptSource: LPSN
+                Id: 3025
+                LpsnRecordNumber: 5395
+                Synonyms:
+                - Name: Leptotrichia goodfellowii
+                  ConceptId: species/leptotrichia-goodfellowii
+                  ConceptSource: LPSN
+                  Id: 1494
+                  LpsnRecordNumber: 784149
+            - Name: Sneathia
+              ConceptType: Genus
+              ConceptId: genus/sneathia
+              ConceptSource: LPSN
+              Id: 1244
+              LpsnRecordNumber: 517348
+              Children:
+              - Name: Sneathia sanguinegens
+                ConceptType: Species
+                ConceptId: species/sneathia-sanguinegens
+                ConceptSource: LPSN
+                Id: 524
+                LpsnRecordNumber: 784912
+            - Name: Streptobacillus
+              ConceptType: Genus
+              ConceptId: genus/streptobacillus
+              ConceptSource: LPSN
+              Id: 231
+              LpsnRecordNumber: 516688
+              Children:
+              - Name: Streptobacillus moniliformis
+                ConceptType: Species
+                ConceptId: species/streptobacillus-moniliformis
+                ConceptSource: LPSN
+                Id: 566
+                LpsnRecordNumber: 781292
+  - Name: Pseudomonadati
+    ConceptType: Kingdom
+    ConceptId: kingdom/pseudomonadati
+    ConceptSource: LPSN
+    LpsnRecordNumber: 43130
+    Children:
+    - Name: Bacteroidota
+      ConceptType: Phylum
+      ConceptId: phylum/bacteroidota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 25877
+      Children:
+      - Name: Bacteroidia
+        ConceptType: Class
+        ConceptId: class/bacteroidia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 86
+        Children:
+        - Name: Bacteroidales
+          ConceptType: Order
+          ConceptId: order/bacteroidales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5127
+          Children:
+          - Name: Bacteroidaceae
+            ConceptType: Family
+            ConceptId: family/bacteroidaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 195
+            Children:
+            - Name: Bacteroides
+              ConceptType: Genus
+              ConceptId: genus/bacteroides
+              ConceptSource: LPSN
+              Id: 44
+              LpsnRecordNumber: 517409
+              Children:
+              - Name: Bacteroides fragilis group
+                ConceptType: Group
+                ConceptId: 78
+                ConceptSource: NeoIPC
+                Id: 2939
+              - Name: Bacteroides caccae
+                ConceptType: Species
+                ConceptId: species/bacteroides-caccae
+                ConceptSource: LPSN
+                Id: 2408
+                LpsnRecordNumber: 783439
+              - Name: Bacteroides denticanum
+                ConceptType: Species
+                ConceptId: species/bacteroides-denticanum
+                ConceptSource: LPSN
+                Id: 2896
+                LpsnRecordNumber: 19298
+              - Name: Bacteroides eggerthii
+                ConceptType: Species
+                ConceptId: species/bacteroides-eggerthii
+                ConceptSource: LPSN
+                Id: 1923
+                LpsnRecordNumber: 773943
+              - Name: Bacteroides faecis
+                ConceptType: Species
+                ConceptId: species/bacteroides-faecis
+                ConceptSource: LPSN
+                Id: 2899
+                LpsnRecordNumber: 788868
+              - Name: Bacteroides fluxus
+                ConceptType: Species
+                ConceptId: species/bacteroides-fluxus
+                ConceptSource: LPSN
+                Id: 2900
+                LpsnRecordNumber: 788691
+              - Name: Bacteroides fragilis
+                ConceptType: Species
+                ConceptId: species/bacteroides-fragilis
+                ConceptSource: LPSN
+                Id: 1296
+                LpsnRecordNumber: 773945
+              - Name: Bacteroides galacturonicus
+                ConceptType: Species
+                ConceptId: species/bacteroides-galacturonicus
+                ConceptSource: LPSN
+                Id: 2902
+                LpsnRecordNumber: 773946
+              - Name: Bacteroides nordii
+                ConceptType: Species
+                ConceptId: species/bacteroides-nordii
+                ConceptSource: LPSN
+                Id: 772
+                LpsnRecordNumber: 783452
+              - Name: Bacteroides ovatus
+                ConceptType: Species
+                ConceptId: species/bacteroides-ovatus
+                ConceptSource: LPSN
+                Id: 685
+                LpsnRecordNumber: 773966
+              - Name: Bacteroides pectinophilus
+                ConceptType: Species
+                ConceptId: species/bacteroides-pectinophilus
+                ConceptSource: LPSN
+                Id: 2903
+                LpsnRecordNumber: 783455
+              - Name: Bacteroides pyogenes
+                ConceptType: Species
+                ConceptId: species/bacteroides-pyogenes
+                ConceptSource: LPSN
+                Id: 1217
+                LpsnRecordNumber: 773970
+                Synonyms:
+                - Name: Bacteroides suis
+                  ConceptId: species/bacteroides-suis
+                  ConceptSource: LPSN
+                  Id: 2562
+                  LpsnRecordNumber: 773974
+                - Name: Bacteroides tectus
+                  ConceptId: species/bacteroides-tectus
+                  ConceptSource: LPSN
+                  Id: 925
+                  LpsnRecordNumber: 783468
+              - Name: Bacteroides salyersiae
+                ConceptType: Species
+                ConceptId: species/bacteroides-salyersiae
+                ConceptSource: LPSN
+                Id: 2904
+                LpsnRecordNumber: 785773
+              - Name: Bacteroides stercoris
+                ConceptType: Species
+                ConceptId: species/bacteroides-stercoris
+                ConceptSource: LPSN
+                Id: 2216
+                LpsnRecordNumber: 783465
+              - Name: Bacteroides thetaiotaomicron
+                ConceptType: Species
+                ConceptId: species/bacteroides-thetaiotaomicron
+                ConceptSource: LPSN
+                Id: 2104
+                LpsnRecordNumber: 773976
+              - Name: Bacteroides uniformis
+                ConceptType: Species
+                ConceptId: species/bacteroides-uniformis
+                ConceptSource: LPSN
+                Id: 1027
+                LpsnRecordNumber: 773977
+              - Name: Bacteroides zoogleoformans
+                ConceptType: Species
+                ConceptId: species/bacteroides-zoogleoformans
+                ConceptSource: LPSN
+                Id: 2009
+                LpsnRecordNumber: 783471
+                Synonyms:
+                - Name: Prevotella zoogleoformans
+                  ConceptId: species/prevotella-zoogleoformans
+                  ConceptSource: LPSN
+                  Id: 1421
+                  LpsnRecordNumber: 784687
+            - Name: Phocaeicola
+              ConceptType: Genus
+              ConceptId: genus/phocaeicola
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517895
+              Children:
+              - Name: Phocaeicola dorei
+                ConceptType: Species
+                ConceptId: species/phocaeicola-dorei
+                ConceptSource: LPSN
+                Id: 2897
+                LpsnRecordNumber: 7835
+                Carbapenems: true
+                Synonyms:
+                - Name: Bacteroides dorei
+                  ConceptId: species/bacteroides-dorei
+                  ConceptSource: LPSN
+                  Id: 2898
+                  LpsnRecordNumber: 773942
+              - Name: Phocaeicola massiliensis
+                ConceptType: Species
+                ConceptId: species/phocaeicola-massiliensis
+                ConceptSource: LPSN
+                Id: 3039
+                LpsnRecordNumber: 7836
+                Carbapenems: true
+                Synonyms:
+                - Name: Bacteroides massiliensis
+                  ConceptId: species/bacteroides-massiliensis
+                  ConceptSource: LPSN
+                  Id: 2189
+                  LpsnRecordNumber: 773955
+              - Name: Phocaeicola vulgatus
+                ConceptType: Species
+                ConceptId: species/phocaeicola-vulgatus
+                ConceptSource: LPSN
+                Id: 3294
+                LpsnRecordNumber: 7841
+                Carbapenems: true
+                Synonyms:
+                - Name: Bacteroides vulgatus
+                  ConceptId: species/bacteroides-vulgatus
+                  ConceptSource: LPSN
+                  Id: 197
+                  LpsnRecordNumber: 773979
+          - Name: Dysgonomonadaceae
+            ConceptType: Family
+            ConceptId: family/dysgonomonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 7791
+            Children:
+            - Name: Dysgonomonas
+              ConceptType: Genus
+              ConceptId: genus/dysgonomonas
+              ConceptSource: LPSN
+              Id: 2469
+              LpsnRecordNumber: 517223
+              Children:
+              - Name: Dysgonomonas capnocytophagoides
+                ConceptType: Species
+                ConceptId: species/dysgonomonas-capnocytophagoides
+                ConceptSource: LPSN
+                Id: 2553
+                LpsnRecordNumber: 783749
+              - Name: Dysgonomonas gadei
+                ConceptType: Species
+                ConceptId: species/dysgonomonas-gadei
+                ConceptSource: LPSN
+                Id: 208
+                LpsnRecordNumber: 783750
+          - Name: Odoribacteraceae
+            ConceptType: Family
+            ConceptId: family/odoribacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2047
+            Children:
+            - Name: Butyricimonas
+              ConceptType: Genus
+              ConceptId: genus/butyricimonas
+              ConceptSource: LPSN
+              Id: 606
+              LpsnRecordNumber: 517878
+              Children:
+              - Name: Butyricimonas virosa
+                ConceptType: Species
+                ConceptId: species/butyricimonas-virosa
+                ConceptSource: LPSN
+                Id: 2060
+                LpsnRecordNumber: 787963
+            - Name: Odoribacter
+              ConceptType: Genus
+              ConceptId: genus/odoribacter
+              ConceptSource: LPSN
+              Id: 693
+              LpsnRecordNumber: 517748
+              Children:
+              - Name: Odoribacter splanchnicus
+                ConceptType: Species
+                ConceptId: species/odoribacter-splanchnicus
+                ConceptSource: LPSN
+                Id: 1738
+                LpsnRecordNumber: 787189
+                Synonyms:
+                - Name: Bacteroides splanchnicus
+                  ConceptId: species/bacteroides-splanchnicus
+                  ConceptSource: LPSN
+                  Id: 2311
+                  LpsnRecordNumber: 773973
+          - Name: Porphyromonadaceae
+            ConceptType: Family
+            ConceptId: family/porphyromonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1100
+            Children:
+            - Name: Porphyromonas
+              ConceptType: Genus
+              ConceptId: genus/porphyromonas
+              ConceptSource: LPSN
+              Id: 1073
+              LpsnRecordNumber: 516379
+              Children:
+              - Name: Porphyromonas asaccharolytica
+                ConceptType: Species
+                ConceptId: species/porphyromonas-asaccharolytica
+                ConceptSource: LPSN
+                Id: 2955
+                LpsnRecordNumber: 779763
+              - Name: Porphyromonas cangingivalis
+                ConceptType: Species
+                ConceptId: species/porphyromonas-cangingivalis
+                ConceptSource: LPSN
+                Id: 290
+                LpsnRecordNumber: 784661
+              - Name: Porphyromonas canoris
+                ConceptType: Species
+                ConceptId: species/porphyromonas-canoris
+                ConceptSource: LPSN
+                Id: 1006
+                LpsnRecordNumber: 784662
+              - Name: Porphyromonas catoniae
+                ConceptType: Species
+                ConceptId: species/porphyromonas-catoniae
+                ConceptSource: LPSN
+                Id: 447
+                LpsnRecordNumber: 784664
+              - Name: Porphyromonas circumdentaria
+                ConceptType: Species
+                ConceptId: species/porphyromonas-circumdentaria
+                ConceptSource: LPSN
+                Id: 505
+                LpsnRecordNumber: 784665
+              - Name: Porphyromonas crevioricanis
+                ConceptType: Species
+                ConceptId: species/porphyromonas-crevioricanis
+                ConceptSource: LPSN
+                Id: 857
+                LpsnRecordNumber: 784666
+                Synonyms:
+                - Name: Porphyromonas cansulci
+                  ConceptId: species/porphyromonas-cansulci
+                  ConceptSource: LPSN
+                  Id: 561
+                  LpsnRecordNumber: 784663
+              - Name: Porphyromonas endodontalis
+                ConceptType: Species
+                ConceptId: species/porphyromonas-endodontalis
+                ConceptSource: LPSN
+                Id: 2284
+                LpsnRecordNumber: 784667
+                Synonyms:
+                - Name: Bacteroides endodontalis
+                  ConceptId: species/bacteroides-endodontalis
+                  ConceptSource: LPSN
+                  Id: 2168
+                  LpsnRecordNumber: 783443
+              - Name: Porphyromonas gingivalis
+                ConceptType: Species
+                ConceptId: species/porphyromonas-gingivalis
+                ConceptSource: LPSN
+                Id: 1250
+                LpsnRecordNumber: 779764
+                Synonyms:
+                - Name: Bacteroides gingivalis
+                  ConceptId: species/bacteroides-gingivalis
+                  ConceptSource: LPSN
+                  Id: 1610
+                  LpsnRecordNumber: 773948
+              - Name: Porphyromonas gingivicanis
+                ConceptType: Species
+                ConceptId: species/porphyromonas-gingivicanis
+                ConceptSource: LPSN
+                Id: 1893
+                LpsnRecordNumber: 784668
+              - Name: Porphyromonas gulae
+                ConceptType: Species
+                ConceptId: species/porphyromonas-gulae
+                ConceptSource: LPSN
+                Id: 640
+                LpsnRecordNumber: 779765
+              - Name: Porphyromonas levii
+                ConceptType: Species
+                ConceptId: species/porphyromonas-levii
+                ConceptSource: LPSN
+                Id: 860
+                LpsnRecordNumber: 784669
+                Synonyms:
+                - Name: Bacteroides levii
+                  ConceptId: species/bacteroides-levii
+                  ConceptSource: LPSN
+                  Id: 1314
+                  LpsnRecordNumber: 783449
+              - Name: Porphyromonas macacae
+                ConceptType: Species
+                ConceptId: species/porphyromonas-macacae
+                ConceptSource: LPSN
+                Id: 50
+                LpsnRecordNumber: 779766
+                Synonyms:
+                - Name: Bacteroides macacae
+                  ConceptId: species/bacteroides-macacae
+                  ConceptSource: LPSN
+                  Id: 1600
+                  LpsnRecordNumber: 773954
+                - Name: Bacteroides salivosus
+                  ConceptId: species/bacteroides-salivosus
+                  ConceptSource: LPSN
+                  Id: 1237
+                  LpsnRecordNumber: 783462
+                - Name: Porphyromonas salivosa
+                  ConceptId: species/porphyromonas-salivosa
+                  ConceptSource: LPSN
+                  Id: 2402
+                  LpsnRecordNumber: 784670
+              - Name: Porphyromonas somerae
+                ConceptType: Species
+                ConceptId: species/porphyromonas-somerae
+                ConceptSource: LPSN
+                Id: 1752
+                LpsnRecordNumber: 784671
+          - Name: Prevotellaceae
+            ConceptType: Family
+            ConceptId: family/prevotellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1105
+            Children:
+            - Name: Alloprevotella
+              ConceptType: Genus
+              ConceptId: genus/alloprevotella
+              ConceptSource: LPSN
+              LpsnRecordNumber: 518330
+              Children:
+              - Name: Alloprevotella tannerae
+                ConceptType: Species
+                ConceptId: species/alloprevotella-tannerae
+                ConceptSource: LPSN
+                Id: 3223
+                LpsnRecordNumber: 790648
+                Colistin: true
+                Synonyms:
+                - Name: Prevotella tannerae
+                  ConceptId: species/prevotella-tannerae
+                  ConceptSource: LPSN
+                  Id: 526
+                  LpsnRecordNumber: 784685
+            - Name: Prevotella
+              ConceptType: Genus
+              ConceptId: genus/prevotella
+              ConceptSource: LPSN
+              Id: 1128
+              LpsnRecordNumber: 516385
+              Children:
+              - Name: Prevotella oralis group
+                ConceptType: Group
+                ConceptId: 84
+                ConceptSource: NeoIPC
+                Id: 2956
+              - Name: Prevotella bivia
+                ConceptType: Species
+                ConceptId: species/prevotella-bivia
+                ConceptSource: LPSN
+                Id: 2279
+                LpsnRecordNumber: 779783
+                Synonyms:
+                - Name: Bacteroides bivius
+                  ConceptId: species/bacteroides-bivius
+                  ConceptSource: LPSN
+                  Id: 525
+                  LpsnRecordNumber: 773931
+              - Name: Prevotella buccae
+                ConceptType: Species
+                ConceptId: species/prevotella-buccae
+                ConceptSource: LPSN
+                Id: 1355
+                LpsnRecordNumber: 779785
+                Synonyms:
+                - Name: Bacteroides buccae
+                  ConceptId: species/bacteroides-buccae
+                  ConceptSource: LPSN
+                  Id: 1984
+                  LpsnRecordNumber: 773932
+                - Name: Bacteroides capillus
+                  ConceptId: species/bacteroides-capillus
+                  ConceptSource: LPSN
+                  Id: 734
+                  LpsnRecordNumber: 783441
+                - Name: Bacteroides pentosaceus
+                  ConceptId: species/bacteroides-pentosaceus
+                  ConceptSource: LPSN
+                  Id: 2579
+                  LpsnRecordNumber: 773967
+              - Name: Prevotella buccalis
+                ConceptType: Species
+                ConceptId: species/prevotella-buccalis
+                ConceptSource: LPSN
+                Id: 1863
+                LpsnRecordNumber: 779786
+                Synonyms:
+                - Name: Bacteroides buccalis
+                  ConceptId: species/bacteroides-buccalis
+                  ConceptSource: LPSN
+                  Id: 932
+                  LpsnRecordNumber: 773933
+              - Name: Prevotella corporis
+                ConceptType: Species
+                ConceptId: species/prevotella-corporis
+                ConceptSource: LPSN
+                Id: 404
+                LpsnRecordNumber: 784674
+                Synonyms:
+                - Name: Bacteroides corporis
+                  ConceptId: species/bacteroides-corporis
+                  ConceptSource: LPSN
+                  Id: 1414
+                  LpsnRecordNumber: 783442
+              - Name: Prevotella dentalis
+                ConceptType: Species
+                ConceptId: species/prevotella-dentalis
+                ConceptSource: LPSN
+                Id: 2388
+                LpsnRecordNumber: 779788
+                Synonyms:
+                - Name: Mitsuokella dentalis
+                  ConceptId: species/mitsuokella-dentalis
+                  ConceptSource: LPSN
+                  Id: 1593
+                  LpsnRecordNumber: 778272
+              - Name: Prevotella denticola
+                ConceptType: Species
+                ConceptId: species/prevotella-denticola
+                ConceptSource: LPSN
+                Id: 338
+                LpsnRecordNumber: 779789
+                Synonyms:
+                - Name: Bacteroides denticola
+                  ConceptId: species/bacteroides-denticola
+                  ConceptSource: LPSN
+                  Id: 1222
+                  LpsnRecordNumber: 773939
+              - Name: Prevotella disiens
+                ConceptType: Species
+                ConceptId: species/prevotella-disiens
+                ConceptSource: LPSN
+                Id: 1586
+                LpsnRecordNumber: 779790
+                Synonyms:
+                - Name: Bacteroides disiens
+                  ConceptId: species/bacteroides-disiens
+                  ConceptSource: LPSN
+                  Id: 365
+                  LpsnRecordNumber: 773940
+              - Name: Prevotella enoeca
+                ConceptType: Species
+                ConceptId: species/prevotella-enoeca
+                ConceptSource: LPSN
+                Id: 1942
+                LpsnRecordNumber: 784675
+              - Name: Prevotella heparinolytica
+                ConceptType: Species
+                ConceptId: species/prevotella-heparinolytica
+                ConceptSource: LPSN
+                Id: 1272
+                LpsnRecordNumber: 784676
+                Synonyms:
+                - Name: Bacteroides heparinolyticus
+                  ConceptId: species/bacteroides-heparinolyticus
+                  ConceptSource: LPSN
+                  Id: 1413
+                  LpsnRecordNumber: 783448
+              - Name: Prevotella intermedia
+                ConceptType: Species
+                ConceptId: species/prevotella-intermedia
+                ConceptSource: LPSN
+                Id: 385
+                LpsnRecordNumber: 779791
+                Synonyms:
+                - Name: Bacteroides intermedius
+                  ConceptId: species/bacteroides-intermedius
+                  ConceptSource: LPSN
+                  Id: 2592
+                  LpsnRecordNumber: 773951
+              - Name: Prevotella loescheii
+                ConceptType: Species
+                ConceptId: species/prevotella-loescheii
+                ConceptSource: LPSN
+                Id: 2364
+                LpsnRecordNumber: 784677
+              - Name: Prevotella marshii
+                ConceptType: Species
+                ConceptId: species/prevotella-marshii
+                ConceptSource: LPSN
+                Id: 139
+                LpsnRecordNumber: 779792
+              - Name: Prevotella melaninogenica
+                ConceptType: Species
+                ConceptId: species/prevotella-melaninogenica
+                ConceptSource: LPSN
+                Id: 362
+                LpsnRecordNumber: 779793
+                Synonyms:
+                - Name: Bacteroides melaninogenicus
+                  ConceptId: species/bacteroides-melaninogenicus
+                  ConceptSource: LPSN
+                  Id: 903
+                  LpsnRecordNumber: 773956
+              - Name: Prevotella multiformis
+                ConceptType: Species
+                ConceptId: species/prevotella-multiformis
+                ConceptSource: LPSN
+                Id: 624
+                LpsnRecordNumber: 779794
+              - Name: Prevotella multisaccharivorax
+                ConceptType: Species
+                ConceptId: species/prevotella-multisaccharivorax
+                ConceptSource: LPSN
+                Id: 2332
+                LpsnRecordNumber: 779795
+              - Name: Prevotella nigrescens
+                ConceptType: Species
+                ConceptId: species/prevotella-nigrescens
+                ConceptSource: LPSN
+                Id: 2167
+                LpsnRecordNumber: 779796
+              - Name: Prevotella oralis
+                ConceptType: Species
+                ConceptId: species/prevotella-oralis
+                ConceptSource: LPSN
+                Id: 627
+                LpsnRecordNumber: 779797
+                Synonyms:
+                - Name: Bacteroides oralis
+                  ConceptId: species/bacteroides-oralis
+                  ConceptSource: LPSN
+                  Id: 1502
+                  LpsnRecordNumber: 773965
+              - Name: Prevotella oris
+                ConceptType: Species
+                ConceptId: species/prevotella-oris
+                ConceptSource: LPSN
+                Id: 1005
+                LpsnRecordNumber: 784678
+                Synonyms:
+                - Name: Bacteroides oris
+                  ConceptId: species/bacteroides-oris
+                  ConceptSource: LPSN
+                  Id: 920
+                  LpsnRecordNumber: 783453
+              - Name: Prevotella oulorum
+                ConceptType: Species
+                ConceptId: species/prevotella-oulorum
+                ConceptSource: LPSN
+                Id: 582
+                LpsnRecordNumber: 784680
+                Synonyms:
+                - Name: Bacteroides oulorum
+                  ConceptId: species/bacteroides-oulorum
+                  ConceptSource: LPSN
+                  Id: 1949
+                  LpsnRecordNumber: 783454
+                - Name: Prevotella oulora
+                  ConceptId: species/prevotella-oulora
+                  ConceptSource: LPSN
+                  Id: 213
+                  LpsnRecordNumber: 784679
+              - Name: Prevotella pallens
+                ConceptType: Species
+                ConceptId: species/prevotella-pallens
+                ConceptSource: LPSN
+                Id: 194
+                LpsnRecordNumber: 784681
+              - Name: Prevotella ruminicola
+                ConceptType: Species
+                ConceptId: species/prevotella-ruminicola
+                ConceptSource: LPSN
+                Id: 2522
+                LpsnRecordNumber: 784682
+                Synonyms:
+                - Name: Bacteroides ruminicola
+                  ConceptId: species/bacteroides-ruminicola
+                  ConceptSource: LPSN
+                  Id: 1778
+                  LpsnRecordNumber: 783459
+              - Name: Prevotella salivae
+                ConceptType: Species
+                ConceptId: species/prevotella-salivae
+                ConceptSource: LPSN
+                Id: 1545
+                LpsnRecordNumber: 779798
+              - Name: Prevotella shahii
+                ConceptType: Species
+                ConceptId: species/prevotella-shahii
+                ConceptSource: LPSN
+                Id: 909
+                LpsnRecordNumber: 779799
+              - Name: Prevotella veroralis
+                ConceptType: Species
+                ConceptId: species/prevotella-veroralis
+                ConceptSource: LPSN
+                Id: 1472
+                LpsnRecordNumber: 784686
+                Synonyms:
+                - Name: Bacteroides veroralis
+                  ConceptId: species/bacteroides-veroralis
+                  ConceptSource: LPSN
+                  Id: 1213
+                  LpsnRecordNumber: 783470
+          - Name: Rikenellaceae
+            ConceptType: Family
+            ConceptId: family/rikenellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1202
+            Children:
+            - Name: Alistipes
+              ConceptType: Genus
+              ConceptId: genus/alistipes
+              ConceptSource: LPSN
+              Id: 1906
+              LpsnRecordNumber: 515078
+              Children:
+              - Name: Alistipes putredinis
+                ConceptType: Species
+                ConceptId: species/alistipes-putredinis
+                ConceptSource: LPSN
+                Id: 1619
+                LpsnRecordNumber: 773065
+                Synonyms:
+                - Name: Bacteroides putredinis
+                  ConceptId: species/bacteroides-putredinis
+                  ConceptSource: LPSN
+                  Id: 84
+                  LpsnRecordNumber: 783458
+          - Name: Tannerellaceae
+            ConceptType: Family
+            ConceptId: family/tannerellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 29533
+            Children:
+            - Name: Parabacteroides
+              ConceptType: Genus
+              ConceptId: genus/parabacteroides
+              ConceptSource: LPSN
+              Id: 1493
+              LpsnRecordNumber: 516255
+              Children:
+              - Name: Parabacteroides chongii
+                ConceptType: Species
+                ConceptId: species/parabacteroides-chongii
+                ConceptSource: LPSN
+                Id: 2905
+                LpsnRecordNumber: 800750
+              - Name: Parabacteroides distasonis
+                ConceptType: Species
+                ConceptId: species/parabacteroides-distasonis
+                ConceptSource: LPSN
+                Id: 1928
+                LpsnRecordNumber: 779148
+                Synonyms:
+                - Name: Bacteroides distasonis
+                  ConceptId: species/bacteroides-distasonis
+                  ConceptSource: LPSN
+                  Id: 382
+                  LpsnRecordNumber: 785239
+              - Name: Parabacteroides goldsteinii
+                ConceptType: Species
+                ConceptId: species/parabacteroides-goldsteinii
+                ConceptSource: LPSN
+                Id: 1515
+                LpsnRecordNumber: 785240
+                Synonyms:
+                - Name: Bacteroides goldsteinii
+                  ConceptId: species/bacteroides-goldsteinii
+                  ConceptSource: LPSN
+                  Id: 444
+                  LpsnRecordNumber: 795957
+              - Name: Parabacteroides gordonii
+                ConceptType: Species
+                ConceptId: species/parabacteroides-gordonii
+                ConceptSource: LPSN
+                Id: 2906
+                LpsnRecordNumber: 788208
+              - Name: Parabacteroides merdae
+                ConceptType: Species
+                ConceptId: species/parabacteroides-merdae
+                ConceptSource: LPSN
+                Id: 615
+                LpsnRecordNumber: 785241
+                Synonyms:
+                - Name: Bacteroides merdae
+                  ConceptId: species/bacteroides-merdae
+                  ConceptSource: LPSN
+                  Id: 1434
+                  LpsnRecordNumber: 795956
+            - Name: Tannerella
+              ConceptType: Genus
+              ConceptId: genus/tannerella
+              ConceptSource: LPSN
+              Id: 2531
+              LpsnRecordNumber: 517360
+              Children:
+              - Name: Tannerella forsythia
+                ConceptType: Species
+                ConceptId: species/tannerella-forsythia
+                ConceptSource: LPSN
+                Id: 2294
+                LpsnRecordNumber: 787491
+                Synonyms:
+                - Name: Bacteroides forsythus
+                  ConceptId: species/bacteroides-forsythus
+                  ConceptSource: LPSN
+                  Id: 2901
+                  LpsnRecordNumber: 783444
+      - Name: Flavobacteriia
+        ConceptType: Class
+        ConceptId: class/flavobacteriia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 39
+        Children:
+        - Name: Flavobacteriales
+          ConceptType: Order
+          ConceptId: order/flavobacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5130
+          Children:
+          - Name: Flavobacteriaceae
+            ConceptType: Family
+            ConceptId: family/flavobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 524
+            Children:
+            - Name: Capnocytophaga
+              ConceptType: Genus
+              ConceptId: genus/capnocytophaga
+              ConceptSource: LPSN
+              Id: 2177
+              LpsnRecordNumber: 515307
+              Children:
+              - Name: Capnocytophaga canimorsus
+                ConceptType: Species
+                ConceptId: species/capnocytophaga-canimorsus
+                ConceptSource: LPSN
+                Id: 29
+                LpsnRecordNumber: 783603
+              - Name: Capnocytophaga cynodegmi
+                ConceptType: Species
+                ConceptId: species/capnocytophaga-cynodegmi
+                ConceptSource: LPSN
+                Id: 1905
+                LpsnRecordNumber: 783604
+              - Name: Capnocytophaga gingivalis
+                ConceptType: Species
+                ConceptId: species/capnocytophaga-gingivalis
+                ConceptSource: LPSN
+                Id: 755
+                LpsnRecordNumber: 774466
+              - Name: Capnocytophaga granulosa
+                ConceptType: Species
+                ConceptId: species/capnocytophaga-granulosa
+                ConceptSource: LPSN
+                Id: 1518
+                LpsnRecordNumber: 774467
+              - Name: Capnocytophaga haemolytica
+                ConceptType: Species
+                ConceptId: species/capnocytophaga-haemolytica
+                ConceptSource: LPSN
+                Id: 1139
+                LpsnRecordNumber: 774468
+              - Name: Capnocytophaga ochracea
+                ConceptType: Species
+                ConceptId: species/capnocytophaga-ochracea
+                ConceptSource: LPSN
+                Id: 61
+                LpsnRecordNumber: 774469
+                Synonyms:
+                - Name: Bacteroides ochraceus
+                  ConceptId: species/bacteroides-ochraceus
+                  ConceptSource: LPSN
+                  Id: 742
+                  LpsnRecordNumber: 773964
+              - Name: Capnocytophaga sputigena
+                ConceptType: Species
+                ConceptId: species/capnocytophaga-sputigena
+                ConceptSource: LPSN
+                Id: 499
+                LpsnRecordNumber: 774470
+            - Name: Flavobacterium
+              ConceptType: Genus
+              ConceptId: genus/flavobacterium
+              ConceptSource: LPSN
+              Id: 2299
+              LpsnRecordNumber: 515640
+              Children:
+              - Name: Flavobacterium devorans
+                ConceptType: Species
+                ConceptId: species/flavobacterium-devorans
+                ConceptSource: LPSN
+                Id: 1688
+                LpsnRecordNumber: 776232
+            - Name: Myroides
+              ConceptType: Genus
+              ConceptId: genus/myroides
+              ConceptSource: LPSN
+              Id: 1308
+              LpsnRecordNumber: 516143
+              Children:
+              - Name: Myroides odoratus
+                ConceptType: Species
+                ConceptId: species/myroides-odoratus
+                ConceptSource: LPSN
+                Id: 1743
+                LpsnRecordNumber: 778559
+                Synonyms:
+                - Name: Flavobacterium odoratum
+                  ConceptId: species/flavobacterium-odoratum
+                  ConceptSource: LPSN
+                  Id: 620
+                  LpsnRecordNumber: 776258
+          - Name: Weeksellaceae
+            ConceptType: Family
+            ConceptId: family/weeksellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 7789
+            Children:
+            - Name: Bergeyella
+              ConceptType: Genus
+              ConceptId: genus/bergeyella
+              ConceptSource: LPSN
+              Id: 680
+              LpsnRecordNumber: 515233
+              Children:
+              - Name: Bergeyella zoohelcum
+                ConceptType: Species
+                ConceptId: species/bergeyella-zoohelcum
+                ConceptSource: LPSN
+                Id: 494
+                LpsnRecordNumber: 774016
+                Synonyms:
+                - Name: Weeksella zoohelcum
+                  ConceptId: species/weeksella-zoohelcum
+                  ConceptSource: LPSN
+                  Id: 2056
+                  LpsnRecordNumber: 785188
+            - Name: Chryseobacterium
+              ConceptType: Genus
+              ConceptId: genus/chryseobacterium
+              ConceptSource: LPSN
+              Id: 2384
+              LpsnRecordNumber: 516998
+              Children:
+              - Name: Chryseobacterium gleum
+                ConceptType: Species
+                ConceptId: species/chryseobacterium-gleum
+                ConceptSource: LPSN
+                Id: 2544
+                LpsnRecordNumber: 774713
+                Synonyms:
+                - Name: Flavobacterium gleum
+                  ConceptId: species/flavobacterium-gleum
+                  ConceptSource: LPSN
+                  Id: 1446
+                  LpsnRecordNumber: 776242
+              - Name: Chryseobacterium indologenes
+                ConceptType: Species
+                ConceptId: species/chryseobacterium-indologenes
+                ConceptSource: LPSN
+                Id: 294
+                LpsnRecordNumber: 774714
+                Synonyms:
+                - Name: Flavobacterium indologenes
+                  ConceptId: species/flavobacterium-indologenes
+                  ConceptSource: LPSN
+                  Id: 636
+                  LpsnRecordNumber: 783849
+            - Name: Elizabethkingia
+              ConceptType: Genus
+              ConceptId: genus/elizabethkingia
+              ConceptSource: LPSN
+              Id: 795
+              LpsnRecordNumber: 515572
+              Children:
+              - Name: Elizabethkingia meningoseptica
+                ConceptType: Species
+                ConceptId: species/elizabethkingia-meningoseptica
+                ConceptSource: LPSN
+                Id: 690
+                LpsnRecordNumber: 775890
+                Synonyms:
+                - Name: Chryseobacterium meningosepticum
+                  ConceptId: species/chryseobacterium-meningosepticum
+                  ConceptSource: LPSN
+                  Id: 2806
+                  LpsnRecordNumber: 774717
+                - Name: Flavobacterium meningosepticum
+                  ConceptId: species/flavobacterium-meningosepticum
+                  ConceptSource: LPSN
+                  Id: 2363
+                  LpsnRecordNumber: 776254
+            - Name: Empedobacter
+              ConceptType: Genus
+              ConceptId: genus/empedobacter
+              ConceptSource: LPSN
+              Id: 13
+              LpsnRecordNumber: 515577
+              Children:
+              - Name: Empedobacter brevis
+                ConceptType: Species
+                ConceptId: species/empedobacter-brevis
+                ConceptSource: LPSN
+                Id: 1338
+                LpsnRecordNumber: 775904
+                Synonyms:
+                - Name: Flavobacterium breve
+                  ConceptId: species/flavobacterium-breve
+                  ConceptSource: LPSN
+                  Id: 1039
+                  LpsnRecordNumber: 776226
+            - Name: Riemerella
+              ConceptType: Genus
+              ConceptId: genus/riemerella
+              ConceptSource: LPSN
+              Id: 812
+              LpsnRecordNumber: 516490
+              Children:
+              - Name: Riemerella anatipestifera
+                ConceptType: Species
+                ConceptId: species/riemerella-anatipestifera
+                ConceptSource: LPSN
+                Id: 2974
+                LpsnRecordNumber: 31594
+                Synonyms:
+                - Name: Moraxella anatipestifer
+                  ConceptId: species/moraxella-anatipestifer
+                  ConceptSource: LPSN
+                  Id: 689
+                  LpsnRecordNumber: 778307
+                - Name: Moraxella anatipestifera
+                  ConceptId: species/moraxella-anatipestifera
+                  ConceptSource: LPSN
+                  Id: 3075
+                  LpsnRecordNumber: 29630
+                - Name: Riemerella anatipestifer
+                  ConceptId: species/riemerella-anatipestifer
+                  ConceptSource: LPSN
+                  Id: 1178
+                  LpsnRecordNumber: 780558
+            - Name: Weeksella
+              ConceptType: Genus
+              ConceptId: genus/weeksella
+              ConceptSource: LPSN
+              Id: 397
+              LpsnRecordNumber: 516918
+              Children:
+              - Name: Weeksella virosa
+                ConceptType: Species
+                ConceptId: species/weeksella-virosa
+                ConceptSource: LPSN
+                Id: 661
+                LpsnRecordNumber: 783088
+      - Name: Sphingobacteriia
+        ConceptType: Class
+        ConceptId: class/sphingobacteriia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 90
+        Children:
+        - Name: Sphingobacteriales
+          ConceptType: Order
+          ConceptId: order/sphingobacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5132
+          Children:
+          - Name: Sphingobacteriaceae
+            ConceptType: Family
+            ConceptId: family/sphingobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1299
+            Children:
+            - Name: Pedobacter
+              ConceptType: Genus
+              ConceptId: genus/pedobacter
+              ConceptSource: LPSN
+              Id: 1900
+              LpsnRecordNumber: 516275
+              Children:
+              - Name: Pedobacter antarcticus
+                ConceptType: Species
+                ConceptId: species/pedobacter-antarcticus
+                ConceptSource: LPSN
+                Id: 3194
+                LpsnRecordNumber: 791641
+                Synonyms:
+                - Name: Pedobacter piscium
+                  ConceptId: species/pedobacter-piscium
+                  ConceptSource: LPSN
+                  Id: 643
+                  LpsnRecordNumber: 779227
+                - Name: Sphingobacterium piscium
+                  ConceptId: species/sphingobacterium-piscium
+                  ConceptSource: LPSN
+                  Id: 1266
+                  LpsnRecordNumber: 780979
+              - Name: Pedobacter heparinus
+                ConceptType: Species
+                ConceptId: species/pedobacter-heparinus
+                ConceptSource: LPSN
+                Id: 1048
+                LpsnRecordNumber: 779224
+                Synonyms:
+                - Name: Cytophaga heparina
+                  ConceptId: species/cytophaga-heparina
+                  ConceptSource: LPSN
+                  Id: 771
+                  LpsnRecordNumber: 775393
+                - Name: Flavobacterium heparinum
+                  ConceptId: species/flavobacterium-heparinum
+                  ConceptSource: LPSN
+                  Id: 2242
+                  LpsnRecordNumber: 776246
+                - Name: Sphingobacterium heparinum
+                  ConceptId: species/sphingobacterium-heparinum
+                  ConceptSource: LPSN
+                  Id: 65
+                  LpsnRecordNumber: 780976
+            - Name: Sphingobacterium
+              ConceptType: Genus
+              ConceptId: genus/sphingobacterium
+              ConceptSource: LPSN
+              Id: 156
+              LpsnRecordNumber: 516626
+              Children:
+              - Name: Sphingobacterium faecium
+                ConceptType: Species
+                ConceptId: species/sphingobacterium-faecium
+                ConceptSource: LPSN
+                Id: 953
+                LpsnRecordNumber: 780975
+              - Name: Sphingobacterium mizutaii
+                ConceptType: Species
+                ConceptId: species/sphingobacterium-mizutaii
+                ConceptSource: LPSN
+                Id: 3281
+                LpsnRecordNumber: 780977
+                Synonyms:
+                - Name: Sphingobacterium mizutae
+                  ConceptId: species/sphingobacterium-mizutae
+                  ConceptSource: LPSN
+                  Id: 2088
+                  LpsnRecordNumber: 784915
+              - Name: Sphingobacterium multivorum
+                ConceptType: Species
+                ConceptId: species/sphingobacterium-multivorum
+                ConceptSource: LPSN
+                Id: 109
+                LpsnRecordNumber: 780978
+                Synonyms:
+                - Name: Flavobacterium multivorum
+                  ConceptId: species/flavobacterium-multivorum
+                  ConceptSource: LPSN
+                  Id: 1945
+                  LpsnRecordNumber: 776257
+              - Name: Sphingobacterium spiritivorum
+                ConceptType: Species
+                ConceptId: species/sphingobacterium-spiritivorum
+                ConceptSource: LPSN
+                Id: 989
+                LpsnRecordNumber: 780981
+                Synonyms:
+                - Name: Flavobacterium spiritivorum
+                  ConceptId: species/flavobacterium-spiritivorum
+                  ConceptSource: LPSN
+                  Id: 1305
+                  LpsnRecordNumber: 776269
+                - Name: Flavobacterium yabuuchiae
+                  ConceptId: species/flavobacterium-yabuuchiae
+                  ConceptSource: LPSN
+                  Id: 319
+                  LpsnRecordNumber: 783862
+              - Name: Sphingobacterium thalpophilum
+                ConceptType: Species
+                ConceptId: species/sphingobacterium-thalpophilum
+                ConceptSource: LPSN
+                Id: 1917
+                LpsnRecordNumber: 780982
+                Synonyms:
+                - Name: Flavobacterium thalpophilum
+                  ConceptId: species/flavobacterium-thalpophilum
+                  ConceptSource: LPSN
+                  Id: 2128
+                  LpsnRecordNumber: 776274
+    - Name: Chlamydiota
+      ConceptType: Phylum
+      ConceptId: phylum/chlamydiota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 25878
+      Children:
+      - Name: Chlamydiia
+        ConceptType: Class
+        ConceptId: class/chlamydiia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 20
+        Children:
+        - Name: Chlamydiales
+          ConceptType: Order
+          ConceptId: order/chlamydiales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5015
+          Children:
+          - Name: Chlamydiaceae
+            ConceptType: Family
+            ConceptId: family/chlamydiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 306
+            Children:
+            - Name: Chlamydia
+              ConceptType: Genus
+              ConceptId: genus/chlamydia
+              ConceptSource: LPSN
+              Id: 2165
+              LpsnRecordNumber: 517200
+              Children:
+              - Name: Chlamydia abortus
+                ConceptType: Species
+                ConceptId: species/chlamydia-abortus
+                ConceptSource: LPSN
+                Id: 3324
+                LpsnRecordNumber: 792965
+                Synonyms:
+                - Name: Chlamydophila abortus
+                  ConceptId: species/chlamydophila-abortus
+                  ConceptSource: LPSN
+                  Id: 625
+                  LpsnRecordNumber: 783630
+              - Name: Chlamydia pneumoniae
+                ConceptType: Species
+                ConceptId: species/chlamydia-pneumoniae
+                ConceptSource: LPSN
+                Id: 1758
+                LpsnRecordNumber: 783626
+                Synonyms:
+                - Name: Chlamydophila pneumoniae
+                  ConceptId: species/chlamydophila-pneumoniae
+                  ConceptSource: LPSN
+                  Id: 352
+                  LpsnRecordNumber: 783634
+              - Name: Chlamydia psittaci
+                ConceptType: Species
+                ConceptId: species/chlamydia-psittaci
+                ConceptSource: LPSN
+                Id: 1766
+                LpsnRecordNumber: 783627
+                Synonyms:
+                - Name: Chlamydophila psittaci
+                  ConceptId: species/chlamydophila-psittaci
+                  ConceptSource: LPSN
+                  Id: 1425
+                  LpsnRecordNumber: 783635
+              - Name: Chlamydia trachomatis
+                ConceptType: Species
+                ConceptId: species/chlamydia-trachomatis
+                ConceptSource: LPSN
+                Id: 2325
+                LpsnRecordNumber: 783629
+              Synonyms:
+              - Name: Chlamydophila
+                ConceptId: genus/chlamydophila
+                ConceptSource: LPSN
+                Id: 2450
+                LpsnRecordNumber: 517201
+    - Name: Pseudomonadota
+      ConceptType: Phylum
+      ConceptId: phylum/pseudomonadota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 25914
+      Children:
+      - Name: Alphaproteobacteria
+        ConceptType: Class
+        ConceptId: class/alphaproteobacteria
+        ConceptSource: LPSN
+        LpsnRecordNumber: 5
+        Children:
+        - Name: Caulobacterales
+          ConceptType: Order
+          ConceptId: order/caulobacterales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5014
+          Children:
+          - Name: Caulobacteraceae
+            ConceptType: Family
+            ConceptId: family/caulobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 290
+            Children:
+            - Name: Brevundimonas
+              ConceptType: Genus
+              ConceptId: genus/brevundimonas
+              ConceptSource: LPSN
+              Id: 340
+              LpsnRecordNumber: 515272
+              Children:
+              - Name: Brevundimonas diminuta
+                ConceptType: Species
+                ConceptId: species/brevundimonas-diminuta
+                ConceptSource: LPSN
+                Id: 2548
+                LpsnRecordNumber: 774245
+                Synonyms:
+                - Name: Pseudomonas diminuta
+                  ConceptId: species/pseudomonas-diminuta
+                  ConceptSource: LPSN
+                  Id: 1243
+                  LpsnRecordNumber: 780007
+              - Name: Brevundimonas vesicularis
+                ConceptType: Species
+                ConceptId: species/brevundimonas-vesicularis
+                ConceptSource: LPSN
+                Id: 2193
+                LpsnRecordNumber: 774254
+                Synonyms:
+                - Name: Pseudomonas vesicularis
+                  ConceptId: species/pseudomonas-vesicularis
+                  ConceptSource: LPSN
+                  Id: 1029
+                  LpsnRecordNumber: 780156
+        - Name: Hyphomicrobiales
+          ConceptType: Order
+          ConceptId: order/hyphomicrobiales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5020
+          Children:
+          - Name: Aurantimonadaceae
+            ConceptType: Family
+            ConceptId: family/aurantimonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 11160
+            Children:
+            - Name: Aureimonas
+              ConceptType: Genus
+              ConceptId: genus/aureimonas
+              ConceptSource: LPSN
+              Id: 1072
+              LpsnRecordNumber: 518147
+              Children:
+              - Name: Aureimonas altamirensis
+                ConceptType: Species
+                ConceptId: species/aureimonas-altamirensis
+                ConceptSource: LPSN
+                Id: 1665
+                LpsnRecordNumber: 789532
+                Synonyms:
+                - Name: Aurantimonas altamirensis
+                  ConceptId: species/aurantimonas-altamirensis
+                  ConceptSource: LPSN
+                  Id: 1951
+                  LpsnRecordNumber: 785667
+          - Name: Bartonellaceae
+            ConceptType: Family
+            ConceptId: family/bartonellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 201
+            Children:
+            - Name: Bartonella
+              ConceptType: Genus
+              ConceptId: genus/bartonella
+              ConceptSource: LPSN
+              Id: 1166
+              LpsnRecordNumber: 515225
+              Children:
+              - Name: Bartonella bacilliformis
+                ConceptType: Species
+                ConceptId: species/bartonella-bacilliformis
+                ConceptSource: LPSN
+                Id: 1010
+                LpsnRecordNumber: 783476
+              - Name: Bartonella clarridgeiae
+                ConceptType: Species
+                ConceptId: species/bartonella-clarridgeiae
+                ConceptSource: LPSN
+                Id: 264
+                LpsnRecordNumber: 783481
+              - Name: Bartonella elizabethae
+                ConceptType: Species
+                ConceptId: species/bartonella-elizabethae
+                ConceptSource: LPSN
+                Id: 2520
+                LpsnRecordNumber: 783483
+                Synonyms:
+                - Name: Rochalimaea elizabethae
+                  ConceptId: species/rochalimaea-elizabethae
+                  ConceptSource: LPSN
+                  Id: 712
+                  LpsnRecordNumber: 784811
+              - Name: Bartonella henselae
+                ConceptType: Species
+                ConceptId: species/bartonella-henselae
+                ConceptSource: LPSN
+                Id: 1639
+                LpsnRecordNumber: 783485
+                Synonyms:
+                - Name: Rochalimaea henselae
+                  ConceptId: species/rochalimaea-henselae
+                  ConceptSource: LPSN
+                  Id: 1365
+                  LpsnRecordNumber: 784812
+              - Name: Bartonella quintana
+                ConceptType: Species
+                ConceptId: species/bartonella-quintana
+                ConceptSource: LPSN
+                Id: 2075
+                LpsnRecordNumber: 783488
+                Synonyms:
+                - Name: Rochalimaea quintana
+                  ConceptId: species/rochalimaea-quintana
+                  ConceptSource: LPSN
+                  Id: 2094
+                  LpsnRecordNumber: 784813
+              - Name: Bartonella vinsonii
+                ConceptType: Species
+                ConceptId: species/bartonella-vinsonii
+                ConceptSource: LPSN
+                Id: 1535
+                LpsnRecordNumber: 783493
+                Synonyms:
+                - Name: Rochalimaea vinsonii
+                  ConceptId: species/rochalimaea-vinsonii
+                  ConceptSource: LPSN
+                  Id: 413
+                  LpsnRecordNumber: 784814
+          - Name: Brucellaceae
+            ConceptType: Family
+            ConceptId: family/brucellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 244
+            Children:
+            - Name: Brucella
+              ConceptType: Genus
+              ConceptId: genus/brucella
+              ConceptSource: LPSN
+              Id: 1316
+              LpsnRecordNumber: 515274
+              Children:
+              - Name: Brucella anthropi
+                ConceptType: Species
+                ConceptId: species/brucella-anthropi
+                ConceptSource: LPSN
+                Id: 3176
+                LpsnRecordNumber: 11078
+                Synonyms:
+                - Name: Ochrobactrum anthropi
+                  ConceptId: species/ochrobactrum-anthropi
+                  ConceptSource: LPSN
+                  Id: 1368
+                  LpsnRecordNumber: 778956
+              - Name: Brucella intermedia
+                ConceptType: Species
+                ConceptId: species/brucella-intermedia
+                ConceptSource: LPSN
+                Id: 3317
+                LpsnRecordNumber: 11075
+                Synonyms:
+                - Name: Ochrobactrum intermedium
+                  ConceptId: species/ochrobactrum-intermedium
+                  ConceptSource: LPSN
+                  Id: 2413
+                  LpsnRecordNumber: 778960
+              - Name: Brucella melitensis
+                ConceptType: Species
+                ConceptId: species/brucella-melitensis
+                ConceptSource: LPSN
+                Id: 556
+                LpsnRecordNumber: 783564
+                Synonyms:
+                - Name: Brucella abortus
+                  ConceptId: species/brucella-abortus
+                  ConceptSource: LPSN
+                  Id: 2195
+                  LpsnRecordNumber: 783562
+                - Name: Brucella canis
+                  ConceptId: species/brucella-canis
+                  ConceptSource: LPSN
+                  Id: 2152
+                  LpsnRecordNumber: 783563
+                - Name: Brucella neotomae
+                  ConceptId: species/brucella-neotomae
+                  ConceptSource: LPSN
+                  Id: 11
+                  LpsnRecordNumber: 783565
+                - Name: Brucella ovis
+                  ConceptId: species/brucella-ovis
+                  ConceptSource: LPSN
+                  Id: 887
+                  LpsnRecordNumber: 783566
+                - Name: Brucella suis
+                  ConceptId: species/brucella-suis
+                  ConceptSource: LPSN
+                  Id: 36
+                  LpsnRecordNumber: 783567
+              Synonyms:
+              - Name: Ochrobactrum
+                ConceptId: genus/ochrobactrum
+                ConceptSource: LPSN
+                Id: 1062
+                LpsnRecordNumber: 516200
+          - Name: Methylobacteriaceae
+            ConceptType: Family
+            ConceptId: family/methylobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 852
+            Children:
+            - Name: Methylobacterium
+              ConceptType: Genus
+              ConceptId: genus/methylobacterium
+              ConceptSource: LPSN
+              Id: 1522
+              LpsnRecordNumber: 516060
+              Children:
+              - Name: Methylobacterium mesophilicum
+                ConceptType: Species
+                ConceptId: species/methylobacterium-mesophilicum
+                ConceptSource: LPSN
+                Id: 704
+                LpsnRecordNumber: 777978
+            - Name: Methylorubrum
+              ConceptType: Genus
+              ConceptId: genus/methylorubrum
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520392
+              Children:
+              - Name: Methylorubrum zatmanii
+                ConceptType: Species
+                ConceptId: species/methylorubrum-zatmanii
+                ConceptSource: LPSN
+                Id: 3202
+                LpsnRecordNumber: 798443
+                Synonyms:
+                - Name: Methylobacterium zatmanii
+                  ConceptId: species/methylobacterium-zatmanii
+                  ConceptSource: LPSN
+                  Id: 164
+                  LpsnRecordNumber: 777988
+          - Name: Nitrobacteraceae
+            ConceptType: Family
+            ConceptId: family/nitrobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 952
+            Children:
+            - Name: Afipia
+              ConceptType: Genus
+              ConceptId: genus/afipia
+              ConceptSource: LPSN
+              Id: 1269
+              LpsnRecordNumber: 515054
+              Children:
+              - Name: Afipia clevelandensis
+                ConceptType: Species
+                ConceptId: species/afipia-clevelandensis
+                ConceptSource: LPSN
+                Id: 334
+                LpsnRecordNumber: 772930
+              - Name: Afipia felis
+                ConceptType: Species
+                ConceptId: species/afipia-felis
+                ConceptSource: LPSN
+                Id: 35
+                LpsnRecordNumber: 772931
+          - Name: Rhizobiaceae
+            ConceptType: Family
+            ConceptId: family/rhizobiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1170
+            Children:
+            - Name: Agrobacterium
+              ConceptType: Genus
+              ConceptId: genus/agrobacterium
+              ConceptSource: LPSN
+              Id: 830
+              LpsnRecordNumber: 515059
+              Children:
+              - Name: Agrobacterium radiobacter
+                ConceptType: Species
+                ConceptId: species/agrobacterium-radiobacter
+                ConceptSource: LPSN
+                Id: 1008
+                LpsnRecordNumber: 772957
+                Synonyms:
+                - Name: Rhizobium radiobacter
+                  ConceptId: species/rhizobium-radiobacter
+                  ConceptSource: LPSN
+                  Id: 1028
+                  LpsnRecordNumber: 780373
+              - Name: Agrobacterium rubi
+                ConceptType: Species
+                ConceptId: species/agrobacterium-rubi
+                ConceptSource: LPSN
+                Id: 3076
+                LpsnRecordNumber: 772959
+                Synonyms:
+                - Name: Rhizobium rubi
+                  ConceptId: species/rhizobium-rubi
+                  ConceptSource: LPSN
+                  Id: 1083
+                  LpsnRecordNumber: 780375
+            - Name: Allorhizobium
+              ConceptType: Genus
+              ConceptId: genus/allorhizobium
+              ConceptSource: LPSN
+              LpsnRecordNumber: 517172
+              Children:
+              - Name: Allorhizobium vitis
+                ConceptType: Species
+                ConceptId: species/allorhizobium-vitis
+                ConceptSource: LPSN
+                Id: 3139
+                LpsnRecordNumber: 794741
+                Synonyms:
+                - Name: Rhizobium vitis
+                  ConceptId: species/rhizobium-vitis
+                  ConceptSource: LPSN
+                  Id: 407
+                  LpsnRecordNumber: 780382
+            - Name: Rhizobium
+              ConceptType: Genus
+              ConceptId: genus/rhizobium
+              ConceptSource: LPSN
+              Id: 427
+              LpsnRecordNumber: 517106
+              Children:
+              - Name: Rhizobium viscosum
+                ConceptType: Species
+                ConceptId: species/rhizobium-viscosum
+                ConceptSource: LPSN
+                Id: 3005
+                LpsnRecordNumber: 795460
+                CommonCommensal: true
+                Synonyms:
+                - Name: Arthrobacter viscosus
+                  ConceptId: species/arthrobacter-viscosus
+                  ConceptSource: LPSN
+                  Id: 1386
+                  LpsnRecordNumber: 773456
+          - Name: Xanthobacteraceae
+            ConceptType: Family
+            ConceptId: family/xanthobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1568
+            Children:
+            - Name: Azorhizobium
+              ConceptType: Genus
+              ConceptId: genus/azorhizobium
+              ConceptSource: LPSN
+              Id: 1400
+              LpsnRecordNumber: 516972
+              Children:
+              - Name: Azorhizobium caulinodans
+                ConceptType: Species
+                ConceptId: species/azorhizobium-caulinodans
+                ConceptSource: LPSN
+                Id: 1
+                LpsnRecordNumber: 773587
+        - Name: Rhodobacterales
+          ConceptType: Order
+          ConceptId: order/rhodobacterales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5095
+          Children:
+          - Name: Paracoccaceae
+            ConceptType: Family
+            ConceptId: family/paracoccaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 34881
+            Children:
+            - Name: Paracoccus
+              ConceptType: Genus
+              ConceptId: genus/paracoccus
+              ConceptSource: LPSN
+              Id: 1978
+              LpsnRecordNumber: 516256
+              Children:
+              - Name: Paracoccus yeei
+                ConceptType: Species
+                ConceptId: species/paracoccus-yeei
+                ConceptSource: LPSN
+                Id: 2262
+                LpsnRecordNumber: 784572
+        - Name: Rhodospirillales
+          ConceptType: Order
+          ConceptId: order/rhodospirillales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5025
+          Children:
+          - Name: Acetobacteraceae
+            ConceptType: Family
+            ConceptId: family/acetobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 6
+            Children:
+            - Name: Roseomonas
+              ConceptType: Genus
+              ConceptId: genus/roseomonas
+              ConceptSource: LPSN
+              Id: 716
+              LpsnRecordNumber: 517335
+              CommonCommensal: true
+              Children:
+              - Name: Roseomonas cervicalis
+                ConceptType: Species
+                ConceptId: species/roseomonas-cervicalis
+                ConceptSource: LPSN
+                Id: 283
+                LpsnRecordNumber: 784821
+                CommonCommensal: true
+              - Name: Roseomonas gilardii
+                ConceptType: Species
+                ConceptId: species/roseomonas-gilardii
+                ConceptSource: LPSN
+                Id: 1774
+                LpsnRecordNumber: 784823
+                CommonCommensal: true
+              - Name: Roseomonas mucosa
+                ConceptType: Species
+                ConceptId: species/roseomonas-mucosa
+                ConceptSource: LPSN
+                Id: 1362
+                LpsnRecordNumber: 784827
+                CommonCommensal: true
+          - Name: Azospirillaceae
+            ConceptType: Family
+            ConceptId: family/azospirillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 11015
+            Children:
+            - Name: Azospirillum
+              ConceptType: Genus
+              ConceptId: genus/azospirillum
+              ConceptSource: LPSN
+              Id: 2581
+              LpsnRecordNumber: 516973
+              Children:
+              - Name: Azospirillum brasilense
+                ConceptType: Species
+                ConceptId: species/azospirillum-brasilense
+                ConceptSource: LPSN
+                Id: 1918
+                LpsnRecordNumber: 773591
+            - Name: Inquilinus
+              ConceptType: Genus
+              ConceptId: genus/inquilinus
+              ConceptSource: LPSN
+              Id: 1553
+              LpsnRecordNumber: 515852
+              Children:
+              - Name: Inquilinus limosus
+                ConceptType: Species
+                ConceptId: species/inquilinus-limosus
+                ConceptSource: LPSN
+                Id: 1107
+                LpsnRecordNumber: 777035
+        - Name: Rickettsiales
+          ConceptType: Order
+          ConceptId: order/rickettsiales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5026
+          Children:
+          - Name: Ehrlichiaceae
+            ConceptType: Family
+            ConceptId: family/ehrlichiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 473
+            Children:
+            - Name: Anaplasma
+              ConceptType: Genus
+              ConceptId: genus/anaplasma
+              ConceptSource: LPSN
+              Id: 2123
+              LpsnRecordNumber: 517177
+            - Name: Ehrlichia
+              ConceptType: Genus
+              ConceptId: genus/ehrlichia
+              ConceptSource: LPSN
+              Id: 731
+              LpsnRecordNumber: 517226
+              Children:
+              - Name: Ehrlichia sennetsu
+                ConceptType: Species
+                ConceptId: species/ehrlichia-sennetsu
+                ConceptSource: LPSN
+                Id: 3156
+                LpsnRecordNumber: 783764
+                Synonyms:
+                - Name: Neorickettsia sennetsu
+                  ConceptId: species/neorickettsia-sennetsu
+                  ConceptSource: LPSN
+                  Id: 2598
+                  LpsnRecordNumber: 784474
+            - Name: Neorickettsia
+              ConceptType: Genus
+              ConceptId: genus/neorickettsia
+              ConceptSource: LPSN
+              Id: 59
+              LpsnRecordNumber: 517293
+          - Name: Rickettsiaceae
+            ConceptType: Family
+            ConceptId: family/rickettsiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1198
+            Children:
+            - Name: Orientia
+              ConceptType: Genus
+              ConceptId: genus/orientia
+              ConceptSource: LPSN
+              Id: 1946
+              LpsnRecordNumber: 517303
+              Children:
+              - Name: Orientia tsutsugamushi
+                ConceptType: Species
+                ConceptId: species/orientia-tsutsugamushi
+                ConceptSource: LPSN
+                Id: 2166
+                LpsnRecordNumber: 784544
+                Synonyms:
+                - Name: Rickettsia tsutsugamushi
+                  ConceptId: species/rickettsia-tsutsugamushi
+                  ConceptSource: LPSN
+                  Id: 313
+                  LpsnRecordNumber: 784805
+            - Name: Rickettsia
+              ConceptType: Genus
+              ConceptId: genus/rickettsia
+              ConceptSource: LPSN
+              Id: 414
+              LpsnRecordNumber: 517330
+              Children:
+              - Name: Rickettsia akari
+                ConceptType: Species
+                ConceptId: species/rickettsia-akari
+                ConceptSource: LPSN
+                Id: 2101
+                LpsnRecordNumber: 784782
+              - Name: Rickettsia conorii
+                ConceptType: Species
+                ConceptId: species/rickettsia-conorii
+                ConceptSource: LPSN
+                Id: 1566
+                LpsnRecordNumber: 784787
+              - Name: Rickettsia parkeri
+                ConceptType: Species
+                ConceptId: species/rickettsia-parkeri
+                ConceptSource: LPSN
+                Id: 325
+                LpsnRecordNumber: 784796
+              - Name: Rickettsia prowazekii
+                ConceptType: Species
+                ConceptId: species/rickettsia-prowazekii
+                ConceptSource: LPSN
+                Id: 817
+                LpsnRecordNumber: 784798
+              - Name: Rickettsia rickettsii
+                ConceptType: Species
+                ConceptId: species/rickettsia-rickettsii
+                ConceptSource: LPSN
+                Id: 1356
+                LpsnRecordNumber: 784800
+              - Name: Rickettsia sibirica
+                ConceptType: Species
+                ConceptId: species/rickettsia-sibirica
+                ConceptSource: LPSN
+                Id: 236
+                LpsnRecordNumber: 784802
+              - Name: Rickettsia typhi
+                ConceptType: Species
+                ConceptId: species/rickettsia-typhi
+                ConceptSource: LPSN
+                Id: 1860
+                LpsnRecordNumber: 784806
+        - Name: Sphingomonadales
+          ConceptType: Order
+          ConceptId: order/sphingomonadales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5097
+          Children:
+          - Name: Sphingomonadaceae
+            ConceptType: Family
+            ConceptId: family/sphingomonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1302
+            Children:
+            - Name: Sphingomonas
+              ConceptType: Genus
+              ConceptId: genus/sphingomonas
+              ConceptSource: LPSN
+              Id: 310
+              LpsnRecordNumber: 516629
+              Children:
+              - Name: Sphingomonas parapaucimobilis
+                ConceptType: Species
+                ConceptId: species/sphingomonas-parapaucimobilis
+                ConceptSource: LPSN
+                Id: 1366
+                LpsnRecordNumber: 781020
+              - Name: Sphingomonas paucimobilis
+                ConceptType: Species
+                ConceptId: species/sphingomonas-paucimobilis
+                ConceptSource: LPSN
+                Id: 529
+                LpsnRecordNumber: 781021
+                Synonyms:
+                - Name: Pseudomonas paucimobilis
+                  ConceptId: species/pseudomonas-paucimobilis
+                  ConceptSource: LPSN
+                  Id: 2142
+                  LpsnRecordNumber: 780091
+      - Name: Betaproteobacteria
+        ConceptType: Class
+        ConceptId: class/betaproteobacteria
+        ConceptSource: LPSN
+        LpsnRecordNumber: 17
+        Children:
+        - Name: Burkholderiales
+          ConceptType: Order
+          ConceptId: order/burkholderiales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5079
+          Children:
+          - Name: Alcaligenaceae
+            ConceptType: Family
+            ConceptId: family/alcaligenaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 76
+            Children:
+            - Name: Achromobacter
+              ConceptType: Genus
+              ConceptId: genus/achromobacter
+              ConceptSource: LPSN
+              Id: 2476
+              LpsnRecordNumber: 515003
+              Children:
+              - Name: Achromobacter denitrificans
+                ConceptType: Species
+                ConceptId: species/achromobacter-denitrificans
+                ConceptSource: LPSN
+                Id: 2395
+                LpsnRecordNumber: 772551
+              - Name: Achromobacter piechaudii
+                ConceptType: Species
+                ConceptId: species/achromobacter-piechaudii
+                ConceptSource: LPSN
+                Id: 752
+                LpsnRecordNumber: 772562
+                Synonyms:
+                - Name: Alcaligenes piechaudii
+                  ConceptId: species/alcaligenes-piechaudii
+                  ConceptSource: LPSN
+                  Id: 2274
+                  LpsnRecordNumber: 773020
+              - Name: Achromobacter ruhlandii
+                ConceptType: Species
+                ConceptId: species/achromobacter-ruhlandii
+                ConceptSource: LPSN
+                Id: 366
+                LpsnRecordNumber: 772563
+              - Name: Achromobacter xylosoxidans
+                ConceptType: Species
+                ConceptId: species/achromobacter-xylosoxidans
+                ConceptSource: LPSN
+                Id: 1374
+                LpsnRecordNumber: 772566
+                Synonyms:
+                - Name: Achromobacter xylosoxidans subsp. xylosoxidans
+                  ConceptId: subspecies/achromobacter-xylosoxidans-xylosoxidans
+                  ConceptSource: LPSN
+                  Id: 1482
+                  LpsnRecordNumber: 772568
+                - Name: Alcaligenes xylosoxidans
+                  ConceptId: species/alcaligenes-xylosoxidans
+                  ConceptSource: LPSN
+                  Id: 1584
+                  LpsnRecordNumber: 773025
+                - Name: Alcaligenes xylosoxidans subsp. xylosoxidans
+                  ConceptId: subspecies/alcaligenes-xylosoxidans-xylosoxidans
+                  ConceptSource: LPSN
+                  Id: 351
+                  LpsnRecordNumber: 773027
+            - Name: Alcaligenes
+              ConceptType: Genus
+              ConceptId: genus/alcaligenes
+              ConceptSource: LPSN
+              Id: 93
+              LpsnRecordNumber: 515067
+              Children:
+              - Name: Alcaligenes faecalis
+                ConceptType: Species
+                ConceptId: species/alcaligenes-faecalis
+                ConceptSource: LPSN
+                Id: 602
+                LpsnRecordNumber: 773011
+            - Name: Bordetella
+              ConceptType: Genus
+              ConceptId: genus/bordetella
+              ConceptSource: LPSN
+              Id: 249
+              LpsnRecordNumber: 516980
+              Children:
+              - Name: Bordetella avium
+                ConceptType: Species
+                ConceptId: species/bordetella-avium
+                ConceptSource: LPSN
+                Id: 189
+                LpsnRecordNumber: 774099
+              - Name: Bordetella bronchiseptica
+                ConceptType: Species
+                ConceptId: species/bordetella-bronchiseptica
+                ConceptSource: LPSN
+                Id: 79
+                LpsnRecordNumber: 774100
+              - Name: Bordetella hinzii
+                ConceptType: Species
+                ConceptId: species/bordetella-hinzii
+                ConceptSource: LPSN
+                Id: 2375
+                LpsnRecordNumber: 774101
+              - Name: Bordetella holmesii
+                ConceptType: Species
+                ConceptId: species/bordetella-holmesii
+                ConceptSource: LPSN
+                Id: 1963
+                LpsnRecordNumber: 774102
+              - Name: Bordetella parapertussis
+                ConceptType: Species
+                ConceptId: species/bordetella-parapertussis
+                ConceptSource: LPSN
+                Id: 1859
+                LpsnRecordNumber: 774103
+              - Name: Bordetella pertussis
+                ConceptType: Species
+                ConceptId: species/bordetella-pertussis
+                ConceptSource: LPSN
+                Id: 2174
+                LpsnRecordNumber: 774104
+              - Name: Bordetella petrii
+                ConceptType: Species
+                ConceptId: species/bordetella-petrii
+                ConceptSource: LPSN
+                Id: 1577
+                LpsnRecordNumber: 774105
+              - Name: Bordetella trematum
+                ConceptType: Species
+                ConceptId: species/bordetella-trematum
+                ConceptSource: LPSN
+                Id: 1744
+                LpsnRecordNumber: 774107
+            - Name: Kerstersia
+              ConceptType: Genus
+              ConceptId: genus/kerstersia
+              ConceptSource: LPSN
+              Id: 2217
+              LpsnRecordNumber: 515880
+              Children:
+              - Name: Kerstersia gyiorum
+                ConceptType: Species
+                ConceptId: species/kerstersia-gyiorum
+                ConceptSource: LPSN
+                Id: 2383
+                LpsnRecordNumber: 777091
+            - Name: Oligella
+              ConceptType: Genus
+              ConceptId: genus/oligella
+              ConceptSource: LPSN
+              Id: 678
+              LpsnRecordNumber: 516211
+              Children:
+              - Name: Oligella ureolytica
+                ConceptType: Species
+                ConceptId: species/oligella-ureolytica
+                ConceptSource: LPSN
+                Id: 1911
+                LpsnRecordNumber: 778979
+              - Name: Oligella urethralis
+                ConceptType: Species
+                ConceptId: species/oligella-urethralis
+                ConceptSource: LPSN
+                Id: 1161
+                LpsnRecordNumber: 778980
+                Synonyms:
+                - Name: Moraxella urethralis
+                  ConceptId: species/moraxella-urethralis
+                  ConceptSource: LPSN
+                  Id: 705
+                  LpsnRecordNumber: 778316
+          - Name: Burkholderiaceae
+            ConceptType: Family
+            ConceptId: family/burkholderiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 251
+            Children:
+            - Name: Burkholderia
+              ConceptType: Genus
+              ConceptId: genus/burkholderia
+              ConceptSource: LPSN
+              Id: 2124
+              LpsnRecordNumber: 515281
+              Children:
+              - Name: Burkholderia cepacia complex
+                ConceptType: Group
+                ConceptId: 79
+                ConceptSource: NeoIPC
+                Id: 2940
+                Children:
+                - Name: Burkholderia ambifaria
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-ambifaria
+                  ConceptSource: LPSN
+                  Id: 720
+                  LpsnRecordNumber: 774269
+                - Name: Burkholderia anthina
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-anthina
+                  ConceptSource: LPSN
+                  Id: 302
+                  LpsnRecordNumber: 774271
+                - Name: Burkholderia cenocepacia
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-cenocepacia
+                  ConceptSource: LPSN
+                  Id: 411
+                  LpsnRecordNumber: 774276
+                - Name: Burkholderia cepacia
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-cepacia
+                  ConceptSource: LPSN
+                  Id: 2117
+                  LpsnRecordNumber: 774277
+                  Synonyms:
+                  - Name: Pseudomonas cepacia
+                    ConceptId: species/pseudomonas-cepacia
+                    ConceptSource: LPSN
+                    Id: 1485
+                    LpsnRecordNumber: 779989
+                - Name: Burkholderia dolosa
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-dolosa
+                  ConceptSource: LPSN
+                  Id: 1488
+                  LpsnRecordNumber: 774279
+                - Name: Burkholderia multivorans
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-multivorans
+                  ConceptSource: LPSN
+                  Id: 2039
+                  LpsnRecordNumber: 774288
+                - Name: Burkholderia pyrrocinia
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-pyrrocinia
+                  ConceptSource: LPSN
+                  Id: 2963
+                  LpsnRecordNumber: 774298
+                  Synonyms:
+                  - Name: Pseudomonas pyrrocinia
+                    ConceptId: species/pseudomonas-pyrrocinia
+                    ConceptSource: LPSN
+                    Id: 2237
+                    LpsnRecordNumber: 780115
+                - Name: Burkholderia stabilis
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-stabilis
+                  ConceptSource: LPSN
+                  Id: 2105
+                  LpsnRecordNumber: 774304
+                - Name: Burkholderia vietnamiensis
+                  ConceptType: Species
+                  ConceptId: species/burkholderia-vietnamiensis
+                  ConceptSource: LPSN
+                  Id: 1137
+                  LpsnRecordNumber: 774312
+              - Name: Burkholderia arboris
+                ConceptType: Species
+                ConceptId: species/burkholderia-arboris
+                ConceptSource: LPSN
+                Id: 1933
+                LpsnRecordNumber: 787428
+              - Name: Burkholderia contaminans
+                ConceptType: Species
+                ConceptId: species/burkholderia-contaminans
+                ConceptSource: LPSN
+                Id: 1444
+                LpsnRecordNumber: 787670
+              - Name: Burkholderia diffusa
+                ConceptType: Species
+                ConceptId: species/burkholderia-diffusa
+                ConceptSource: LPSN
+                Id: 1068
+                LpsnRecordNumber: 787429
+              - Name: Burkholderia gladioli
+                ConceptType: Species
+                ConceptId: species/burkholderia-gladioli
+                ConceptSource: LPSN
+                Id: 1427
+                LpsnRecordNumber: 774282
+                Synonyms:
+                - Name: Pseudomonas antimicrobica
+                  ConceptId: species/pseudomonas-antimicrobica
+                  ConceptSource: LPSN
+                  Id: 1387
+                  LpsnRecordNumber: 779958
+                - Name: Pseudomonas cocovenenans
+                  ConceptId: species/pseudomonas-cocovenenans
+                  ConceptSource: LPSN
+                  Id: 1856
+                  LpsnRecordNumber: 779994
+                - Name: Pseudomonas gladioli
+                  ConceptId: species/pseudomonas-gladioli
+                  ConceptSource: LPSN
+                  Id: 68
+                  LpsnRecordNumber: 780027
+              - Name: Burkholderia lata
+                ConceptType: Species
+                ConceptId: species/burkholderia-lata
+                ConceptSource: LPSN
+                Id: 251
+                LpsnRecordNumber: 787671
+              - Name: Burkholderia latens
+                ConceptType: Species
+                ConceptId: species/burkholderia-latens
+                ConceptSource: LPSN
+                Id: 2567
+                LpsnRecordNumber: 787430
+              - Name: Burkholderia mallei
+                ConceptType: Species
+                ConceptId: species/burkholderia-mallei
+                ConceptSource: LPSN
+                Id: 1150
+                LpsnRecordNumber: 783570
+                Synonyms:
+                - Name: Pseudomonas mallei
+                  ConceptId: species/pseudomonas-mallei
+                  ConceptSource: LPSN
+                  Id: 1099
+                  LpsnRecordNumber: 784726
+              - Name: Burkholderia metallica
+                ConceptType: Species
+                ConceptId: species/burkholderia-metallica
+                ConceptSource: LPSN
+                Id: 426
+                LpsnRecordNumber: 787431
+              - Name: Burkholderia pseudomallei
+                ConceptType: Species
+                ConceptId: species/burkholderia-pseudomallei
+                ConceptSource: LPSN
+                Id: 2253
+                LpsnRecordNumber: 783571
+                Synonyms:
+                - Name: Pseudomonas pseudomallei
+                  ConceptId: species/pseudomonas-pseudomallei
+                  ConceptSource: LPSN
+                  Id: 1160
+                  LpsnRecordNumber: 784734
+              - Name: Burkholderia thailandensis
+                ConceptType: Species
+                ConceptId: species/burkholderia-thailandensis
+                ConceptSource: LPSN
+                Id: 1396
+                LpsnRecordNumber: 774307
+              - Name: Burkholderia ubonensis
+                ConceptType: Species
+                ConceptId: species/burkholderia-ubonensis
+                ConceptSource: LPSN
+                Id: 395
+                LpsnRecordNumber: 774309
+            - Name: Cupriavidus
+              ConceptType: Genus
+              ConceptId: genus/cupriavidus
+              ConceptSource: LPSN
+              Id: 1467
+              LpsnRecordNumber: 515448
+              Children:
+              - Name: Cupriavidus basilensis
+                ConceptType: Species
+                ConceptId: species/cupriavidus-basilensis
+                ConceptSource: LPSN
+                Id: 1699
+                LpsnRecordNumber: 775314
+              - Name: Cupriavidus gilardii
+                ConceptType: Species
+                ConceptId: species/cupriavidus-gilardii
+                ConceptSource: LPSN
+                Id: 1536
+                LpsnRecordNumber: 775316
+                Synonyms:
+                - Name: Ralstonia gilardii
+                  ConceptId: species/ralstonia-gilardii
+                  ConceptSource: LPSN
+                  Id: 1969
+                  LpsnRecordNumber: 780314
+                - Name: Wautersia gilardii
+                  ConceptId: species/wautersia-gilardii
+                  ConceptSource: LPSN
+                  Id: 230
+                  LpsnRecordNumber: 783081
+              - Name: Cupriavidus metallidurans
+                ConceptType: Species
+                ConceptId: species/cupriavidus-metallidurans
+                ConceptSource: LPSN
+                Id: 2359
+                LpsnRecordNumber: 775317
+              - Name: Cupriavidus necator
+                ConceptType: Species
+                ConceptId: species/cupriavidus-necator
+                ConceptSource: LPSN
+                Id: 2555
+                LpsnRecordNumber: 775318
+              - Name: Cupriavidus pauculus
+                ConceptType: Species
+                ConceptId: species/cupriavidus-pauculus
+                ConceptSource: LPSN
+                Id: 1512
+                LpsnRecordNumber: 775320
+                Synonyms:
+                - Name: Wautersia paucula
+                  ConceptId: species/wautersia-paucula
+                  ConceptSource: LPSN
+                  Id: 2071
+                  LpsnRecordNumber: 783085
+              - Name: Cupriavidus respiraculi
+                ConceptType: Species
+                ConceptId: species/cupriavidus-respiraculi
+                ConceptSource: LPSN
+                Id: 2546
+                LpsnRecordNumber: 775321
+                Synonyms:
+                - Name: Ralstonia respiraculi
+                  ConceptId: species/ralstonia-respiraculi
+                  ConceptSource: LPSN
+                  Id: 85
+                  LpsnRecordNumber: 784756
+            - Name: Pandoraea
+              ConceptType: Genus
+              ConceptId: genus/pandoraea
+              ConceptSource: LPSN
+              Id: 2051
+              LpsnRecordNumber: 516248
+              Children:
+              - Name: Pandoraea apista
+                ConceptType: Species
+                ConceptId: species/pandoraea-apista
+                ConceptSource: LPSN
+                Id: 1750
+                LpsnRecordNumber: 779126
+              - Name: Pandoraea norimbergensis
+                ConceptType: Species
+                ConceptId: species/pandoraea-norimbergensis
+                ConceptSource: LPSN
+                Id: 775
+                LpsnRecordNumber: 779127
+              - Name: Pandoraea pnomenusa
+                ConceptType: Species
+                ConceptId: species/pandoraea-pnomenusa
+                ConceptSource: LPSN
+                Id: 848
+                LpsnRecordNumber: 779128
+              - Name: Pandoraea pulmonicola
+                ConceptType: Species
+                ConceptId: species/pandoraea-pulmonicola
+                ConceptSource: LPSN
+                Id: 698
+                LpsnRecordNumber: 779129
+              - Name: Pandoraea sputorum
+                ConceptType: Species
+                ConceptId: species/pandoraea-sputorum
+                ConceptSource: LPSN
+                Id: 1345
+                LpsnRecordNumber: 779130
+            - Name: Paraburkholderia
+              ConceptType: Genus
+              ConceptId: genus/paraburkholderia
+              ConceptSource: LPSN
+              Id: 1211
+              LpsnRecordNumber: 518752
+              Children:
+              - Name: Paraburkholderia fungorum
+                ConceptType: Species
+                ConceptId: species/paraburkholderia-fungorum
+                ConceptSource: LPSN
+                Id: 2524
+                LpsnRecordNumber: 793025
+                Synonyms:
+                - Name: Burkholderia fungorum
+                  ConceptId: species/burkholderia-fungorum
+                  ConceptSource: LPSN
+                  Id: 2396
+                  LpsnRecordNumber: 774281
+            - Name: Ralstonia
+              ConceptType: Genus
+              ConceptId: genus/ralstonia
+              ConceptSource: LPSN
+              Id: 1964
+              LpsnRecordNumber: 516451
+              Children:
+              - Name: Ralstonia insidiosa
+                ConceptType: Species
+                ConceptId: species/ralstonia-insidiosa
+                ConceptSource: LPSN
+                Id: 2421
+                LpsnRecordNumber: 780315
+              - Name: Ralstonia mannitolilytica
+                ConceptType: Species
+                ConceptId: species/ralstonia-mannitolilytica
+                ConceptSource: LPSN
+                Id: 1119
+                LpsnRecordNumber: 780316
+              - Name: Ralstonia pickettii
+                ConceptType: Species
+                ConceptId: species/ralstonia-pickettii
+                ConceptSource: LPSN
+                Id: 954
+                LpsnRecordNumber: 780320
+                Synonyms:
+                - Name: Burkholderia pickettii
+                  ConceptId: species/burkholderia-pickettii
+                  ConceptSource: LPSN
+                  Id: 635
+                  LpsnRecordNumber: 774296
+                - Name: Pseudomonas pickettii
+                  ConceptId: species/pseudomonas-pickettii
+                  ConceptSource: LPSN
+                  Id: 63
+                  LpsnRecordNumber: 780098
+            - Name: Wautersia
+              ConceptType: Genus
+              ConceptId: genus/wautersia
+              ConceptSource: LPSN
+              Id: 275
+              LpsnRecordNumber: 516917
+          - Name: Comamonadaceae
+            ConceptType: Family
+            ConceptId: family/comamonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 336
+            Children:
+            - Name: Acidovorax
+              ConceptType: Genus
+              ConceptId: genus/acidovorax
+              ConceptSource: LPSN
+              Id: 312
+              LpsnRecordNumber: 515020
+              Children:
+              - Name: Acidovorax delafieldii
+                ConceptType: Species
+                ConceptId: species/acidovorax-delafieldii
+                ConceptSource: LPSN
+                Id: 807
+                LpsnRecordNumber: 772600
+                Synonyms:
+                - Name: Pseudomonas delafieldii
+                  ConceptId: species/pseudomonas-delafieldii
+                  ConceptSource: LPSN
+                  Id: 2043
+                  LpsnRecordNumber: 780003
+              - Name: Acidovorax facilis
+                ConceptType: Species
+                ConceptId: species/acidovorax-facilis
+                ConceptSource: LPSN
+                Id: 274
+                LpsnRecordNumber: 772601
+                Synonyms:
+                - Name: Pseudomonas facilis
+                  ConceptId: species/pseudomonas-facilis
+                  ConceptSource: LPSN
+                  Id: 1862
+                  LpsnRecordNumber: 780015
+              - Name: Acidovorax temperans
+                ConceptType: Species
+                ConceptId: species/acidovorax-temperans
+                ConceptSource: LPSN
+                Id: 1086
+                LpsnRecordNumber: 772607
+            - Name: Comamonas
+              ConceptType: Genus
+              ConceptId: genus/comamonas
+              ConceptSource: LPSN
+              Id: 143
+              LpsnRecordNumber: 515404
+              Children:
+              - Name: Comamonas aquatica
+                ConceptType: Species
+                ConceptId: species/comamonas-aquatica
+                ConceptSource: LPSN
+                Id: 1235
+                LpsnRecordNumber: 775074
+              - Name: Comamonas kerstersii
+                ConceptType: Species
+                ConceptId: species/comamonas-kerstersii
+                ConceptSource: LPSN
+                Id: 1170
+                LpsnRecordNumber: 775079
+              - Name: Comamonas terrigena
+                ConceptType: Species
+                ConceptId: species/comamonas-terrigena
+                ConceptSource: LPSN
+                Id: 1398
+                LpsnRecordNumber: 775084
+              - Name: Comamonas testosteroni
+                ConceptType: Species
+                ConceptId: species/comamonas-testosteroni
+                ConceptSource: LPSN
+                Id: 843
+                LpsnRecordNumber: 775085
+                Synonyms:
+                - Name: Pseudomonas testosteroni
+                  ConceptId: species/pseudomonas-testosteroni
+                  ConceptSource: LPSN
+                  Id: 2486
+                  LpsnRecordNumber: 780144
+            - Name: Delftia
+              ConceptType: Genus
+              ConceptId: genus/delftia
+              ConceptSource: LPSN
+              Id: 1125
+              LpsnRecordNumber: 515486
+              Children:
+              - Name: Delftia acidovorans
+                ConceptType: Species
+                ConceptId: species/delftia-acidovorans
+                ConceptSource: LPSN
+                Id: 2356
+                LpsnRecordNumber: 775497
+                Synonyms:
+                - Name: Comamonas acidovorans
+                  ConceptId: species/comamonas-acidovorans
+                  ConceptSource: LPSN
+                  Id: 684
+                  LpsnRecordNumber: 775073
+                - Name: Pseudomonas acidovorans
+                  ConceptId: species/pseudomonas-acidovorans
+                  ConceptSource: LPSN
+                  Id: 1604
+                  LpsnRecordNumber: 779947
+          - Name: Oxalobacteraceae
+            ConceptType: Family
+            ConceptId: family/oxalobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1010
+            Children:
+            - Name: Herbaspirillum
+              ConceptType: Genus
+              ConceptId: genus/herbaspirillum
+              ConceptSource: LPSN
+              Id: 69
+              LpsnRecordNumber: 517054
+            - Name: Massilia
+              ConceptType: Genus
+              ConceptId: genus/massilia
+              ConceptSource: LPSN
+              Id: 206
+              LpsnRecordNumber: 516024
+              Children:
+              - Name: Massilia timonae
+                ConceptType: Species
+                ConceptId: species/massilia-timonae
+                ConceptSource: LPSN
+                Id: 1423
+                LpsnRecordNumber: 777737
+          - Name: Sphaerotilaceae
+            ConceptType: Family
+            ConceptId: family/sphaerotilaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 36139
+            Children:
+            - Name: Aquabacterium
+              ConceptType: Genus
+              ConceptId: genus/aquabacterium
+              ConceptSource: LPSN
+              Id: 1554
+              LpsnRecordNumber: 515155
+              Children:
+              - Name: Aquabacterium parvum
+                ConceptType: Species
+                ConceptId: species/aquabacterium-parvum
+                ConceptSource: LPSN
+                Id: 14
+                LpsnRecordNumber: 773314
+          - Name: Sutterellaceae
+            ConceptType: Family
+            ConceptId: family/sutterellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1899
+            Children:
+            - Name: Sutterella
+              ConceptType: Genus
+              ConceptId: genus/sutterella
+              ConceptSource: LPSN
+              Id: 1013
+              LpsnRecordNumber: 516712
+              Children:
+              - Name: Sutterella wadsworthensis
+                ConceptType: Species
+                ConceptId: species/sutterella-wadsworthensis
+                ConceptSource: LPSN
+                Id: 2447
+                LpsnRecordNumber: 782339
+        - Name: Neisseriales
+          ConceptType: Order
+          ConceptId: order/neisseriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5092
+          Children:
+          - Name: Chromobacteriaceae
+            ConceptType: Family
+            ConceptId: family/chromobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1958
+            Children:
+            - Name: Chromobacterium
+              ConceptType: Genus
+              ConceptId: genus/chromobacterium
+              ConceptSource: LPSN
+              Id: 1524
+              LpsnRecordNumber: 515365
+              Children:
+              - Name: Chromobacterium violaceum
+                ConceptType: Species
+                ConceptId: species/chromobacterium-violaceum
+                ConceptSource: LPSN
+                Id: 453
+                LpsnRecordNumber: 774700
+          - Name: Neisseriaceae
+            ConceptType: Family
+            ConceptId: family/neisseriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 938
+            Children:
+            - Name: Alysiella
+              ConceptType: Genus
+              ConceptId: genus/alysiella
+              ConceptSource: LPSN
+              Id: 2247
+              LpsnRecordNumber: 515096
+              Children:
+              - Name: Alysiella crassa
+                ConceptType: Species
+                ConceptId: species/alysiella-crassa
+                ConceptSource: LPSN
+                Id: 1658
+                LpsnRecordNumber: 773140
+                Synonyms:
+                - Name: Simonsiella crassa
+                  ConceptId: species/simonsiella-crassa
+                  ConceptSource: LPSN
+                  Id: 76
+                  LpsnRecordNumber: 780926
+            - Name: Eikenella
+              ConceptType: Genus
+              ConceptId: genus/eikenella
+              ConceptSource: LPSN
+              Id: 1089
+              LpsnRecordNumber: 515568
+              Children:
+              - Name: Eikenella corrodens
+                ConceptType: Species
+                ConceptId: species/eikenella-corrodens
+                ConceptSource: LPSN
+                Id: 2135
+                LpsnRecordNumber: 775886
+            - Name: Kingella
+              ConceptType: Genus
+              ConceptId: genus/kingella
+              ConceptSource: LPSN
+              Id: 769
+              LpsnRecordNumber: 515886
+              Children:
+              - Name: Kingella denitrificans
+                ConceptType: Species
+                ConceptId: species/kingella-denitrificans
+                ConceptSource: LPSN
+                Id: 1713
+                LpsnRecordNumber: 777106
+              - Name: Kingella kingae
+                ConceptType: Species
+                ConceptId: species/kingella-kingae
+                ConceptSource: LPSN
+                Id: 655
+                LpsnRecordNumber: 777108
+              - Name: Kingella oralis
+                ConceptType: Species
+                ConceptId: species/kingella-oralis
+                ConceptSource: LPSN
+                Id: 174
+                LpsnRecordNumber: 777109
+              - Name: Kingella potus
+                ConceptType: Species
+                ConceptId: species/kingella-potus
+                ConceptSource: LPSN
+                Id: 195
+                LpsnRecordNumber: 777110
+            - Name: Neisseria
+              ConceptType: Genus
+              ConceptId: genus/neisseria
+              ConceptSource: LPSN
+              Id: 1915
+              LpsnRecordNumber: 516160
+              3GCR: true
+              Carbapenems: true
+              Children:
+              - Name: Neisseria animaloris
+                ConceptType: Species
+                ConceptId: species/neisseria-animaloris
+                ConceptSource: LPSN
+                Id: 2841
+                LpsnRecordNumber: 785314
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria bacilliformis
+                ConceptType: Species
+                ConceptId: species/neisseria-bacilliformis
+                ConceptSource: LPSN
+                Id: 2842
+                LpsnRecordNumber: 785253
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria canis
+                ConceptType: Species
+                ConceptId: species/neisseria-canis
+                ConceptSource: LPSN
+                Id: 2269
+                LpsnRecordNumber: 778627
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria cinerea
+                ConceptType: Species
+                ConceptId: species/neisseria-cinerea
+                ConceptSource: LPSN
+                Id: 713
+                LpsnRecordNumber: 778628
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria dentiae
+                ConceptType: Species
+                ConceptId: species/neisseria-dentiae
+                ConceptSource: LPSN
+                Id: 391
+                LpsnRecordNumber: 784463
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria dumasiana
+                ConceptType: Species
+                ConceptId: species/neisseria-dumasiana
+                ConceptSource: LPSN
+                Id: 2843
+                LpsnRecordNumber: 796193
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria elongata
+                ConceptType: Species
+                ConceptId: species/neisseria-elongata
+                ConceptSource: LPSN
+                Id: 1626
+                LpsnRecordNumber: 784464
+                3GCR: true
+                Carbapenems: true
+                Children:
+                - Name: Neisseria elongata subsp. elongata
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/neisseria-elongata-elongata
+                  ConceptSource: LPSN
+                  Id: 1790
+                  LpsnRecordNumber: 778629
+                  3GCR: true
+                  Carbapenems: true
+                - Name: Neisseria elongata subsp. glycolytica
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/neisseria-elongata-glycolytica
+                  ConceptSource: LPSN
+                  Id: 2484
+                  LpsnRecordNumber: 784465
+                  3GCR: true
+                  Carbapenems: true
+                - Name: Neisseria elongata subsp. nitroreducens
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/neisseria-elongata-nitroreducens
+                  ConceptSource: LPSN
+                  Id: 2588
+                  LpsnRecordNumber: 778630
+                  3GCR: true
+                  Carbapenems: true
+              - Name: Neisseria flava
+                ConceptType: Species
+                ConceptId: species/neisseria-flava
+                ConceptSource: LPSN
+                Id: 2844
+                LpsnRecordNumber: 784466
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria flavescens
+                ConceptType: Species
+                ConceptId: species/neisseria-flavescens
+                ConceptSource: LPSN
+                Id: 718
+                LpsnRecordNumber: 778631
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria gonorrhoeae
+                ConceptType: Species
+                ConceptId: species/neisseria-gonorrhoeae
+                ConceptSource: LPSN
+                Id: 1357
+                LpsnRecordNumber: 778632
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria iguanae
+                ConceptType: Species
+                ConceptId: species/neisseria-iguanae
+                ConceptSource: LPSN
+                Id: 985
+                LpsnRecordNumber: 784467
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria lactamica
+                ConceptType: Species
+                ConceptId: species/neisseria-lactamica
+                ConceptSource: LPSN
+                Id: 1719
+                LpsnRecordNumber: 778633
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria macacae
+                ConceptType: Species
+                ConceptId: species/neisseria-macacae
+                ConceptSource: LPSN
+                Id: 1881
+                LpsnRecordNumber: 784468
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria meningitidis
+                ConceptType: Species
+                ConceptId: species/neisseria-meningitidis
+                ConceptSource: LPSN
+                Id: 1206
+                LpsnRecordNumber: 778634
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria mucosa
+                ConceptType: Species
+                ConceptId: species/neisseria-mucosa
+                ConceptSource: LPSN
+                Id: 610
+                LpsnRecordNumber: 778635
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria oralis
+                ConceptType: Species
+                ConceptId: species/neisseria-oralis
+                ConceptSource: LPSN
+                Id: 827
+                LpsnRecordNumber: 790676
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria perflava
+                ConceptType: Species
+                ConceptId: species/neisseria-perflava
+                ConceptSource: LPSN
+                Id: 2271
+                LpsnRecordNumber: 778637
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria polysaccharea
+                ConceptType: Species
+                ConceptId: species/neisseria-polysaccharea
+                ConceptSource: LPSN
+                Id: 2129
+                LpsnRecordNumber: 784470
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria shayeganii
+                ConceptType: Species
+                ConceptId: species/neisseria-shayeganii
+                ConceptSource: LPSN
+                Id: 2845
+                LpsnRecordNumber: 788999
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria sicca
+                ConceptType: Species
+                ConceptId: species/neisseria-sicca
+                ConceptSource: LPSN
+                Id: 2518
+                LpsnRecordNumber: 778638
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria subflava
+                ConceptType: Species
+                ConceptId: species/neisseria-subflava
+                ConceptSource: LPSN
+                Id: 316
+                LpsnRecordNumber: 778639
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria wadsworthii
+                ConceptType: Species
+                ConceptId: species/neisseria-wadsworthii
+                ConceptSource: LPSN
+                Id: 2846
+                LpsnRecordNumber: 789000
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria weaveri
+                ConceptType: Species
+                ConceptId: species/neisseria-weaveri
+                ConceptSource: LPSN
+                Id: 2847
+                LpsnRecordNumber: 778640
+                3GCR: true
+                Carbapenems: true
+              - Name: Neisseria zoodegmatis
+                ConceptType: Species
+                ConceptId: species/neisseria-zoodegmatis
+                ConceptSource: LPSN
+                Id: 2848
+                LpsnRecordNumber: 785315
+                3GCR: true
+                Carbapenems: true
+            - Name: Simonsiella
+              ConceptType: Genus
+              ConceptId: genus/simonsiella
+              ConceptSource: LPSN
+              Id: 1210
+              LpsnRecordNumber: 516600
+              Children:
+              - Name: Simonsiella muelleri
+                ConceptType: Species
+                ConceptId: species/simonsiella-muelleri
+                ConceptSource: LPSN
+                Id: 1348
+                LpsnRecordNumber: 780927
+        - Name: Spirillales
+          ConceptType: Order
+          ConceptId: order/spirillales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5027
+          Children:
+          - Name: Spirillaceae
+            ConceptType: Family
+            ConceptId: family/spirillaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1305
+            Children:
+            - Name: Spirillum
+              ConceptType: Genus
+              ConceptId: genus/spirillum
+              ConceptSource: LPSN
+              Id: 1562
+              LpsnRecordNumber: 517115
+      - Name: Gammaproteobacteria
+        ConceptType: Class
+        ConceptId: class/gammaproteobacteria
+        ConceptSource: LPSN
+        LpsnRecordNumber: 40
+        Children:
+        - Name: Aeromonadales
+          ConceptType: Order
+          ConceptId: order/aeromonadales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5069
+          Children:
+          - Name: Aeromonadaceae
+            ConceptType: Family
+            ConceptId: family/aeromonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 60
+            Children:
+            - Name: Aeromonas
+              ConceptType: Genus
+              ConceptId: genus/aeromonas
+              ConceptSource: LPSN
+              Id: 1731
+              LpsnRecordNumber: 515052
+              Colistin: true
+              Children:
+              - Name: Aeromonas bestiarum
+                ConceptType: Species
+                ConceptId: species/aeromonas-bestiarum
+                ConceptSource: LPSN
+                Id: 1765
+                LpsnRecordNumber: 772894
+                Colistin: true
+              - Name: Aeromonas caviae
+                ConceptType: Species
+                ConceptId: species/aeromonas-caviae
+                ConceptSource: LPSN
+                Id: 461
+                LpsnRecordNumber: 772895
+                Colistin: true
+                Synonyms:
+                - Name: Aeromonas punctata
+                  ConceptId: species/aeromonas-punctata
+                  ConceptSource: LPSN
+                  Id: 2379
+                  LpsnRecordNumber: 772911
+              - Name: Aeromonas encheleia
+                ConceptType: Species
+                ConceptId: species/aeromonas-encheleia
+                ConceptSource: LPSN
+                Id: 2316
+                LpsnRecordNumber: 772897
+                Colistin: true
+              - Name: Aeromonas enteropelogenes
+                ConceptType: Species
+                ConceptId: species/aeromonas-enteropelogenes
+                ConceptSource: LPSN
+                Id: 2578
+                LpsnRecordNumber: 772898
+                Colistin: true
+                Synonyms:
+                - Name: Aeromonas trota
+                  ConceptId: species/aeromonas-trota
+                  ConceptSource: LPSN
+                  Id: 652
+                  LpsnRecordNumber: 772921
+              - Name: Aeromonas eucrenophila
+                ConceptType: Species
+                ConceptId: species/aeromonas-eucrenophila
+                ConceptSource: LPSN
+                Id: 1801
+                LpsnRecordNumber: 772899
+                Colistin: true
+              - Name: Aeromonas hydrophila
+                ConceptType: Species
+                ConceptId: species/aeromonas-hydrophila
+                ConceptSource: LPSN
+                Id: 107
+                LpsnRecordNumber: 772900
+                Colistin: true
+              - Name: Aeromonas jandaei
+                ConceptType: Species
+                ConceptId: species/aeromonas-jandaei
+                ConceptSource: LPSN
+                Id: 983
+                LpsnRecordNumber: 772907
+                Colistin: true
+              - Name: Aeromonas media
+                ConceptType: Species
+                ConceptId: species/aeromonas-media
+                ConceptSource: LPSN
+                Id: 32
+                LpsnRecordNumber: 772908
+                Colistin: true
+              - Name: Aeromonas molluscorum
+                ConceptType: Species
+                ConceptId: species/aeromonas-molluscorum
+                ConceptSource: LPSN
+                Id: 2563
+                LpsnRecordNumber: 772909
+                Colistin: true
+              - Name: Aeromonas popoffii
+                ConceptType: Species
+                ConceptId: species/aeromonas-popoffii
+                ConceptSource: LPSN
+                Id: 232
+                LpsnRecordNumber: 783327
+                Colistin: true
+              - Name: Aeromonas salmonicida
+                ConceptType: Species
+                ConceptId: species/aeromonas-salmonicida
+                ConceptSource: LPSN
+                Id: 2328
+                LpsnRecordNumber: 772913
+                Colistin: true
+              - Name: Aeromonas schubertii
+                ConceptType: Species
+                ConceptId: species/aeromonas-schubertii
+                ConceptSource: LPSN
+                Id: 1985
+                LpsnRecordNumber: 772915
+                Colistin: true
+              - Name: Aeromonas simiae
+                ConceptType: Species
+                ConceptId: species/aeromonas-simiae
+                ConceptSource: LPSN
+                Id: 2293
+                LpsnRecordNumber: 772918
+                Colistin: true
+              - Name: Aeromonas sobria
+                ConceptType: Species
+                ConceptId: species/aeromonas-sobria
+                ConceptSource: LPSN
+                Id: 763
+                LpsnRecordNumber: 783333
+                Colistin: true
+              - Name: Aeromonas veronii
+                ConceptType: Species
+                ConceptId: species/aeromonas-veronii
+                ConceptSource: LPSN
+                Id: 2573
+                LpsnRecordNumber: 772923
+                Colistin: true
+          - Name: Succinivibrionaceae
+            ConceptType: Family
+            ConceptId: family/succinivibrionaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1360
+            Children:
+            - Name: Anaerobiospirillum
+              ConceptType: Genus
+              ConceptId: genus/anaerobiospirillum
+              ConceptSource: LPSN
+              Id: 337
+              LpsnRecordNumber: 515116
+              Children:
+              - Name: Anaerobiospirillum succiniciproducens
+                ConceptType: Species
+                ConceptId: species/anaerobiospirillum-succiniciproducens
+                ConceptSource: LPSN
+                Id: 1871
+                LpsnRecordNumber: 773238
+              - Name: Anaerobiospirillum thomasii
+                ConceptType: Species
+                ConceptId: species/anaerobiospirillum-thomasii
+                ConceptSource: LPSN
+                Id: 968
+                LpsnRecordNumber: 773239
+            - Name: Succinivibrio
+              ConceptType: Genus
+              ConceptId: genus/succinivibrio
+              ConceptSource: LPSN
+              Id: 343
+              LpsnRecordNumber: 516702
+              Children:
+              - Name: Succinivibrio dextrinosolvens
+                ConceptType: Species
+                ConceptId: species/succinivibrio-dextrinosolvens
+                ConceptSource: LPSN
+                Id: 2336
+                LpsnRecordNumber: 782288
+        - Name: Alteromonadales
+          ConceptType: Order
+          ConceptId: order/alteromonadales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5070
+          Children:
+          - Name: Shewanellaceae
+            ConceptType: Family
+            ConceptId: family/shewanellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1276
+            Children:
+            - Name: Shewanella
+              ConceptType: Genus
+              ConceptId: genus/shewanella
+              ConceptSource: LPSN
+              Id: 2596
+              LpsnRecordNumber: 516592
+              Children:
+              - Name: Shewanella algae
+                ConceptType: Species
+                ConceptId: species/shewanella-algae
+                ConceptSource: LPSN
+                Id: 1850
+                LpsnRecordNumber: 780891
+              - Name: Shewanella putrefaciens
+                ConceptType: Species
+                ConceptId: species/shewanella-putrefaciens
+                ConceptSource: LPSN
+                Id: 863
+                LpsnRecordNumber: 780908
+        - Name: Beggiatoales
+          ConceptType: Order
+          ConceptId: order/beggiatoales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5012
+          Children:
+          - Name: Francisellaceae
+            ConceptType: Family
+            ConceptId: family/francisellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 536
+            Children:
+            - Name: Francisella
+              ConceptType: Genus
+              ConceptId: genus/francisella
+              ConceptSource: LPSN
+              Id: 1761
+              LpsnRecordNumber: 515653
+              Children:
+              - Name: Francisella tularensis
+                ConceptType: Species
+                ConceptId: species/francisella-tularensis
+                ConceptSource: LPSN
+                Id: 467
+                LpsnRecordNumber: 783871
+        - Name: Cardiobacteriales
+          ConceptType: Order
+          ConceptId: order/cardiobacteriales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5071
+          Children:
+          - Name: Cardiobacteriaceae
+            ConceptType: Family
+            ConceptId: family/cardiobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 276
+            Children:
+            - Name: Cardiobacterium
+              ConceptType: Genus
+              ConceptId: genus/cardiobacterium
+              ConceptSource: LPSN
+              Id: 1020
+              LpsnRecordNumber: 515312
+              Children:
+              - Name: Cardiobacterium hominis
+                ConceptType: Species
+                ConceptId: species/cardiobacterium-hominis
+                ConceptSource: LPSN
+                Id: 2141
+                LpsnRecordNumber: 774479
+              - Name: Cardiobacterium valvarum
+                ConceptType: Species
+                ConceptId: species/cardiobacterium-valvarum
+                ConceptSource: LPSN
+                Id: 836
+                LpsnRecordNumber: 774480
+            - Name: Dichelobacter
+              ConceptType: Genus
+              ConceptId: genus/dichelobacter
+              ConceptSource: LPSN
+              Id: 1318
+              LpsnRecordNumber: 515525
+              Children:
+              - Name: Dichelobacter nodosus
+                ConceptType: Species
+                ConceptId: species/dichelobacter-nodosus
+                ConceptSource: LPSN
+                Id: 299
+                LpsnRecordNumber: 775764
+                Synonyms:
+                - Name: Bacteroides nodosus
+                  ConceptId: species/bacteroides-nodosus
+                  ConceptSource: LPSN
+                  Id: 1641
+                  LpsnRecordNumber: 773963
+            - Name: Suttonella
+              ConceptType: Genus
+              ConceptId: genus/suttonella
+              ConceptSource: LPSN
+              Id: 1779
+              LpsnRecordNumber: 516713
+              Children:
+              - Name: Suttonella indologenes
+                ConceptType: Species
+                ConceptId: species/suttonella-indologenes
+                ConceptSource: LPSN
+                Id: 1278
+                LpsnRecordNumber: 782340
+                Synonyms:
+                - Name: Kingella indologenes
+                  ConceptId: species/kingella-indologenes
+                  ConceptSource: LPSN
+                  Id: 951
+                  LpsnRecordNumber: 777107
+        - Name: Chromatiales
+          ConceptType: Order
+          ConceptId: order/chromatiales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5050
+          Children:
+          - Name: Chromatiaceae
+            ConceptType: Family
+            ConceptId: family/chromatiaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 316
+            Children:
+            - Name: Alishewanella
+              ConceptType: Genus
+              ConceptId: genus/alishewanella
+              ConceptSource: LPSN
+              Id: 1995
+              LpsnRecordNumber: 515076
+              Children:
+              - Name: Alishewanella fetalis
+                ConceptType: Species
+                ConceptId: species/alishewanella-fetalis
+                ConceptSource: LPSN
+                Id: 2072
+                LpsnRecordNumber: 773062
+        - Name: Enterobacterales
+          ConceptType: Order
+          ConceptId: order/enterobacterales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5188
+          Children:
+          - Name: Budviciaceae
+            ConceptType: Family
+            ConceptId: family/budviciaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2059
+            Children:
+            - Name: Budvicia
+              ConceptType: Genus
+              ConceptId: genus/budvicia
+              ConceptSource: LPSN
+              Id: 2706
+              LpsnRecordNumber: 515277
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Budvicia aquatica
+                ConceptType: Species
+                ConceptId: species/budvicia-aquatica
+                ConceptSource: LPSN
+                Id: 2707
+                LpsnRecordNumber: 774260
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Leminorella
+              ConceptType: Genus
+              ConceptId: genus/leminorella
+              ConceptSource: LPSN
+              Id: 696
+              LpsnRecordNumber: 515936
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Leminorella grimontii
+                ConceptType: Species
+                ConceptId: species/leminorella-grimontii
+                ConceptSource: LPSN
+                Id: 464
+                LpsnRecordNumber: 777469
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Leminorella richardii
+                ConceptType: Species
+                ConceptId: species/leminorella-richardii
+                ConceptSource: LPSN
+                Id: 2053
+                LpsnRecordNumber: 777470
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Pragia
+              ConceptType: Genus
+              ConceptId: genus/pragia
+              ConceptSource: LPSN
+              Id: 207
+              LpsnRecordNumber: 516382
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Pragia fontium
+                ConceptType: Species
+                ConceptId: species/pragia-fontium
+                ConceptSource: LPSN
+                Id: 323
+                LpsnRecordNumber: 779773
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+          - Name: Enterobacteriaceae
+            ConceptType: Family
+            ConceptId: family/enterobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 482
+            Children:
+            - Name: Averyella
+              ConceptType: Genus
+              ConceptId: genus/averyella
+              ConceptSource: LPSN
+              Id: 2931
+              LpsnRecordNumber: 521822
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Averyella dalhousiensis
+                ConceptType: Species
+                ConceptId: species/averyella-dalhousiensis
+                ConceptSource: LPSN
+                Id: 2932
+                LpsnRecordNumber: 800913
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Buttiauxella
+              ConceptType: Genus
+              ConceptId: genus/buttiauxella
+              ConceptSource: LPSN
+              Id: 2420
+              LpsnRecordNumber: 515282
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Buttiauxella agrestis
+                ConceptType: Species
+                ConceptId: species/buttiauxella-agrestis
+                ConceptSource: LPSN
+                Id: 646
+                LpsnRecordNumber: 774314
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Buttiauxella brennerae
+                ConceptType: Species
+                ConceptId: species/buttiauxella-brennerae
+                ConceptSource: LPSN
+                Id: 245
+                LpsnRecordNumber: 774315
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Buttiauxella ferragutiae
+                ConceptType: Species
+                ConceptId: species/buttiauxella-ferragutiae
+                ConceptSource: LPSN
+                Id: 896
+                LpsnRecordNumber: 774316
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Buttiauxella gaviniae
+                ConceptType: Species
+                ConceptId: species/buttiauxella-gaviniae
+                ConceptSource: LPSN
+                Id: 2371
+                LpsnRecordNumber: 774317
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Buttiauxella izardii
+                ConceptType: Species
+                ConceptId: species/buttiauxella-izardii
+                ConceptSource: LPSN
+                Id: 1854
+                LpsnRecordNumber: 774318
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Buttiauxella noackiae
+                ConceptType: Species
+                ConceptId: species/buttiauxella-noackiae
+                ConceptSource: LPSN
+                Id: 820
+                LpsnRecordNumber: 774319
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Buttiauxella warmboldiae
+                ConceptType: Species
+                ConceptId: species/buttiauxella-warmboldiae
+                ConceptSource: LPSN
+                Id: 1239
+                LpsnRecordNumber: 774320
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Cedecea
+              ConceptType: Genus
+              ConceptId: genus/cedecea
+              ConceptSource: LPSN
+              Id: 904
+              LpsnRecordNumber: 515327
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Cedecea davisae
+                ConceptType: Species
+                ConceptId: species/cedecea-davisae
+                ConceptSource: LPSN
+                Id: 459
+                LpsnRecordNumber: 774539
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Cedecea lapagei
+                ConceptType: Species
+                ConceptId: species/cedecea-lapagei
+                ConceptSource: LPSN
+                Id: 1556
+                LpsnRecordNumber: 774540
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Cedecea neteri
+                ConceptType: Species
+                ConceptId: species/cedecea-neteri
+                ConceptSource: LPSN
+                Id: 1944
+                LpsnRecordNumber: 774541
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Citrobacter
+              ConceptType: Genus
+              ConceptId: genus/citrobacter
+              ConceptSource: LPSN
+              Id: 1940
+              LpsnRecordNumber: 515376
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Citrobacter amalonaticus
+                ConceptType: Species
+                ConceptId: species/citrobacter-amalonaticus
+                ConceptSource: LPSN
+                Id: 1302
+                LpsnRecordNumber: 774743
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Levinea amalonatica
+                  ConceptId: species/levinea-amalonatica
+                  ConceptSource: LPSN
+                  Id: 1471
+                  LpsnRecordNumber: 777572
+              - Name: Citrobacter braakii
+                ConceptType: Species
+                ConceptId: species/citrobacter-braakii
+                ConceptSource: LPSN
+                Id: 841
+                LpsnRecordNumber: 774744
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter farmeri
+                ConceptType: Species
+                ConceptId: species/citrobacter-farmeri
+                ConceptSource: LPSN
+                Id: 292
+                LpsnRecordNumber: 774746
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter freundii
+                ConceptType: Species
+                ConceptId: species/citrobacter-freundii
+                ConceptSource: LPSN
+                Id: 1430
+                LpsnRecordNumber: 774747
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter gillenii
+                ConceptType: Species
+                ConceptId: species/citrobacter-gillenii
+                ConceptSource: LPSN
+                Id: 1079
+                LpsnRecordNumber: 774750
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter koseri
+                ConceptType: Species
+                ConceptId: species/citrobacter-koseri
+                ConceptSource: LPSN
+                Id: 1747
+                LpsnRecordNumber: 774752
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Citrobacter diversus
+                  ConceptId: species/citrobacter-diversus
+                  ConceptSource: LPSN
+                  Id: 1907
+                  LpsnRecordNumber: 774745
+              - Name: Citrobacter murliniae
+                ConceptType: Species
+                ConceptId: species/citrobacter-murliniae
+                ConceptSource: LPSN
+                Id: 1810
+                LpsnRecordNumber: 774753
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter pasteurii
+                ConceptType: Species
+                ConceptId: species/citrobacter-pasteurii
+                ConceptSource: LPSN
+                Id: 2712
+                LpsnRecordNumber: 792820
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter rodentium
+                ConceptType: Species
+                ConceptId: species/citrobacter-rodentium
+                ConceptSource: LPSN
+                Id: 131
+                LpsnRecordNumber: 774754
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter sedlakii
+                ConceptType: Species
+                ConceptId: species/citrobacter-sedlakii
+                ConceptSource: LPSN
+                Id: 2400
+                LpsnRecordNumber: 774755
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter werkmanii
+                ConceptType: Species
+                ConceptId: species/citrobacter-werkmanii
+                ConceptSource: LPSN
+                Id: 1432
+                LpsnRecordNumber: 774757
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Citrobacter youngae
+                ConceptType: Species
+                ConceptId: species/citrobacter-youngae
+                ConceptSource: LPSN
+                Id: 1014
+                LpsnRecordNumber: 774758
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Cronobacter
+              ConceptType: Genus
+              ConceptId: genus/cronobacter
+              ConceptSource: LPSN
+              Id: 347
+              LpsnRecordNumber: 517456
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Cronobacter dublinensis
+                ConceptType: Species
+                ConceptId: species/cronobacter-dublinensis
+                ConceptSource: LPSN
+                Id: 1575
+                LpsnRecordNumber: 786423
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Cronobacter malonaticus
+                ConceptType: Species
+                ConceptId: species/cronobacter-malonaticus
+                ConceptSource: LPSN
+                Id: 1826
+                LpsnRecordNumber: 787374
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Cronobacter muytjensii
+                ConceptType: Species
+                ConceptId: species/cronobacter-muytjensii
+                ConceptSource: LPSN
+                Id: 1501
+                LpsnRecordNumber: 787375
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Cronobacter sakazakii
+                ConceptType: Species
+                ConceptId: species/cronobacter-sakazakii
+                ConceptSource: LPSN
+                Id: 1295
+                LpsnRecordNumber: 787376
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Enterobacter sakazakii
+                  ConceptId: species/enterobacter-sakazakii
+                  ConceptSource: LPSN
+                  Id: 2716
+                  LpsnRecordNumber: 775952
+              - Name: Cronobacter turicensis
+                ConceptType: Species
+                ConceptId: species/cronobacter-turicensis
+                ConceptSource: LPSN
+                Id: 15
+                LpsnRecordNumber: 787377
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Enterobacter
+              ConceptType: Genus
+              ConceptId: genus/enterobacter
+              ConceptSource: LPSN
+              Id: 1849
+              LpsnRecordNumber: 515587
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Enterobacter cloacae complex
+                ConceptType: Group
+                ConceptId: 32
+                ConceptSource: NeoIPC
+                Id: 2711
+                Children:
+                - Name: Enterobacter asburiae
+                  ConceptType: Species
+                  ConceptId: species/enterobacter-asburiae
+                  ConceptSource: LPSN
+                  Id: 1431
+                  LpsnRecordNumber: 775931
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Enterobacter bugandensis
+                  ConceptType: Species
+                  ConceptId: species/enterobacter-bugandensis
+                  ConceptSource: LPSN
+                  Id: 2713
+                  LpsnRecordNumber: 793840
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Enterobacter cancerogenus
+                  ConceptType: Species
+                  ConceptId: species/enterobacter-cancerogenus
+                  ConceptSource: LPSN
+                  Id: 1417
+                  LpsnRecordNumber: 775932
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                  Synonyms:
+                  - Name: Erwinia cancerogena
+                    ConceptId: species/erwinia-cancerogena
+                    ConceptSource: LPSN
+                    Id: 2587
+                    LpsnRecordNumber: 783792
+                - Name: Enterobacter cloacae
+                  ConceptType: Species
+                  ConceptId: species/enterobacter-cloacae
+                  ConceptSource: LPSN
+                  Id: 1212
+                  LpsnRecordNumber: 775933
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                  Children:
+                  - Name: Enterobacter cloacae subsp. dissolvens
+                    ConceptType: Subspecies
+                    ConceptId: subspecies/enterobacter-cloacae-dissolvens
+                    ConceptSource: LPSN
+                    Id: 1130
+                    LpsnRecordNumber: 775935
+                    3GCR: true
+                    Carbapenems: true
+                    Colistin: true
+                    Synonyms:
+                    - Name: Enterobacter dissolvens
+                      ConceptId: species/enterobacter-dissolvens
+                      ConceptSource: LPSN
+                      Id: 1571
+                      LpsnRecordNumber: 775937
+                    - Name: Erwinia dissolvens
+                      ConceptId: species/erwinia-dissolvens
+                      ConceptSource: LPSN
+                      Id: 2390
+                      LpsnRecordNumber: 783797
+                - Name: Enterobacter hormaechei
+                  ConceptType: Species
+                  ConceptId: species/enterobacter-hormaechei
+                  ConceptSource: LPSN
+                  Id: 1495
+                  LpsnRecordNumber: 783768
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Enterobacter kobei
+                  ConceptType: Species
+                  ConceptId: species/enterobacter-kobei
+                  ConceptSource: LPSN
+                  Id: 1591
+                  LpsnRecordNumber: 775946
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Enterobacter ludwigii
+                  ConceptType: Species
+                  ConceptId: species/enterobacter-ludwigii
+                  ConceptSource: LPSN
+                  Id: 117
+                  LpsnRecordNumber: 775948
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+              - Name: Enterobacter huaxiensis
+                ConceptType: Species
+                ConceptId: species/enterobacter-huaxiensis
+                ConceptSource: LPSN
+                Id: 2714
+                LpsnRecordNumber: 800159
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Enterobacter quasihormaechei
+                ConceptType: Species
+                ConceptId: species/enterobacter-quasihormaechei
+                ConceptSource: LPSN
+                Id: 2715
+                LpsnRecordNumber: 5769
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Enterobacter wuhouensis
+                ConceptType: Species
+                ConceptId: species/enterobacter-wuhouensis
+                ConceptSource: LPSN
+                Id: 2717
+                LpsnRecordNumber: 5770
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Escherichia
+              ConceptType: Genus
+              ConceptId: genus/escherichia
+              ConceptSource: LPSN
+              Id: 497
+              LpsnRecordNumber: 515602
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Escherichia albertii
+                ConceptType: Species
+                ConceptId: species/escherichia-albertii
+                ConceptSource: LPSN
+                Id: 1172
+                LpsnRecordNumber: 776053
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Escherichia coli
+                ConceptType: Species
+                ConceptId: species/escherichia-coli
+                ConceptSource: LPSN
+                Id: 1807
+                LpsnRecordNumber: 776057
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Escherichia fergusonii
+                ConceptType: Species
+                ConceptId: species/escherichia-fergusonii
+                ConceptSource: LPSN
+                Id: 1873
+                LpsnRecordNumber: 776059
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Escherichia hermannii
+                ConceptType: Species
+                ConceptId: species/escherichia-hermannii
+                ConceptSource: LPSN
+                Id: 12
+                LpsnRecordNumber: 776060
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Klebsiella
+              ConceptType: Genus
+              ConceptId: genus/klebsiella
+              ConceptSource: LPSN
+              Id: 1223
+              LpsnRecordNumber: 515890
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Klebsiella aerogenes
+                ConceptType: Species
+                ConceptId: species/klebsiella-aerogenes
+                ConceptSource: LPSN
+                Id: 333
+                LpsnRecordNumber: 777146
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Enterobacter aerogenes
+                  ConceptId: species/enterobacter-aerogenes
+                  ConceptSource: LPSN
+                  Id: 2286
+                  LpsnRecordNumber: 775928
+              - Name: Klebsiella granulomatis
+                ConceptType: Species
+                ConceptId: species/klebsiella-granulomatis
+                ConceptSource: LPSN
+                Id: 1760
+                LpsnRecordNumber: 784050
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Calymmatobacterium granulomatis
+                  ConceptId: species/calymmatobacterium-granulomatis
+                  ConceptSource: LPSN
+                  Id: 1914
+                  LpsnRecordNumber: 783583
+              - Name: Klebsiella grimontii
+                ConceptType: Species
+                ConceptId: species/klebsiella-grimontii
+                ConceptSource: LPSN
+                Id: 2720
+                LpsnRecordNumber: 797490
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Klebsiella ornithinolytica
+                ConceptType: Species
+                ConceptId: species/klebsiella-ornithinolytica
+                ConceptSource: LPSN
+                Id: 1832
+                LpsnRecordNumber: 777148
+                3GCR: true
+                Carbapenems: true
+                Synonyms:
+                - Name: Raoultella ornithinolytica
+                  ConceptId: species/raoultella-ornithinolytica
+                  ConceptSource: LPSN
+                  Id: 963
+                  LpsnRecordNumber: 780331
+              - Name: Klebsiella oxytoca
+                ConceptType: Species
+                ConceptId: species/klebsiella-oxytoca
+                ConceptSource: LPSN
+                Id: 1451
+                LpsnRecordNumber: 777149
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Klebsiella pasteurii
+                ConceptType: Species
+                ConceptId: species/klebsiella-pasteurii
+                ConceptSource: LPSN
+                Id: 2721
+                LpsnRecordNumber: 5622
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Klebsiella planticola
+                ConceptType: Species
+                ConceptId: species/klebsiella-planticola
+                ConceptSource: LPSN
+                Id: 476
+                LpsnRecordNumber: 777150
+                3GCR: true
+                Carbapenems: true
+                Synonyms:
+                - Name: Klebsiella trevisanii
+                  ConceptId: species/klebsiella-trevisanii
+                  ConceptSource: LPSN
+                  Id: 2149
+                  LpsnRecordNumber: 777158
+                - Name: Raoultella planticola
+                  ConceptId: species/raoultella-planticola
+                  ConceptSource: LPSN
+                  Id: 1402
+                  LpsnRecordNumber: 780332
+              - Name: Klebsiella pneumoniae
+                ConceptType: Species
+                ConceptId: species/klebsiella-pneumoniae
+                ConceptSource: LPSN
+                Id: 390
+                LpsnRecordNumber: 777151
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Children:
+                - Name: Klebsiella pneumoniae subsp. ozaenae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/klebsiella-pneumoniae-ozaenae
+                  ConceptSource: LPSN
+                  Id: 733
+                  LpsnRecordNumber: 777152
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                  Synonyms:
+                  - Name: Klebsiella ozaenae
+                    ConceptId: species/klebsiella-ozaenae
+                    ConceptSource: LPSN
+                    Id: 926
+                    LpsnRecordNumber: 784052
+                - Name: Klebsiella pneumoniae subsp. pneumoniae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/klebsiella-pneumoniae-pneumoniae
+                  ConceptSource: LPSN
+                  Id: 1281
+                  LpsnRecordNumber: 777153
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Klebsiella pneumoniae subsp. rhinoscleromatis
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/klebsiella-pneumoniae-rhinoscleromatis
+                  ConceptSource: LPSN
+                  Id: 1705
+                  LpsnRecordNumber: 777154
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                  Synonyms:
+                  - Name: Klebsiella rhinoscleromatis
+                    ConceptId: species/klebsiella-rhinoscleromatis
+                    ConceptSource: LPSN
+                    Id: 2549
+                    LpsnRecordNumber: 784053
+              - Name: Klebsiella quasipneumoniae
+                ConceptType: Species
+                ConceptId: species/klebsiella-quasipneumoniae
+                ConceptSource: LPSN
+                Id: 2722
+                LpsnRecordNumber: 792147
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Children:
+                - Name: Klebsiella quasipneumoniae subsp. quasipneumoniae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/klebsiella-quasipneumoniae-quasipneumoniae
+                  ConceptSource: LPSN
+                  Id: 2724
+                  LpsnRecordNumber: 792148
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Klebsiella quasipneumoniae subsp. similipneumoniae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/klebsiella-quasipneumoniae-similipneumoniae
+                  ConceptSource: LPSN
+                  Id: 2723
+                  LpsnRecordNumber: 792149
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+              - Name: Klebsiella terrigena
+                ConceptType: Species
+                ConceptId: species/klebsiella-terrigena
+                ConceptSource: LPSN
+                Id: 760
+                LpsnRecordNumber: 777157
+                3GCR: true
+                Carbapenems: true
+                Synonyms:
+                - Name: Raoultella terrigena
+                  ConceptId: species/raoultella-terrigena
+                  ConceptSource: LPSN
+                  Id: 1294
+                  LpsnRecordNumber: 780333
+              - Name: Klebsiella variicola
+                ConceptType: Species
+                ConceptId: species/klebsiella-variicola
+                ConceptSource: LPSN
+                Id: 2264
+                LpsnRecordNumber: 777159
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Klebsiella singaporensis
+                  ConceptId: species/klebsiella-singaporensis
+                  ConceptSource: LPSN
+                  Id: 1607
+                  LpsnRecordNumber: 777155
+              Synonyms:
+              - Name: Calymmatobacterium
+                ConceptId: genus/calymmatobacterium
+                ConceptSource: LPSN
+                Id: 2119
+                LpsnRecordNumber: 517194
+              - Name: Raoultella
+                ConceptId: genus/raoultella
+                ConceptSource: LPSN
+                Id: 2202
+                LpsnRecordNumber: 516456
+            - Name: Kluyvera
+              ConceptType: Genus
+              ConceptId: genus/kluyvera
+              ConceptSource: LPSN
+              Id: 9
+              LpsnRecordNumber: 515893
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Kluyvera ascorbata
+                ConceptType: Species
+                ConceptId: species/kluyvera-ascorbata
+                ConceptSource: LPSN
+                Id: 1530
+                LpsnRecordNumber: 777167
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Kluyvera cryocrescens
+                ConceptType: Species
+                ConceptId: species/kluyvera-cryocrescens
+                ConceptSource: LPSN
+                Id: 170
+                LpsnRecordNumber: 777170
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Kluyvera georgiana
+                ConceptType: Species
+                ConceptId: species/kluyvera-georgiana
+                ConceptSource: LPSN
+                Id: 409
+                LpsnRecordNumber: 777171
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Kluyvera intermedia
+                ConceptType: Species
+                ConceptId: species/kluyvera-intermedia
+                ConceptSource: LPSN
+                Id: 296
+                LpsnRecordNumber: 777172
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Enterobacter intermedius
+                  ConceptId: species/enterobacter-intermedius
+                  ConceptSource: LPSN
+                  Id: 1809
+                  LpsnRecordNumber: 775945
+            - Name: Kosakonia
+              ConceptType: Genus
+              ConceptId: genus/kosakonia
+              ConceptSource: LPSN
+              Id: 758
+              LpsnRecordNumber: 518439
+              3GCR: true
+              Children:
+              - Name: Kosakonia cowanii
+                ConceptType: Species
+                ConceptId: species/kosakonia-cowanii
+                ConceptSource: LPSN
+                Id: 2352
+                LpsnRecordNumber: 791223
+                3GCR: true
+                Synonyms:
+                - Name: Enterobacter cowanii
+                  ConceptId: species/enterobacter-cowanii
+                  ConceptSource: LPSN
+                  Id: 1974
+                  LpsnRecordNumber: 775936
+            - Name: Leclercia
+              ConceptType: Genus
+              ConceptId: genus/leclercia
+              ConceptSource: LPSN
+              Id: 2266
+              LpsnRecordNumber: 515930
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Leclercia adecarboxylata
+                ConceptType: Species
+                ConceptId: species/leclercia-adecarboxylata
+                ConceptSource: LPSN
+                Id: 2159
+                LpsnRecordNumber: 777447
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Escherichia adecarboxylata
+                  ConceptId: species/escherichia-adecarboxylata
+                  ConceptSource: LPSN
+                  Id: 222
+                  LpsnRecordNumber: 776052
+            - Name: Lelliottia
+              ConceptType: Genus
+              ConceptId: genus/lelliottia
+              ConceptSource: LPSN
+              Id: 2513
+              LpsnRecordNumber: 518437
+              3GCR: true
+              Children:
+              - Name: Lelliottia amnigena
+                ConceptType: Species
+                ConceptId: species/lelliottia-amnigena
+                ConceptSource: LPSN
+                Id: 1228
+                LpsnRecordNumber: 791220
+                3GCR: true
+                Synonyms:
+                - Name: Enterobacter amnigenus
+                  ConceptId: species/enterobacter-amnigenus
+                  ConceptSource: LPSN
+                  Id: 1755
+                  LpsnRecordNumber: 775930
+              - Name: Lelliottia nimipressuralis
+                ConceptType: Species
+                ConceptId: species/lelliottia-nimipressuralis
+                ConceptSource: LPSN
+                Id: 1249
+                LpsnRecordNumber: 791219
+                3GCR: true
+                Synonyms:
+                - Name: Enterobacter nimipressuralis
+                  ConceptId: species/enterobacter-nimipressuralis
+                  ConceptSource: LPSN
+                  Id: 2322
+                  LpsnRecordNumber: 783770
+                - Name: Erwinia nimipressuralis
+                  ConceptId: species/erwinia-nimipressuralis
+                  ConceptSource: LPSN
+                  Id: 1361
+                  LpsnRecordNumber: 783798
+            - Name: Plesiomonas
+              ConceptType: Genus
+              ConceptId: genus/plesiomonas
+              ConceptSource: LPSN
+              Id: 590
+              LpsnRecordNumber: 516359
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Plesiomonas shigelloides
+                ConceptType: Species
+                ConceptId: species/plesiomonas-shigelloides
+                ConceptSource: LPSN
+                Id: 1324
+                LpsnRecordNumber: 779688
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Pluralibacter
+              ConceptType: Genus
+              ConceptId: genus/pluralibacter
+              ConceptSource: LPSN
+              Id: 630
+              LpsnRecordNumber: 518438
+              3GCR: true
+              Children:
+              - Name: Pluralibacter gergoviae
+                ConceptType: Species
+                ConceptId: species/pluralibacter-gergoviae
+                ConceptSource: LPSN
+                Id: 58
+                LpsnRecordNumber: 791221
+                3GCR: true
+                Synonyms:
+                - Name: Enterobacter gergoviae
+                  ConceptId: species/enterobacter-gergoviae
+                  ConceptSource: LPSN
+                  Id: 446
+                  LpsnRecordNumber: 775939
+              - Name: Pluralibacter pyrinus
+                ConceptType: Species
+                ConceptId: species/pluralibacter-pyrinus
+                ConceptSource: LPSN
+                Id: 553
+                LpsnRecordNumber: 791222
+                3GCR: true
+                Synonyms:
+                - Name: Enterobacter pyrinus
+                  ConceptId: species/enterobacter-pyrinus
+                  ConceptSource: LPSN
+                  Id: 38
+                  LpsnRecordNumber: 775950
+            - Name: Pseudescherichia
+              ConceptType: Genus
+              ConceptId: genus/pseudescherichia
+              ConceptSource: LPSN
+              LpsnRecordNumber: 519311
+              Children:
+              - Name: Pseudescherichia vulneris
+                ConceptType: Species
+                ConceptId: species/pseudescherichia-vulneris
+                ConceptSource: LPSN
+                Id: 3325
+                LpsnRecordNumber: 796273
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Escherichia vulneris
+                  ConceptId: species/escherichia-vulneris
+                  ConceptSource: LPSN
+                  Id: 2353
+                  LpsnRecordNumber: 776063
+            - Name: Salmonella
+              ConceptType: Genus
+              ConceptId: genus/salmonella
+              ConceptSource: LPSN
+              Id: 2504
+              LpsnRecordNumber: 516547
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Salmonella bongori
+                ConceptType: Species
+                ConceptId: species/salmonella-bongori
+                ConceptSource: LPSN
+                Id: 2074
+                LpsnRecordNumber: 780745
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Salmonella enterica
+                ConceptType: Species
+                ConceptId: species/salmonella-enterica
+                ConceptSource: LPSN
+                Id: 40
+                LpsnRecordNumber: 784857
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Children:
+                - Name: Salmonella enterica subsp. arizonae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/salmonella-enterica-arizonae
+                  ConceptSource: LPSN
+                  Id: 2732
+                  LpsnRecordNumber: 780755
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Salmonella enterica subsp. diarizonae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/salmonella-enterica-diarizonae
+                  ConceptSource: LPSN
+                  Id: 2768
+                  LpsnRecordNumber: 780757
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Salmonella enterica subsp. enterica
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/salmonella-enterica-enterica
+                  ConceptSource: LPSN
+                  Id: 2733
+                  LpsnRecordNumber: 780758
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                  Children:
+                  - Name: Salmonella enterica subsp. enterica Bareilly
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Bareilly
+                    ConceptSource: NeoIPC
+                    Id: 2740
+                    Synonyms:
+                    - Name: Salmonella Bareilly
+                      ConceptId: "38"
+                      ConceptSource: NeoIPC
+                      Id: 2741
+                  - Name: Salmonella enterica subsp. enterica Choleraesuis
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Choleraesuis
+                    ConceptSource: NeoIPC
+                    Id: 2734
+                    Synonyms:
+                    - Name: Salmonella choleraesuis
+                      ConceptId: species/salmonella-choleraesuis
+                      ConceptSource: LPSN
+                      Id: 2735
+                      LpsnRecordNumber: 780746
+                  - Name: Salmonella enterica subsp. enterica Enteritidis
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Enteritidis
+                    ConceptSource: NeoIPC
+                    Id: 2736
+                    Synonyms:
+                    - Name: Salmonella enteritidis
+                      ConceptId: species/salmonella-enteritidis
+                      ConceptSource: LPSN
+                      Id: 2737
+                      LpsnRecordNumber: 780762
+                  - Name: Salmonella enterica subsp. enterica Infantis
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Infantis
+                    ConceptSource: NeoIPC
+                    Id: 2738
+                    Synonyms:
+                    - Name: Salmonella Infantis
+                      ConceptId: "36"
+                      ConceptSource: NeoIPC
+                      Id: 2739
+                  - Name: Salmonella enterica subsp. enterica Isangi
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Isangi
+                    ConceptSource: NeoIPC
+                    Id: 2742
+                    Synonyms:
+                    - Name: Salmonella Isangi
+                      ConceptId: "40"
+                      ConceptSource: NeoIPC
+                      Id: 2743
+                  - Name: Salmonella enterica subsp. enterica Kottbus
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Kottbus
+                    ConceptSource: NeoIPC
+                    Id: 2744
+                    Synonyms:
+                    - Name: Salmonella Kottbus
+                      ConceptId: "42"
+                      ConceptSource: NeoIPC
+                      Id: 2745
+                  - Name: Salmonella enterica subsp. enterica Livingstone
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Livingstone
+                    ConceptSource: NeoIPC
+                    Id: 2746
+                    Synonyms:
+                    - Name: Salmonella Livingstone
+                      ConceptId: "44"
+                      ConceptSource: NeoIPC
+                      Id: 2747
+                  - Name: Salmonella enterica subsp. enterica Montevideo
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Montevideo
+                    ConceptSource: NeoIPC
+                    Id: 2748
+                    Synonyms:
+                    - Name: Salmonella Montevideo
+                      ConceptId: "46"
+                      ConceptSource: NeoIPC
+                      Id: 2749
+                  - Name: Salmonella enterica subsp. enterica Newport
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Newport
+                    ConceptSource: NeoIPC
+                    Id: 2750
+                    Synonyms:
+                    - Name: Salmonella Newport
+                      ConceptId: "48"
+                      ConceptSource: NeoIPC
+                      Id: 2751
+                  - Name: Salmonella enterica subsp. enterica Ohio
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Ohio
+                    ConceptSource: NeoIPC
+                    Id: 2752
+                    Synonyms:
+                    - Name: Salmonella Ohio
+                      ConceptId: "50"
+                      ConceptSource: NeoIPC
+                      Id: 2753
+                  - Name: Salmonella enterica subsp. enterica Senftenberg
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Senftenberg
+                    ConceptSource: NeoIPC
+                    Id: 2754
+                    Synonyms:
+                    - Name: Salmonella Senftenberg
+                      ConceptId: "52"
+                      ConceptSource: NeoIPC
+                      Id: 2755
+                  - Name: Salmonella enterica subsp. enterica Tennessee
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Tennessee
+                    ConceptSource: NeoIPC
+                    Id: 2756
+                    Synonyms:
+                    - Name: Salmonella Tennessee
+                      ConceptId: "54"
+                      ConceptSource: NeoIPC
+                      Id: 2757
+                  - Name: Salmonella enterica subsp. enterica Typhi
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Typhi
+                    ConceptSource: NeoIPC
+                    Id: 2764
+                    Synonyms:
+                    - Name: Salmonella typhi
+                      ConceptId: species/salmonella-typhi
+                      ConceptSource: LPSN
+                      Id: 2765
+                      LpsnRecordNumber: 784859
+                  - Name: Salmonella enterica subsp. enterica Typhimurium
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Typhimurium
+                    ConceptSource: NeoIPC
+                    Id: 2766
+                    Synonyms:
+                    - Name: Salmonella typhimurium
+                      ConceptId: species/salmonella-typhimurium
+                      ConceptSource: LPSN
+                      Id: 2767
+                      LpsnRecordNumber: 780770
+                  - Name: Salmonella enterica subsp. enterica Urbana
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Urbana
+                    ConceptSource: NeoIPC
+                    Id: 2758
+                    Synonyms:
+                    - Name: Salmonella Urbana
+                      ConceptId: "56"
+                      ConceptSource: NeoIPC
+                      Id: 2759
+                  - Name: Salmonella enterica subsp. enterica Virchow
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Virchow
+                    ConceptSource: NeoIPC
+                    Id: 2760
+                    Synonyms:
+                    - Name: Salmonella Virchow
+                      ConceptId: "58"
+                      ConceptSource: NeoIPC
+                      Id: 2761
+                  - Name: Salmonella enterica subsp. enterica Worthington
+                    ConceptType: Serotype
+                    ConceptId: Salmonella enterica subsp. enterica Worthington
+                    ConceptSource: NeoIPC
+                    Id: 2762
+                    Synonyms:
+                    - Name: Salmonella Worthington
+                      ConceptId: "60"
+                      ConceptSource: NeoIPC
+                      Id: 2763
+                - Name: Salmonella enterica subsp. houtenae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/salmonella-enterica-houtenae
+                  ConceptSource: LPSN
+                  Id: 2771
+                  LpsnRecordNumber: 780759
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Salmonella enterica subsp. indica
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/salmonella-enterica-indica
+                  ConceptSource: LPSN
+                  Id: 2769
+                  LpsnRecordNumber: 780760
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Salmonella enterica subsp. salamae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/salmonella-enterica-salamae
+                  ConceptSource: LPSN
+                  Id: 2770
+                  LpsnRecordNumber: 780761
+                  3GCR: true
+                  Carbapenems: true
+                  Colistin: true
+            - Name: Shigella
+              ConceptType: Genus
+              ConceptId: genus/shigella
+              ConceptSource: LPSN
+              Id: 86
+              LpsnRecordNumber: 516593
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Shigella boydii
+                ConceptType: Species
+                ConceptId: species/shigella-boydii
+                ConceptSource: LPSN
+                Id: 1438
+                LpsnRecordNumber: 780913
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Shigella dysenteriae
+                ConceptType: Species
+                ConceptId: species/shigella-dysenteriae
+                ConceptSource: LPSN
+                Id: 828
+                LpsnRecordNumber: 780914
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Shigella flexneri
+                ConceptType: Species
+                ConceptId: species/shigella-flexneri
+                ConceptSource: LPSN
+                Id: 1541
+                LpsnRecordNumber: 780915
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Shigella sonnei
+                ConceptType: Species
+                ConceptId: species/shigella-sonnei
+                ConceptSource: LPSN
+                Id: 1450
+                LpsnRecordNumber: 780917
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Trabulsiella
+              ConceptType: Genus
+              ConceptId: genus/trabulsiella
+              ConceptSource: LPSN
+              Id: 377
+              LpsnRecordNumber: 516853
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Trabulsiella guamensis
+                ConceptType: Species
+                ConceptId: species/trabulsiella-guamensis
+                ConceptSource: LPSN
+                Id: 1523
+                LpsnRecordNumber: 782814
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Yokenella
+              ConceptType: Genus
+              ConceptId: genus/yokenella
+              ConceptSource: LPSN
+              Id: 564
+              LpsnRecordNumber: 516948
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Yokenella regensburgei
+                ConceptType: Species
+                ConceptId: species/yokenella-regensburgei
+                ConceptSource: LPSN
+                Id: 2227
+                LpsnRecordNumber: 783205
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Koserella trabulsii
+                  ConceptId: species/koserella-trabulsii
+                  ConceptSource: LPSN
+                  Id: 1922
+                  LpsnRecordNumber: 777203
+          - Name: Erwiniaceae
+            ConceptType: Family
+            ConceptId: family/erwiniaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2056
+            Children:
+            - Name: Erwinia
+              ConceptType: Genus
+              ConceptId: genus/erwinia
+              ConceptSource: LPSN
+              Id: 1286
+              LpsnRecordNumber: 515596
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Erwinia persicina
+                ConceptType: Species
+                ConceptId: species/erwinia-persicina
+                ConceptSource: LPSN
+                Id: 1063
+                LpsnRecordNumber: 783800
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Erwinia persicinus
+                  ConceptId: species/erwinia-persicinus
+                  ConceptSource: LPSN
+                  Id: 2718
+                  LpsnRecordNumber: 783801
+            - Name: Mixta
+              ConceptType: Genus
+              ConceptId: genus/mixta
+              ConceptSource: LPSN
+              LpsnRecordNumber: 520368
+              Children:
+              - Name: Mixta calida
+                ConceptType: Species
+                ConceptId: species/mixta-calida
+                ConceptSource: LPSN
+                Id: 2726
+                LpsnRecordNumber: 798509
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Pantoea calida
+                  ConceptId: species/pantoea-calida
+                  ConceptSource: LPSN
+                  Id: 2727
+                  LpsnRecordNumber: 788296
+            - Name: Pantoea
+              ConceptType: Genus
+              ConceptId: genus/pantoea
+              ConceptSource: LPSN
+              Id: 1288
+              LpsnRecordNumber: 516251
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Pantoea agglomerans
+                ConceptType: Species
+                ConceptId: species/pantoea-agglomerans
+                ConceptSource: LPSN
+                Id: 987
+                LpsnRecordNumber: 779135
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Enterobacter agglomerans
+                  ConceptId: species/enterobacter-agglomerans
+                  ConceptSource: LPSN
+                  Id: 2281
+                  LpsnRecordNumber: 775929
+              - Name: Pantoea ananatis
+                ConceptType: Species
+                ConceptId: species/pantoea-ananatis
+                ConceptSource: LPSN
+                Id: 2041
+                LpsnRecordNumber: 779136
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Erwinia ananas
+                  ConceptId: species/erwinia-ananas
+                  ConceptSource: LPSN
+                  Id: 1948
+                  LpsnRecordNumber: 798508
+                - Name: Erwinia ananatis
+                  ConceptId: species/erwinia-ananatis
+                  ConceptSource: LPSN
+                  Id: 3086
+                  LpsnRecordNumber: 776009
+                - Name: Erwinia uredovora
+                  ConceptId: species/erwinia-uredovora
+                  ConceptSource: LPSN
+                  Id: 2099
+                  LpsnRecordNumber: 776036
+                - Name: Pantoea ananas
+                  ConceptId: species/pantoea-ananas
+                  ConceptSource: LPSN
+                  Id: 533
+                  LpsnRecordNumber: 784563
+              - Name: Pantoea brenneri
+                ConceptType: Species
+                ConceptId: species/pantoea-brenneri
+                ConceptSource: LPSN
+                Id: 2725
+                LpsnRecordNumber: 788825
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pantoea conspicua
+                ConceptType: Species
+                ConceptId: species/pantoea-conspicua
+                ConceptSource: LPSN
+                Id: 2728
+                LpsnRecordNumber: 788826
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pantoea dispersa
+                ConceptType: Species
+                ConceptId: species/pantoea-dispersa
+                ConceptSource: LPSN
+                Id: 913
+                LpsnRecordNumber: 779138
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pantoea eucrina
+                ConceptType: Species
+                ConceptId: species/pantoea-eucrina
+                ConceptSource: LPSN
+                Id: 2729
+                LpsnRecordNumber: 788824
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pantoea septica
+                ConceptType: Species
+                ConceptId: species/pantoea-septica
+                ConceptSource: LPSN
+                Id: 2730
+                LpsnRecordNumber: 788823
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Tatumella
+              ConceptType: Genus
+              ConceptId: genus/tatumella
+              ConceptSource: LPSN
+              Id: 318
+              LpsnRecordNumber: 516731
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Tatumella ptyseos
+                ConceptType: Species
+                ConceptId: species/tatumella-ptyseos
+                ConceptSource: LPSN
+                Id: 592
+                LpsnRecordNumber: 782389
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Tatumella saanichensis
+                ConceptType: Species
+                ConceptId: species/tatumella-saanichensis
+                ConceptSource: LPSN
+                Id: 2773
+                LpsnRecordNumber: 792867
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+          - Name: Hafniaceae
+            ConceptType: Family
+            ConceptId: family/hafniaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2055
+            Children:
+            - Name: Edwardsiella
+              ConceptType: Genus
+              ConceptId: genus/edwardsiella
+              ConceptSource: LPSN
+              Id: 1689
+              LpsnRecordNumber: 515566
+              3GCR: true
+              Carbapenems: true
+              Children:
+              - Name: Edwardsiella hoshinae
+                ConceptType: Species
+                ConceptId: species/edwardsiella-hoshinae
+                ConceptSource: LPSN
+                Id: 1350
+                LpsnRecordNumber: 775880
+                3GCR: true
+                Carbapenems: true
+              - Name: Edwardsiella ictaluri
+                ConceptType: Species
+                ConceptId: species/edwardsiella-ictaluri
+                ConceptSource: LPSN
+                Id: 2309
+                LpsnRecordNumber: 775881
+                3GCR: true
+                Carbapenems: true
+              - Name: Edwardsiella tarda
+                ConceptType: Species
+                ConceptId: species/edwardsiella-tarda
+                ConceptSource: LPSN
+                Id: 2260
+                LpsnRecordNumber: 775882
+                3GCR: true
+                Carbapenems: true
+                Synonyms:
+                - Name: Edwardsiella anguillimortifera
+                  ConceptId: species/edwardsiella-anguillimortifera
+                  ConceptSource: LPSN
+                  Id: 1910
+                  LpsnRecordNumber: 783754
+            - Name: Hafnia
+              ConceptType: Genus
+              ConceptId: genus/hafnia
+              ConceptSource: LPSN
+              Id: 779
+              LpsnRecordNumber: 515741
+              3GCR: true
+              Carbapenems: true
+              Children:
+              - Name: Hafnia alvei
+                ConceptType: Species
+                ConceptId: species/hafnia-alvei
+                ConceptSource: LPSN
+                Id: 23
+                LpsnRecordNumber: 776651
+                3GCR: true
+                Carbapenems: true
+              - Name: Hafnia paralvei
+                ConceptType: Species
+                ConceptId: species/hafnia-paralvei
+                ConceptSource: LPSN
+                Id: 2719
+                LpsnRecordNumber: 788679
+                3GCR: true
+                Carbapenems: true
+            - Name: Obesumbacterium
+              ConceptType: Genus
+              ConceptId: genus/obesumbacterium
+              ConceptSource: LPSN
+              Id: 1802
+              LpsnRecordNumber: 516189
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Obesumbacterium proteus
+                ConceptType: Species
+                ConceptId: species/obesumbacterium-proteus
+                ConceptSource: LPSN
+                Id: 527
+                LpsnRecordNumber: 778923
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+          - Name: Morganellaceae
+            ConceptType: Family
+            ConceptId: family/morganellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2058
+            Children:
+            - Name: Moellerella
+              ConceptType: Genus
+              ConceptId: genus/moellerella
+              ConceptSource: LPSN
+              Id: 472
+              LpsnRecordNumber: 516111
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Moellerella wisconsensis
+                ConceptType: Species
+                ConceptId: species/moellerella-wisconsensis
+                ConceptSource: LPSN
+                Id: 761
+                LpsnRecordNumber: 778280
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Morganella
+              ConceptType: Genus
+              ConceptId: genus/morganella
+              ConceptSource: LPSN
+              Id: 665
+              LpsnRecordNumber: 516125
+              3GCR: true
+              Carbapenems: true
+              Children:
+              - Name: Morganella morganii
+                ConceptType: Species
+                ConceptId: species/morganella-morganii
+                ConceptSource: LPSN
+                Id: 66
+                LpsnRecordNumber: 778330
+                3GCR: true
+                Carbapenems: true
+                Children:
+                - Name: Morganella morganii subsp. sibonii
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/morganella-morganii-sibonii
+                  ConceptSource: LPSN
+                  Id: 149
+                  LpsnRecordNumber: 778332
+                  3GCR: true
+                  Carbapenems: true
+            - Name: Photorhabdus
+              ConceptType: Genus
+              ConceptId: genus/photorhabdus
+              ConceptSource: LPSN
+              Id: 1208
+              LpsnRecordNumber: 516324
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Photorhabdus asymbiotica
+                ConceptType: Species
+                ConceptId: species/photorhabdus-asymbiotica
+                ConceptSource: LPSN
+                Id: 287
+                LpsnRecordNumber: 784628
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Photorhabdus luminescens
+                ConceptType: Species
+                ConceptId: species/photorhabdus-luminescens
+                ConceptSource: LPSN
+                Id: 781
+                LpsnRecordNumber: 779539
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Xenorhabdus luminescens
+                  ConceptId: species/xenorhabdus-luminescens
+                  ConceptSource: LPSN
+                  Id: 360
+                  LpsnRecordNumber: 783167
+              - Name: Photorhabdus temperata
+                ConceptType: Species
+                ConceptId: species/photorhabdus-temperata
+                ConceptSource: LPSN
+                Id: 265
+                LpsnRecordNumber: 779546
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Proteus
+              ConceptType: Genus
+              ConceptId: genus/proteus
+              ConceptSource: LPSN
+              Id: 2386
+              LpsnRecordNumber: 516404
+              3GCR: true
+              Carbapenems: true
+              Children:
+              - Name: Proteus faecis
+                ConceptType: Species
+                ConceptId: species/proteus-faecis
+                ConceptSource: LPSN
+                Id: 2731
+                LpsnRecordNumber: 800143
+                3GCR: true
+                Carbapenems: true
+              - Name: Proteus hauseri
+                ConceptType: Species
+                ConceptId: species/proteus-hauseri
+                ConceptSource: LPSN
+                Id: 1671
+                LpsnRecordNumber: 779871
+                3GCR: true
+                Carbapenems: true
+              - Name: Proteus mirabilis
+                ConceptType: Species
+                ConceptId: species/proteus-mirabilis
+                ConceptSource: LPSN
+                Id: 420
+                LpsnRecordNumber: 779875
+                3GCR: true
+                Carbapenems: true
+              - Name: Proteus myxofaciens
+                ConceptType: Species
+                ConceptId: species/proteus-myxofaciens
+                ConceptSource: LPSN
+                Id: 2008
+                LpsnRecordNumber: 779877
+                3GCR: true
+                Carbapenems: true
+                Synonyms:
+                - Name: Cosenzaea myxofaciens
+                  ConceptId: species/cosenzaea-myxofaciens
+                  ConceptSource: LPSN
+                  Id: 3238
+                  LpsnRecordNumber: 789320
+              - Name: Proteus penneri
+                ConceptType: Species
+                ConceptId: species/proteus-penneri
+                ConceptSource: LPSN
+                Id: 1179
+                LpsnRecordNumber: 779878
+                3GCR: true
+                Carbapenems: true
+              - Name: Proteus vulgaris
+                ConceptType: Species
+                ConceptId: species/proteus-vulgaris
+                ConceptSource: LPSN
+                Id: 1517
+                LpsnRecordNumber: 779882
+                3GCR: true
+                Carbapenems: true
+              Synonyms:
+              - Name: Cosenzaea
+                ConceptId: genus/cosenzaea
+                ConceptSource: LPSN
+                Id: 3479
+                LpsnRecordNumber: 518101
+            - Name: Providencia
+              ConceptType: Genus
+              ConceptId: genus/providencia
+              ConceptSource: LPSN
+              Id: 1876
+              LpsnRecordNumber: 516408
+              3GCR: true
+              Carbapenems: true
+              Children:
+              - Name: Providencia alcalifaciens
+                ConceptType: Species
+                ConceptId: species/providencia-alcalifaciens
+                ConceptSource: LPSN
+                Id: 2084
+                LpsnRecordNumber: 779886
+                3GCR: true
+                Carbapenems: true
+              - Name: Providencia heimbachae
+                ConceptType: Species
+                ConceptId: species/providencia-heimbachae
+                ConceptSource: LPSN
+                Id: 2178
+                LpsnRecordNumber: 779888
+                3GCR: true
+                Carbapenems: true
+              - Name: Providencia rettgeri
+                ConceptType: Species
+                ConceptId: species/providencia-rettgeri
+                ConceptSource: LPSN
+                Id: 516
+                LpsnRecordNumber: 779889
+                3GCR: true
+                Carbapenems: true
+                Synonyms:
+                - Name: Proteus rettgeri
+                  ConceptId: species/proteus-rettgeri
+                  ConceptSource: LPSN
+                  Id: 747
+                  LpsnRecordNumber: 779879
+              - Name: Providencia rustigianii
+                ConceptType: Species
+                ConceptId: species/providencia-rustigianii
+                ConceptSource: LPSN
+                Id: 2120
+                LpsnRecordNumber: 779890
+                3GCR: true
+                Carbapenems: true
+                Synonyms:
+                - Name: Providencia friedericiana
+                  ConceptId: species/providencia-friedericiana
+                  ConceptSource: LPSN
+                  Id: 2112
+                  LpsnRecordNumber: 779887
+              - Name: Providencia stuartii
+                ConceptType: Species
+                ConceptId: species/providencia-stuartii
+                ConceptSource: LPSN
+                Id: 535
+                LpsnRecordNumber: 779892
+                3GCR: true
+                Carbapenems: true
+            - Name: Xenorhabdus
+              ConceptType: Genus
+              ConceptId: genus/xenorhabdus
+              ConceptSource: LPSN
+              Id: 1257
+              LpsnRecordNumber: 516934
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Xenorhabdus nematophila
+                ConceptType: Species
+                ConceptId: species/xenorhabdus-nematophila
+                ConceptSource: LPSN
+                Id: 944
+                LpsnRecordNumber: 783170
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+          - Name: Pectobacteriaceae
+            ConceptType: Family
+            ConceptId: family/pectobacteriaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2054
+            Children:
+            - Name: Pectobacterium
+              ConceptType: Genus
+              ConceptId: genus/pectobacterium
+              ConceptSource: LPSN
+              Id: 2559
+              LpsnRecordNumber: 516273
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+            - Name: Sodalis
+              ConceptType: Genus
+              ConceptId: genus/sodalis
+              ConceptSource: LPSN
+              LpsnRecordNumber: 516613
+              Children:
+              - Name: Sodalis praecaptivus
+                ConceptType: Species
+                ConceptId: species/sodalis-praecaptivus
+                ConceptSource: LPSN
+                Id: 2772
+                LpsnRecordNumber: 792825
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+          - Name: Yersiniaceae
+            ConceptType: Family
+            ConceptId: family/yersiniaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2057
+            Children:
+            - Name: Ewingella
+              ConceptType: Genus
+              ConceptId: genus/ewingella
+              ConceptSource: LPSN
+              Id: 1248
+              LpsnRecordNumber: 515607
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Ewingella americana
+                ConceptType: Species
+                ConceptId: species/ewingella-americana
+                ConceptSource: LPSN
+                Id: 1443
+                LpsnRecordNumber: 776130
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Rahnella
+              ConceptType: Genus
+              ConceptId: genus/rahnella
+              ConceptSource: LPSN
+              Id: 209
+              LpsnRecordNumber: 516450
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Rahnella aquatilis
+                ConceptType: Species
+                ConceptId: species/rahnella-aquatilis
+                ConceptSource: LPSN
+                Id: 943
+                LpsnRecordNumber: 780310
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Serratia
+              ConceptType: Genus
+              ConceptId: genus/serratia
+              ConceptSource: LPSN
+              Id: 2393
+              LpsnRecordNumber: 516590
+              3GCR: true
+              Carbapenems: true
+              Children:
+              - Name: Serratia entomophila
+                ConceptType: Species
+                ConceptId: species/serratia-entomophila
+                ConceptSource: LPSN
+                Id: 1895
+                LpsnRecordNumber: 780871
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia ficaria
+                ConceptType: Species
+                ConceptId: species/serratia-ficaria
+                ConceptSource: LPSN
+                Id: 1552
+                LpsnRecordNumber: 780872
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia fonticola
+                ConceptType: Species
+                ConceptId: species/serratia-fonticola
+                ConceptSource: LPSN
+                Id: 893
+                LpsnRecordNumber: 780873
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia grimesii
+                ConceptType: Species
+                ConceptId: species/serratia-grimesii
+                ConceptSource: LPSN
+                Id: 2295
+                LpsnRecordNumber: 780874
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia liquefaciens
+                ConceptType: Species
+                ConceptId: species/serratia-liquefaciens
+                ConceptSource: LPSN
+                Id: 1456
+                LpsnRecordNumber: 780875
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia marcescens
+                ConceptType: Species
+                ConceptId: species/serratia-marcescens
+                ConceptSource: LPSN
+                Id: 1827
+                LpsnRecordNumber: 780876
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia odorifera
+                ConceptType: Species
+                ConceptId: species/serratia-odorifera
+                ConceptSource: LPSN
+                Id: 1162
+                LpsnRecordNumber: 780880
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia plymuthica
+                ConceptType: Species
+                ConceptId: species/serratia-plymuthica
+                ConceptSource: LPSN
+                Id: 2233
+                LpsnRecordNumber: 780882
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia proteamaculans
+                ConceptType: Species
+                ConceptId: species/serratia-proteamaculans
+                ConceptSource: LPSN
+                Id: 1846
+                LpsnRecordNumber: 780883
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia quinivorans
+                ConceptType: Species
+                ConceptId: species/serratia-quinivorans
+                ConceptSource: LPSN
+                Id: 2337
+                LpsnRecordNumber: 780885
+                3GCR: true
+                Carbapenems: true
+              - Name: Serratia rubidaea
+                ConceptType: Species
+                ConceptId: species/serratia-rubidaea
+                ConceptSource: LPSN
+                Id: 768
+                LpsnRecordNumber: 780886
+                3GCR: true
+                Carbapenems: true
+                Synonyms:
+                - Name: Serratia marinorubra
+                  ConceptId: species/serratia-marinorubra
+                  ConceptSource: LPSN
+                  Id: 1186
+                  LpsnRecordNumber: 780879
+              - Name: Serratia ureilytica
+                ConceptType: Species
+                ConceptId: species/serratia-ureilytica
+                ConceptSource: LPSN
+                Id: 1047
+                LpsnRecordNumber: 780887
+                3GCR: true
+                Carbapenems: true
+            - Name: Yersinia
+              ConceptType: Genus
+              ConceptId: genus/yersinia
+              ConceptSource: LPSN
+              Id: 431
+              LpsnRecordNumber: 516947
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Yersinia aldovae
+                ConceptType: Species
+                ConceptId: species/yersinia-aldovae
+                ConceptSource: LPSN
+                Id: 2098
+                LpsnRecordNumber: 783197
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia aleksiciae
+                ConceptType: Species
+                ConceptId: species/yersinia-aleksiciae
+                ConceptSource: LPSN
+                Id: 1121
+                LpsnRecordNumber: 783198
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia bercovieri
+                ConceptType: Species
+                ConceptId: species/yersinia-bercovieri
+                ConceptSource: LPSN
+                Id: 1122
+                LpsnRecordNumber: 785220
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia canariae
+                ConceptType: Species
+                ConceptId: species/yersinia-canariae
+                ConceptSource: LPSN
+                Id: 2774
+                LpsnRecordNumber: 5910
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia enterocolitica
+                ConceptType: Species
+                ConceptId: species/yersinia-enterocolitica
+                ConceptSource: LPSN
+                Id: 1303
+                LpsnRecordNumber: 785221
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia frederiksenii
+                ConceptType: Species
+                ConceptId: species/yersinia-frederiksenii
+                ConceptSource: LPSN
+                Id: 611
+                LpsnRecordNumber: 785222
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia intermedia
+                ConceptType: Species
+                ConceptId: species/yersinia-intermedia
+                ConceptSource: LPSN
+                Id: 440
+                LpsnRecordNumber: 785223
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia kristensenii
+                ConceptType: Species
+                ConceptId: species/yersinia-kristensenii
+                ConceptSource: LPSN
+                Id: 1782
+                LpsnRecordNumber: 785224
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia mollaretii
+                ConceptType: Species
+                ConceptId: species/yersinia-mollaretii
+                ConceptSource: LPSN
+                Id: 254
+                LpsnRecordNumber: 785225
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia pestis
+                ConceptType: Species
+                ConceptId: species/yersinia-pestis
+                ConceptSource: LPSN
+                Id: 554
+                LpsnRecordNumber: 785226
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia pseudotuberculosis
+                ConceptType: Species
+                ConceptId: species/yersinia-pseudotuberculosis
+                ConceptSource: LPSN
+                Id: 1255
+                LpsnRecordNumber: 783202
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia rohdei
+                ConceptType: Species
+                ConceptId: species/yersinia-rohdei
+                ConceptSource: LPSN
+                Id: 2115
+                LpsnRecordNumber: 783203
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Yersinia ruckeri
+                ConceptType: Species
+                ConceptId: species/yersinia-ruckeri
+                ConceptSource: LPSN
+                Id: 1218
+                LpsnRecordNumber: 785227
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+        - Name: Legionellales
+          ConceptType: Order
+          ConceptId: order/legionellales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5072
+          Children:
+          - Name: Coxiellaceae
+            ConceptType: Family
+            ConceptId: family/coxiellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 350
+            Children:
+            - Name: Coxiella
+              ConceptType: Genus
+              ConceptId: genus/coxiella
+              ConceptSource: LPSN
+              Id: 2346
+              LpsnRecordNumber: 517210
+              Children:
+              - Name: Coxiella burnetii
+                ConceptType: Species
+                ConceptId: species/coxiella-burnetii
+                ConceptSource: LPSN
+                Id: 917
+                LpsnRecordNumber: 783706
+          - Name: Legionellaceae
+            ConceptType: Family
+            ConceptId: family/legionellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 744
+            Children:
+            - Name: Legionella
+              ConceptType: Genus
+              ConceptId: genus/legionella
+              ConceptSource: LPSN
+              Id: 2557
+              LpsnRecordNumber: 515933
+              Children:
+              - Name: Legionella adelaidensis
+                ConceptType: Species
+                ConceptId: species/legionella-adelaidensis
+                ConceptSource: LPSN
+                Id: 1855
+                LpsnRecordNumber: 784081
+              - Name: Legionella anisa
+                ConceptType: Species
+                ConceptId: species/legionella-anisa
+                ConceptSource: LPSN
+                Id: 1527
+                LpsnRecordNumber: 777452
+              - Name: Legionella beliardensis
+                ConceptType: Species
+                ConceptId: species/legionella-beliardensis
+                ConceptSource: LPSN
+                Id: 350
+                LpsnRecordNumber: 784082
+              - Name: Legionella birminghamensis
+                ConceptType: Species
+                ConceptId: species/legionella-birminghamensis
+                ConceptSource: LPSN
+                Id: 2444
+                LpsnRecordNumber: 784083
+              - Name: Legionella bozemanae
+                ConceptType: Species
+                ConceptId: species/legionella-bozemanae
+                ConceptSource: LPSN
+                Id: 549
+                LpsnRecordNumber: 784084
+                Synonyms:
+                - Name: Fluoribacter bozemanae
+                  ConceptId: species/fluoribacter-bozemanae
+                  ConceptSource: LPSN
+                  Id: 135
+                  LpsnRecordNumber: 776305
+                - Name: Legionella bozemanii
+                  ConceptId: species/legionella-bozemanii
+                  ConceptSource: LPSN
+                  Id: 2907
+                  LpsnRecordNumber: 784085
+              - Name: Legionella brunensis
+                ConceptType: Species
+                ConceptId: species/legionella-brunensis
+                ConceptSource: LPSN
+                Id: 1569
+                LpsnRecordNumber: 784086
+              - Name: Legionella busanensis
+                ConceptType: Species
+                ConceptId: species/legionella-busanensis
+                ConceptSource: LPSN
+                Id: 1700
+                LpsnRecordNumber: 784087
+              - Name: Legionella cardiaca
+                ConceptType: Species
+                ConceptId: species/legionella-cardiaca
+                ConceptSource: LPSN
+                Id: 2908
+                LpsnRecordNumber: 790327
+              - Name: Legionella cherrii
+                ConceptType: Species
+                ConceptId: species/legionella-cherrii
+                ConceptSource: LPSN
+                Id: 1729
+                LpsnRecordNumber: 784088
+              - Name: Legionella cincinnatiensis
+                ConceptType: Species
+                ConceptId: species/legionella-cincinnatiensis
+                ConceptSource: LPSN
+                Id: 1219
+                LpsnRecordNumber: 784089
+              - Name: Legionella drancourtii
+                ConceptType: Species
+                ConceptId: species/legionella-drancourtii
+                ConceptSource: LPSN
+                Id: 424
+                LpsnRecordNumber: 784090
+              - Name: Legionella drozanskii
+                ConceptType: Species
+                ConceptId: species/legionella-drozanskii
+                ConceptSource: LPSN
+                Id: 1031
+                LpsnRecordNumber: 784091
+              - Name: Legionella dumoffii
+                ConceptType: Species
+                ConceptId: species/legionella-dumoffii
+                ConceptSource: LPSN
+                Id: 1262
+                LpsnRecordNumber: 784092
+                Synonyms:
+                - Name: Fluoribacter dumoffii
+                  ConceptId: species/fluoribacter-dumoffii
+                  ConceptSource: LPSN
+                  Id: 947
+                  LpsnRecordNumber: 776306
+              - Name: Legionella erythra
+                ConceptType: Species
+                ConceptId: species/legionella-erythra
+                ConceptSource: LPSN
+                Id: 169
+                LpsnRecordNumber: 777453
+              - Name: Legionella fairfieldensis
+                ConceptType: Species
+                ConceptId: species/legionella-fairfieldensis
+                ConceptSource: LPSN
+                Id: 138
+                LpsnRecordNumber: 784093
+              - Name: Legionella fallonii
+                ConceptType: Species
+                ConceptId: species/legionella-fallonii
+                ConceptSource: LPSN
+                Id: 1177
+                LpsnRecordNumber: 784094
+              - Name: Legionella feeleii
+                ConceptType: Species
+                ConceptId: species/legionella-feeleii
+                ConceptSource: LPSN
+                Id: 912
+                LpsnRecordNumber: 777454
+              - Name: Legionella geestiana
+                ConceptType: Species
+                ConceptId: species/legionella-geestiana
+                ConceptSource: LPSN
+                Id: 1411
+                LpsnRecordNumber: 784095
+              - Name: Legionella gormanii
+                ConceptType: Species
+                ConceptId: species/legionella-gormanii
+                ConceptSource: LPSN
+                Id: 2580
+                LpsnRecordNumber: 784096
+                Synonyms:
+                - Name: Fluoribacter gormanii
+                  ConceptId: species/fluoribacter-gormanii
+                  ConceptSource: LPSN
+                  Id: 766
+                  LpsnRecordNumber: 776307
+              - Name: Legionella hackeliae
+                ConceptType: Species
+                ConceptId: species/legionella-hackeliae
+                ConceptSource: LPSN
+                Id: 1868
+                LpsnRecordNumber: 784099
+              - Name: Legionella indianapolisensis
+                ConceptType: Species
+                ConceptId: species/legionella-indianapolisensis
+                ConceptSource: LPSN
+                Id: 2909
+                LpsnRecordNumber: 17534
+              - Name: Legionella israelensis
+                ConceptType: Species
+                ConceptId: species/legionella-israelensis
+                ConceptSource: LPSN
+                Id: 732
+                LpsnRecordNumber: 784100
+              - Name: Legionella jamestowniensis
+                ConceptType: Species
+                ConceptId: species/legionella-jamestowniensis
+                ConceptSource: LPSN
+                Id: 2528
+                LpsnRecordNumber: 784101
+              - Name: Legionella jordanis
+                ConceptType: Species
+                ConceptId: species/legionella-jordanis
+                ConceptSource: LPSN
+                Id: 495
+                LpsnRecordNumber: 784102
+              - Name: Legionella lansingensis
+                ConceptType: Species
+                ConceptId: species/legionella-lansingensis
+                ConceptSource: LPSN
+                Id: 2308
+                LpsnRecordNumber: 784103
+              - Name: Legionella londiniensis
+                ConceptType: Species
+                ConceptId: species/legionella-londiniensis
+                ConceptSource: LPSN
+                Id: 701
+                LpsnRecordNumber: 784104
+              - Name: Legionella longbeachae
+                ConceptType: Species
+                ConceptId: species/legionella-longbeachae
+                ConceptSource: LPSN
+                Id: 1977
+                LpsnRecordNumber: 777455
+              - Name: Legionella lytica
+                ConceptType: Species
+                ConceptId: species/legionella-lytica
+                ConceptSource: LPSN
+                Id: 1168
+                LpsnRecordNumber: 784105
+              - Name: Legionella maceachernii
+                ConceptType: Species
+                ConceptId: species/legionella-maceachernii
+                ConceptSource: LPSN
+                Id: 1929
+                LpsnRecordNumber: 784106
+              - Name: Legionella micdadei
+                ConceptType: Species
+                ConceptId: species/legionella-micdadei
+                ConceptSource: LPSN
+                Id: 2263
+                LpsnRecordNumber: 784107
+                Synonyms:
+                - Name: Legionella pittsburghensis
+                  ConceptId: species/legionella-pittsburghensis
+                  ConceptSource: LPSN
+                  Id: 443
+                  LpsnRecordNumber: 784112
+                - Name: Tatlockia micdadei
+                  ConceptId: species/tatlockia-micdadei
+                  ConceptSource: LPSN
+                  Id: 1879
+                  LpsnRecordNumber: 782388
+              - Name: Legionella moravica
+                ConceptType: Species
+                ConceptId: species/legionella-moravica
+                ConceptSource: LPSN
+                Id: 740
+                LpsnRecordNumber: 784108
+              - Name: Legionella nagasakiensis
+                ConceptType: Species
+                ConceptId: species/legionella-nagasakiensis
+                ConceptSource: LPSN
+                Id: 2910
+                LpsnRecordNumber: 789597
+              - Name: Legionella nautarum
+                ConceptType: Species
+                ConceptId: species/legionella-nautarum
+                ConceptSource: LPSN
+                Id: 437
+                LpsnRecordNumber: 784109
+              - Name: Legionella oakridgensis
+                ConceptType: Species
+                ConceptId: species/legionella-oakridgensis
+                ConceptSource: LPSN
+                Id: 557
+                LpsnRecordNumber: 784110
+              - Name: Legionella parisiensis
+                ConceptType: Species
+                ConceptId: species/legionella-parisiensis
+                ConceptSource: LPSN
+                Id: 2109
+                LpsnRecordNumber: 784111
+              - Name: Legionella pneumophila
+                ConceptType: Species
+                ConceptId: species/legionella-pneumophila
+                ConceptSource: LPSN
+                Id: 1683
+                LpsnRecordNumber: 784113
+              - Name: Legionella quateirensis
+                ConceptType: Species
+                ConceptId: species/legionella-quateirensis
+                ConceptSource: LPSN
+                Id: 344
+                LpsnRecordNumber: 784114
+              - Name: Legionella quinlivanii
+                ConceptType: Species
+                ConceptId: species/legionella-quinlivanii
+                ConceptSource: LPSN
+                Id: 346
+                LpsnRecordNumber: 784115
+              - Name: Legionella rowbothamii
+                ConceptType: Species
+                ConceptId: species/legionella-rowbothamii
+                ConceptSource: LPSN
+                Id: 700
+                LpsnRecordNumber: 784116
+              - Name: Legionella rubrilucens
+                ConceptType: Species
+                ConceptId: species/legionella-rubrilucens
+                ConceptSource: LPSN
+                Id: 923
+                LpsnRecordNumber: 777459
+              - Name: Legionella sainthelensi
+                ConceptType: Species
+                ConceptId: species/legionella-sainthelensi
+                ConceptSource: LPSN
+                Id: 1955
+                LpsnRecordNumber: 784117
+              - Name: Legionella santicrucis
+                ConceptType: Species
+                ConceptId: species/legionella-santicrucis
+                ConceptSource: LPSN
+                Id: 663
+                LpsnRecordNumber: 784118
+              - Name: Legionella shakespearei
+                ConceptType: Species
+                ConceptId: species/legionella-shakespearei
+                ConceptSource: LPSN
+                Id: 342
+                LpsnRecordNumber: 784119
+              - Name: Legionella spiritensis
+                ConceptType: Species
+                ConceptId: species/legionella-spiritensis
+                ConceptSource: LPSN
+                Id: 886
+                LpsnRecordNumber: 784120
+              - Name: Legionella steelei
+                ConceptType: Species
+                ConceptId: species/legionella-steelei
+                ConceptSource: LPSN
+                Id: 2911
+                LpsnRecordNumber: 790068
+              - Name: Legionella steigerwaltii
+                ConceptType: Species
+                ConceptId: species/legionella-steigerwaltii
+                ConceptSource: LPSN
+                Id: 2568
+                LpsnRecordNumber: 784121
+              - Name: Legionella taurinensis
+                ConceptType: Species
+                ConceptId: species/legionella-taurinensis
+                ConceptSource: LPSN
+                Id: 2231
+                LpsnRecordNumber: 784122
+              - Name: Legionella tucsonensis
+                ConceptType: Species
+                ConceptId: species/legionella-tucsonensis
+                ConceptSource: LPSN
+                Id: 136
+                LpsnRecordNumber: 784123
+              - Name: Legionella wadsworthii
+                ConceptType: Species
+                ConceptId: species/legionella-wadsworthii
+                ConceptSource: LPSN
+                Id: 1334
+                LpsnRecordNumber: 784124
+              - Name: Legionella waltersii
+                ConceptType: Species
+                ConceptId: species/legionella-waltersii
+                ConceptSource: LPSN
+                Id: 724
+                LpsnRecordNumber: 784125
+              - Name: Legionella worsleiensis
+                ConceptType: Species
+                ConceptId: species/legionella-worsleiensis
+                ConceptSource: LPSN
+                Id: 1814
+                LpsnRecordNumber: 784126
+              Synonyms:
+              - Name: Fluoribacter
+                ConceptId: genus/fluoribacter
+                ConceptSource: LPSN
+                Id: 622
+                LpsnRecordNumber: 515646
+        - Name: Lysobacterales
+          ConceptType: Order
+          ConceptId: order/lysobacterales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5021
+          Children:
+          - Name: Lysobacteraceae
+            ConceptType: Family
+            ConceptId: family/lysobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 775
+            Children:
+            - Name: Pseudoxanthomonas
+              ConceptType: Genus
+              ConceptId: genus/pseudoxanthomonas
+              ConceptSource: LPSN
+              Id: 1065
+              LpsnRecordNumber: 516427
+              Children:
+              - Name: Pseudoxanthomonas koreensis
+                ConceptType: Species
+                ConceptId: species/pseudoxanthomonas-koreensis
+                ConceptSource: LPSN
+                Id: 2449
+                LpsnRecordNumber: 780203
+            - Name: Stenotrophomonas
+              ConceptType: Genus
+              ConceptId: genus/stenotrophomonas
+              ConceptSource: LPSN
+              Id: 942
+              LpsnRecordNumber: 516670
+              Children:
+              - Name: Stenotrophomonas beteli
+                ConceptType: Species
+                ConceptId: species/stenotrophomonas-beteli
+                ConceptSource: LPSN
+                Id: 3542
+                LpsnRecordNumber: 55590
+                Synonyms:
+                - Name: Pseudomonas beteli
+                  ConceptId: species/pseudomonas-beteli
+                  ConceptSource: LPSN
+                  Id: 2448
+                  LpsnRecordNumber: 784713
+                - Name: Pseudomonas betle
+                  ConceptId: species/pseudomonas-betle
+                  ConceptSource: LPSN
+                  Id: 1002
+                  LpsnRecordNumber: 784714
+              - Name: Stenotrophomonas maltophilia
+                ConceptType: Species
+                ConceptId: species/stenotrophomonas-maltophilia
+                ConceptSource: LPSN
+                Id: 681
+                LpsnRecordNumber: 781249
+                Synonyms:
+                - Name: Pseudomonas maltophilia
+                  ConceptId: species/pseudomonas-maltophilia
+                  ConceptSource: LPSN
+                  Id: 2033
+                  LpsnRecordNumber: 780058
+                - Name: Xanthomonas maltophilia
+                  ConceptId: species/xanthomonas-maltophilia
+                  ConceptSource: LPSN
+                  Id: 2385
+                  LpsnRecordNumber: 783141
+            - Name: Xanthomonas
+              ConceptType: Genus
+              ConceptId: genus/xanthomonas
+              ConceptSource: LPSN
+              Id: 1508
+              LpsnRecordNumber: 516930
+          - Name: Rhodanobacteraceae
+            ConceptType: Family
+            ConceptId: family/rhodanobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 2002
+            Children:
+            - Name: Dyella
+              ConceptType: Genus
+              ConceptId: genus/dyella
+              ConceptSource: LPSN
+              Id: 2538
+              LpsnRecordNumber: 515561
+        - Name: Oceanospirillales
+          ConceptType: Order
+          ConceptId: order/oceanospirillales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5074
+          Children:
+          - Name: Balneatricaceae
+            ConceptType: Family
+            ConceptId: family/balneatricaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 29683
+            Children:
+            - Name: Balneatrix
+              ConceptType: Genus
+              ConceptId: genus/balneatrix
+              ConceptSource: LPSN
+              Id: 1739
+              LpsnRecordNumber: 515222
+              Children:
+              - Name: Balneatrix alpica
+                ConceptType: Species
+                ConceptId: species/balneatrix-alpica
+                ConceptSource: LPSN
+                Id: 1024
+                LpsnRecordNumber: 773982
+          - Name: Halomonadaceae
+            ConceptType: Family
+            ConceptId: family/halomonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 618
+            Children:
+            - Name: Halomonas
+              ConceptType: Genus
+              ConceptId: genus/halomonas
+              ConceptSource: LPSN
+              Id: 432
+              LpsnRecordNumber: 517051
+              Children:
+              - Name: Halomonas venusta
+                ConceptType: Species
+                ConceptId: species/halomonas-venusta
+                ConceptSource: LPSN
+                Id: 405
+                LpsnRecordNumber: 776791
+        - Name: Pasteurellales
+          ConceptType: Order
+          ConceptId: order/pasteurellales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5075
+          Children:
+          - Name: Pasteurellaceae
+            ConceptType: Family
+            ConceptId: family/pasteurellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1033
+            Children:
+            - Name: Actinobacillus
+              ConceptType: Genus
+              ConceptId: genus/actinobacillus
+              ConceptSource: LPSN
+              Id: 2583
+              LpsnRecordNumber: 515029
+              Children:
+              - Name: Actinobacillus equuli
+                ConceptType: Species
+                ConceptId: species/actinobacillus-equuli
+                ConceptSource: LPSN
+                Id: 386
+                LpsnRecordNumber: 783277
+              - Name: Actinobacillus hominis
+                ConceptType: Species
+                ConceptId: species/actinobacillus-hominis
+                ConceptSource: LPSN
+                Id: 1263
+                LpsnRecordNumber: 783280
+              - Name: Actinobacillus lignieresii
+                ConceptType: Species
+                ConceptId: species/actinobacillus-lignieresii
+                ConceptSource: LPSN
+                Id: 957
+                LpsnRecordNumber: 783282
+              - Name: Actinobacillus suis
+                ConceptType: Species
+                ConceptId: species/actinobacillus-suis
+                ConceptSource: LPSN
+                Id: 2196
+                LpsnRecordNumber: 783289
+              - Name: Actinobacillus ureae
+                ConceptType: Species
+                ConceptId: species/actinobacillus-ureae
+                ConceptSource: LPSN
+                Id: 1592
+                LpsnRecordNumber: 772662
+                Synonyms:
+                - Name: Pasteurella ureae
+                  ConceptId: species/pasteurella-ureae
+                  ConceptSource: LPSN
+                  Id: 645
+                  LpsnRecordNumber: 779185
+            - Name: Aggregatibacter
+              ConceptType: Genus
+              ConceptId: genus/aggregatibacter
+              ConceptSource: LPSN
+              Id: 1896
+              LpsnRecordNumber: 517473
+              Children:
+              - Name: Aggregatibacter actinomycetemcomitans
+                ConceptType: Species
+                ConceptId: species/aggregatibacter-actinomycetemcomitans
+                ConceptSource: LPSN
+                Id: 697
+                LpsnRecordNumber: 785424
+                Synonyms:
+                - Name: Actinobacillus actinomycetemcomitans
+                  ConceptId: species/actinobacillus-actinomycetemcomitans
+                  ConceptSource: LPSN
+                  Id: 1049
+                  LpsnRecordNumber: 785423
+                - Name: Haemophilus actinomycetemcomitans
+                  ConceptId: species/haemophilus-actinomycetemcomitans
+                  ConceptSource: LPSN
+                  Id: 173
+                  LpsnRecordNumber: 776642
+              - Name: Aggregatibacter aphrophilus
+                ConceptType: Species
+                ConceptId: species/aggregatibacter-aphrophilus
+                ConceptSource: LPSN
+                Id: 2085
+                LpsnRecordNumber: 785425
+                Synonyms:
+                - Name: Haemophilus aphrophilus
+                  ConceptId: species/haemophilus-aphrophilus
+                  ConceptSource: LPSN
+                  Id: 293
+                  LpsnRecordNumber: 787104
+              - Name: Aggregatibacter segnis
+                ConceptType: Species
+                ConceptId: species/aggregatibacter-segnis
+                ConceptSource: LPSN
+                Id: 89
+                LpsnRecordNumber: 785426
+                Synonyms:
+                - Name: Haemophilus segnis
+                  ConceptId: species/haemophilus-segnis
+                  ConceptSource: LPSN
+                  Id: 191
+                  LpsnRecordNumber: 795963
+            - Name: Haemophilus
+              ConceptType: Genus
+              ConceptId: genus/haemophilus
+              ConceptSource: LPSN
+              Id: 1304
+              LpsnRecordNumber: 515740
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Haemophilus aegyptius
+                ConceptType: Species
+                ConceptId: species/haemophilus-aegyptius
+                ConceptSource: LPSN
+                Id: 2181
+                LpsnRecordNumber: 783934
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus ducreyi
+                ConceptType: Species
+                ConceptId: species/haemophilus-ducreyi
+                ConceptSource: LPSN
+                Id: 2248
+                LpsnRecordNumber: 776643
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus haemoglobinophilus
+                ConceptType: Species
+                ConceptId: species/haemophilus-haemoglobinophilus
+                ConceptSource: LPSN
+                Id: 1799
+                LpsnRecordNumber: 783938
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Canicola haemoglobinophilus
+                  ConceptId: species/canicola-haemoglobinophilus
+                  ConceptSource: LPSN
+                  Id: 3135
+                  LpsnRecordNumber: 19905
+              - Name: Haemophilus haemolyticus
+                ConceptType: Species
+                ConceptId: species/haemophilus-haemolyticus
+                ConceptSource: LPSN
+                Id: 2467
+                LpsnRecordNumber: 783939
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus influenzae
+                ConceptType: Species
+                ConceptId: species/haemophilus-influenzae
+                ConceptSource: LPSN
+                Id: 1704
+                LpsnRecordNumber: 776645
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus massiliensis
+                ConceptType: Species
+                ConceptId: species/haemophilus-massiliensis
+                ConceptSource: LPSN
+                Id: 2849
+                LpsnRecordNumber: 795584
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus parahaemolyticus
+                ConceptType: Species
+                ConceptId: species/haemophilus-parahaemolyticus
+                ConceptSource: LPSN
+                Id: 658
+                LpsnRecordNumber: 776646
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus parainfluenzae
+                ConceptType: Species
+                ConceptId: species/haemophilus-parainfluenzae
+                ConceptSource: LPSN
+                Id: 2340
+                LpsnRecordNumber: 776647
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus paraphrohaemolyticus
+                ConceptType: Species
+                ConceptId: species/haemophilus-paraphrohaemolyticus
+                ConceptSource: LPSN
+                Id: 2850
+                LpsnRecordNumber: 783942
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus pittmaniae
+                ConceptType: Species
+                ConceptId: species/haemophilus-pittmaniae
+                ConceptSource: LPSN
+                Id: 1788
+                LpsnRecordNumber: 776648
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Haemophilus sputorum
+                ConceptType: Species
+                ConceptId: species/haemophilus-sputorum
+                ConceptSource: LPSN
+                Id: 2851
+                LpsnRecordNumber: 789886
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+            - Name: Mannheimia
+              ConceptType: Genus
+              ConceptId: genus/mannheimia
+              ConceptSource: LPSN
+              Id: 2414
+              LpsnRecordNumber: 516001
+              Children:
+              - Name: Mannheimia haemolytica
+                ConceptType: Species
+                ConceptId: species/mannheimia-haemolytica
+                ConceptSource: LPSN
+                Id: 1880
+                LpsnRecordNumber: 777655
+                Synonyms:
+                - Name: Pasteurella haemolytica
+                  ConceptId: species/pasteurella-haemolytica
+                  ConceptSource: LPSN
+                  Id: 1931
+                  LpsnRecordNumber: 779180
+            - Name: Pasteurella
+              ConceptType: Genus
+              ConceptId: genus/pasteurella
+              ConceptSource: LPSN
+              Id: 1861
+              LpsnRecordNumber: 516266
+              Colistin: true
+              Children:
+              - Name: Pasteurella aerogenes
+                ConceptType: Species
+                ConceptId: species/pasteurella-aerogenes
+                ConceptSource: LPSN
+                Id: 1274
+                LpsnRecordNumber: 779178
+                Colistin: true
+              - Name: Pasteurella bettyae
+                ConceptType: Species
+                ConceptId: species/pasteurella-bettyae
+                ConceptSource: LPSN
+                Id: 967
+                LpsnRecordNumber: 784579
+                Colistin: true
+              - Name: Pasteurella caballi
+                ConceptType: Species
+                ConceptId: species/pasteurella-caballi
+                ConceptSource: LPSN
+                Id: 1690
+                LpsnRecordNumber: 784580
+                Colistin: true
+              - Name: Pasteurella canis
+                ConceptType: Species
+                ConceptId: species/pasteurella-canis
+                ConceptSource: LPSN
+                Id: 491
+                LpsnRecordNumber: 779179
+                Colistin: true
+              - Name: Pasteurella dagmatis
+                ConceptType: Species
+                ConceptId: species/pasteurella-dagmatis
+                ConceptSource: LPSN
+                Id: 1146
+                LpsnRecordNumber: 784581
+                Colistin: true
+              - Name: Pasteurella multocida
+                ConceptType: Species
+                ConceptId: species/pasteurella-multocida
+                ConceptSource: LPSN
+                Id: 831
+                LpsnRecordNumber: 779182
+                Colistin: true
+                Children:
+                - Name: Pasteurella multocida subsp. gallicida
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/pasteurella-multocida-gallicida
+                  ConceptSource: LPSN
+                  Id: 1625
+                  LpsnRecordNumber: 784589
+                  Colistin: true
+                - Name: Pasteurella multocida subsp. multocida
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/pasteurella-multocida-multocida
+                  ConceptSource: LPSN
+                  Id: 2483
+                  LpsnRecordNumber: 779183
+                  Colistin: true
+                - Name: Pasteurella multocida subsp. septica
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/pasteurella-multocida-septica
+                  ConceptSource: LPSN
+                  Id: 2066
+                  LpsnRecordNumber: 784590
+                  Colistin: true
+              - Name: Pasteurella stomatis
+                ConceptType: Species
+                ConceptId: species/pasteurella-stomatis
+                ConceptSource: LPSN
+                Id: 852
+                LpsnRecordNumber: 784594
+                Colistin: true
+            - Name: Rodentibacter
+              ConceptType: Genus
+              ConceptId: genus/rodentibacter
+              ConceptSource: LPSN
+              LpsnRecordNumber: 519198
+              Children:
+              - Name: Rodentibacter pneumotropicus
+                ConceptType: Species
+                ConceptId: species/rodentibacter-pneumotropicus
+                ConceptSource: LPSN
+                Id: 3107
+                LpsnRecordNumber: 795439
+                Colistin: true
+                Synonyms:
+                - Name: Pasteurella pneumotropica
+                  ConceptId: species/pasteurella-pneumotropica
+                  ConceptSource: LPSN
+                  Id: 2079
+                  LpsnRecordNumber: 784592
+        - Name: Pseudomonadales
+          ConceptType: Order
+          ConceptId: order/pseudomonadales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5024
+          Children:
+          - Name: Moraxellaceae
+            ConceptType: Family
+            ConceptId: family/moraxellaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 902
+            Children:
+            - Name: Acinetobacter
+              ConceptType: Genus
+              ConceptId: genus/acinetobacter
+              ConceptSource: LPSN
+              Id: 2409
+              LpsnRecordNumber: 515021
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Acinetobacter calcoaceticus-Acinetobacter baumannii complex
+                ConceptType: Group
+                ConceptId: 31
+                ConceptSource: NeoIPC
+                Id: 2704
+                Carbapenems: true
+                Colistin: true
+                Children:
+                - Name: Acinetobacter baumannii
+                  ConceptType: Species
+                  ConceptId: species/acinetobacter-baumannii
+                  ConceptSource: LPSN
+                  Id: 1660
+                  LpsnRecordNumber: 772610
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Acinetobacter calcoaceticus
+                  ConceptType: Species
+                  ConceptId: species/acinetobacter-calcoaceticus
+                  ConceptSource: LPSN
+                  Id: 1141
+                  LpsnRecordNumber: 772613
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Acinetobacter nosocomialis
+                  ConceptType: Species
+                  ConceptId: species/acinetobacter-nosocomialis
+                  ConceptSource: LPSN
+                  Id: 1448
+                  LpsnRecordNumber: 789231
+                  Carbapenems: true
+                  Colistin: true
+                - Name: Acinetobacter pittii
+                  ConceptType: Species
+                  ConceptId: species/acinetobacter-pittii
+                  ConceptSource: LPSN
+                  Id: 2114
+                  LpsnRecordNumber: 789232
+                  Carbapenems: true
+                  Colistin: true
+              - Name: Acinetobacter baylyi
+                ConceptType: Species
+                ConceptId: species/acinetobacter-baylyi
+                ConceptSource: LPSN
+                Id: 2808
+                LpsnRecordNumber: 772611
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter beijerinckii
+                ConceptType: Species
+                ConceptId: species/acinetobacter-beijerinckii
+                ConceptSource: LPSN
+                Id: 2809
+                LpsnRecordNumber: 787668
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter bereziniae
+                ConceptType: Species
+                ConceptId: species/acinetobacter-bereziniae
+                ConceptSource: LPSN
+                Id: 2810
+                LpsnRecordNumber: 788443
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter guillouiae
+                ConceptType: Species
+                ConceptId: species/acinetobacter-guillouiae
+                ConceptSource: LPSN
+                Id: 2811
+                LpsnRecordNumber: 788442
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter gyllenbergii
+                ConceptType: Species
+                ConceptId: species/acinetobacter-gyllenbergii
+                ConceptSource: LPSN
+                Id: 2812
+                LpsnRecordNumber: 787669
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter haemolyticus
+                ConceptType: Species
+                ConceptId: species/acinetobacter-haemolyticus
+                ConceptSource: LPSN
+                Id: 1727
+                LpsnRecordNumber: 772618
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter johnsonii
+                ConceptType: Species
+                ConceptId: species/acinetobacter-johnsonii
+                ConceptSource: LPSN
+                Id: 2494
+                LpsnRecordNumber: 772619
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter junii
+                ConceptType: Species
+                ConceptId: species/acinetobacter-junii
+                ConceptSource: LPSN
+                Id: 2318
+                LpsnRecordNumber: 772620
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter lwoffii
+                ConceptType: Species
+                ConceptId: species/acinetobacter-lwoffii
+                ConceptSource: LPSN
+                Id: 2705
+                LpsnRecordNumber: 772622
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter parvus
+                ConceptType: Species
+                ConceptId: species/acinetobacter-parvus
+                ConceptSource: LPSN
+                Id: 2813
+                LpsnRecordNumber: 772624
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter radioresistens
+                ConceptType: Species
+                ConceptId: species/acinetobacter-radioresistens
+                ConceptSource: LPSN
+                Id: 1698
+                LpsnRecordNumber: 772626
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter schindleri
+                ConceptType: Species
+                ConceptId: species/acinetobacter-schindleri
+                ConceptSource: LPSN
+                Id: 1877
+                LpsnRecordNumber: 772627
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter seifertii
+                ConceptType: Species
+                ConceptId: species/acinetobacter-seifertii
+                ConceptSource: LPSN
+                Id: 2814
+                LpsnRecordNumber: 792594
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter septicus
+                ConceptType: Species
+                ConceptId: species/acinetobacter-septicus
+                ConceptSource: LPSN
+                Id: 2815
+                LpsnRecordNumber: 786412
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter ursingii
+                ConceptType: Species
+                ConceptId: species/acinetobacter-ursingii
+                ConceptSource: LPSN
+                Id: 2107
+                LpsnRecordNumber: 772633
+                Carbapenems: true
+                Colistin: true
+              - Name: Acinetobacter variabilis
+                ConceptType: Species
+                ConceptId: species/acinetobacter-variabilis
+                ConceptSource: LPSN
+                Id: 2816
+                LpsnRecordNumber: 792593
+                Carbapenems: true
+                Colistin: true
+            - Name: Moraxella
+              ConceptType: Genus
+              ConceptId: genus/moraxella
+              ConceptSource: LPSN
+              Id: 1277
+              LpsnRecordNumber: 516121
+              Children:
+              - Name: Moraxella atlantae
+                ConceptType: Species
+                ConceptId: species/moraxella-atlantae
+                ConceptSource: LPSN
+                Id: 1291
+                LpsnRecordNumber: 784278
+              - Name: Moraxella boevrei
+                ConceptType: Species
+                ConceptId: species/moraxella-boevrei
+                ConceptSource: LPSN
+                Id: 263
+                LpsnRecordNumber: 778308
+              - Name: Moraxella bovis
+                ConceptType: Species
+                ConceptId: species/moraxella-bovis
+                ConceptSource: LPSN
+                Id: 1886
+                LpsnRecordNumber: 784279
+              - Name: Moraxella canis
+                ConceptType: Species
+                ConceptId: species/moraxella-canis
+                ConceptSource: LPSN
+                Id: 555
+                LpsnRecordNumber: 778309
+              - Name: Moraxella caprae
+                ConceptType: Species
+                ConceptId: species/moraxella-caprae
+                ConceptSource: LPSN
+                Id: 1759
+                LpsnRecordNumber: 784280
+              - Name: Moraxella catarrhalis
+                ConceptType: Species
+                ConceptId: species/moraxella-catarrhalis
+                ConceptSource: LPSN
+                Id: 770
+                LpsnRecordNumber: 784281
+                Synonyms:
+                - Name: Branhamella catarrhalis
+                  ConceptId: species/branhamella-catarrhalis
+                  ConceptSource: LPSN
+                  Id: 2441
+                  LpsnRecordNumber: 774167
+              - Name: Moraxella cuniculi
+                ConceptType: Species
+                ConceptId: species/moraxella-cuniculi
+                ConceptSource: LPSN
+                Id: 400
+                LpsnRecordNumber: 784283
+                Synonyms:
+                - Name: Neisseria cuniculi
+                  ConceptId: species/neisseria-cuniculi
+                  ConceptSource: LPSN
+                  Id: 1531
+                  LpsnRecordNumber: 784461
+              - Name: Moraxella lacunata
+                ConceptType: Species
+                ConceptId: species/moraxella-lacunata
+                ConceptSource: LPSN
+                Id: 1131
+                LpsnRecordNumber: 778312
+              - Name: Moraxella lincolnii
+                ConceptType: Species
+                ConceptId: species/moraxella-lincolnii
+                ConceptSource: LPSN
+                Id: 422
+                LpsnRecordNumber: 784284
+              - Name: Moraxella nonliquefaciens
+                ConceptType: Species
+                ConceptId: species/moraxella-nonliquefaciens
+                ConceptSource: LPSN
+                Id: 1633
+                LpsnRecordNumber: 784285
+              - Name: Moraxella oblonga
+                ConceptType: Species
+                ConceptId: species/moraxella-oblonga
+                ConceptSource: LPSN
+                Id: 1499
+                LpsnRecordNumber: 778314
+              - Name: Moraxella osloensis
+                ConceptType: Species
+                ConceptId: species/moraxella-osloensis
+                ConceptSource: LPSN
+                Id: 1036
+                LpsnRecordNumber: 784286
+              - Name: Moraxella ovis
+                ConceptType: Species
+                ConceptId: species/moraxella-ovis
+                ConceptSource: LPSN
+                Id: 2569
+                LpsnRecordNumber: 784287
+                Synonyms:
+                - Name: Neisseria ovis
+                  ConceptId: species/neisseria-ovis
+                  ConceptSource: LPSN
+                  Id: 2285
+                  LpsnRecordNumber: 784469
+            - Name: Psychrobacter
+              ConceptType: Genus
+              ConceptId: genus/psychrobacter
+              ConceptSource: LPSN
+              Id: 1972
+              LpsnRecordNumber: 516431
+              Children:
+              - Name: Psychrobacter immobilis
+                ConceptType: Species
+                ConceptId: species/psychrobacter-immobilis
+                ConceptSource: LPSN
+                Id: 2505
+                LpsnRecordNumber: 780235
+              - Name: Psychrobacter phenylpyruvicus
+                ConceptType: Species
+                ConceptId: species/psychrobacter-phenylpyruvicus
+                ConceptSource: LPSN
+                Id: 1525
+                LpsnRecordNumber: 780241
+                Synonyms:
+                - Name: Moraxella phenylpyruvica
+                  ConceptId: species/moraxella-phenylpyruvica
+                  ConceptSource: LPSN
+                  Id: 837
+                  LpsnRecordNumber: 784288
+          - Name: Pseudomonadaceae
+            ConceptType: Family
+            ConceptId: family/pseudomonadaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1134
+            Children:
+            - Name: Halopseudomonas
+              ConceptType: Genus
+              ConceptId: genus/halopseudomonas
+              ConceptSource: LPSN
+              LpsnRecordNumber: 21216
+              Children:
+              - Name: Halopseudomonas pertucinogena
+                ConceptType: Species
+                ConceptId: species/halopseudomonas-pertucinogena
+                ConceptSource: LPSN
+                Id: 3175
+                LpsnRecordNumber: 21262
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Pseudomonas pertucinogena
+                  ConceptId: species/pseudomonas-pertucinogena
+                  ConceptSource: LPSN
+                  Id: 1691
+                  LpsnRecordNumber: 780095
+            - Name: Pseudomonas
+              ConceptType: Genus
+              ConceptId: genus/pseudomonas
+              ConceptSource: LPSN
+              Id: 1975
+              LpsnRecordNumber: 517405
+              3GCR: true
+              Carbapenems: true
+              Colistin: true
+              Children:
+              - Name: Pseudomonas aeruginosa
+                ConceptType: Species
+                ConceptId: species/pseudomonas-aeruginosa
+                ConceptSource: LPSN
+                Id: 1958
+                LpsnRecordNumber: 779948
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas alcaligenes
+                ConceptType: Species
+                ConceptId: species/pseudomonas-alcaligenes
+                ConceptSource: LPSN
+                Id: 2083
+                LpsnRecordNumber: 779950
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas andersonii
+                ConceptType: Species
+                ConceptId: species/pseudomonas-andersonii
+                ConceptSource: LPSN
+                Id: 2831
+                LpsnRecordNumber: 2884
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas asiatica
+                ConceptType: Species
+                ConceptId: species/pseudomonas-asiatica
+                ConceptSource: LPSN
+                Id: 2832
+                LpsnRecordNumber: 800789
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas chlororaphis
+                ConceptType: Species
+                ConceptId: species/pseudomonas-chlororaphis
+                ConceptSource: LPSN
+                Id: 974
+                LpsnRecordNumber: 779991
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas fluorescens
+                ConceptType: Species
+                ConceptId: species/pseudomonas-fluorescens
+                ConceptSource: LPSN
+                Id: 609
+                LpsnRecordNumber: 780019
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas fulva
+                ConceptType: Species
+                ConceptId: species/pseudomonas-fulva
+                ConceptSource: LPSN
+                Id: 2833
+                LpsnRecordNumber: 780023
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas japonica
+                ConceptType: Species
+                ConceptId: species/pseudomonas-japonica
+                ConceptSource: LPSN
+                Id: 2834
+                LpsnRecordNumber: 787426
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas juntendi
+                ConceptType: Species
+                ConceptId: species/pseudomonas-juntendi
+                ConceptSource: LPSN
+                Id: 2835
+                LpsnRecordNumber: 5590
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas luteola
+                ConceptType: Species
+                ConceptId: species/pseudomonas-luteola
+                ConceptSource: LPSN
+                Id: 2406
+                LpsnRecordNumber: 780056
+                Synonyms:
+                - Name: Chryseomonas luteola
+                  ConceptId: species/chryseomonas-luteola
+                  ConceptSource: LPSN
+                  Id: 1254
+                  LpsnRecordNumber: 774726
+                - Name: Chryseomonas polytricha
+                  ConceptId: species/chryseomonas-polytricha
+                  ConceptSource: LPSN
+                  Id: 1736
+                  LpsnRecordNumber: 774727
+              - Name: Pseudomonas marginalis
+                ConceptType: Species
+                ConceptId: species/pseudomonas-marginalis
+                ConceptSource: LPSN
+                Id: 309
+                LpsnRecordNumber: 780060
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas mendocina
+                ConceptType: Species
+                ConceptId: species/pseudomonas-mendocina
+                ConceptSource: LPSN
+                Id: 2063
+                LpsnRecordNumber: 780065
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas monteilii
+                ConceptType: Species
+                ConceptId: species/pseudomonas-monteilii
+                ConceptSource: LPSN
+                Id: 1445
+                LpsnRecordNumber: 780072
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas mosselii
+                ConceptType: Species
+                ConceptId: species/pseudomonas-mosselii
+                ConceptSource: LPSN
+                Id: 675
+                LpsnRecordNumber: 780074
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas oleovorans
+                ConceptType: Species
+                ConceptId: species/pseudomonas-oleovorans
+                ConceptSource: LPSN
+                Id: 2988
+                LpsnRecordNumber: 780080
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Pseudomonas pseudoalcaligenes
+                  ConceptId: species/pseudomonas-pseudoalcaligenes
+                  ConceptSource: LPSN
+                  Id: 2065
+                  LpsnRecordNumber: 780107
+              - Name: Pseudomonas oryzihabitans
+                ConceptType: Species
+                ConceptId: species/pseudomonas-oryzihabitans
+                ConceptSource: LPSN
+                Id: 1204
+                LpsnRecordNumber: 780082
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Flavimonas oryzihabitans
+                  ConceptId: species/flavimonas-oryzihabitans
+                  ConceptSource: LPSN
+                  Id: 2380
+                  LpsnRecordNumber: 776218
+              - Name: Pseudomonas otitidis
+                ConceptType: Species
+                ConceptId: species/pseudomonas-otitidis
+                ConceptSource: LPSN
+                Id: 2838
+                LpsnRecordNumber: 780083
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas poae
+                ConceptType: Species
+                ConceptId: species/pseudomonas-poae
+                ConceptSource: LPSN
+                Id: 2839
+                LpsnRecordNumber: 780102
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas putida
+                ConceptType: Species
+                ConceptId: species/pseudomonas-putida
+                ConceptSource: LPSN
+                Id: 1775
+                LpsnRecordNumber: 780113
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Arthrobacter siderocapsulatus
+                  ConceptId: species/arthrobacter-siderocapsulatus
+                  ConceptSource: LPSN
+                  Id: 183
+                  LpsnRecordNumber: 773442
+              - Name: Pseudomonas veronii
+                ConceptType: Species
+                ConceptId: species/pseudomonas-veronii
+                ConceptSource: LPSN
+                Id: 2225
+                LpsnRecordNumber: 780155
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              - Name: Pseudomonas yangonensis
+                ConceptType: Species
+                ConceptId: species/pseudomonas-yangonensis
+                ConceptSource: LPSN
+                Id: 2840
+                LpsnRecordNumber: 7920
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+              Synonyms:
+              - Name: Chryseomonas
+                ConceptId: genus/chryseomonas
+                ConceptSource: LPSN
+                Id: 417
+                LpsnRecordNumber: 515367
+            - Name: Stutzerimonas
+              ConceptType: Genus
+              ConceptId: genus/stutzerimonas
+              ConceptSource: LPSN
+              LpsnRecordNumber: 25637
+              Children:
+              - Name: Stutzerimonas nosocomialis
+                ConceptType: Species
+                ConceptId: species/stutzerimonas-nosocomialis
+                ConceptSource: LPSN
+                Id: 2836
+                LpsnRecordNumber: 34539
+                3GCR: true
+                Carbapenems: true
+                Colistin: true
+                Synonyms:
+                - Name: Pseudomonas nosocomialis
+                  ConceptId: species/pseudomonas-nosocomialis
+                  ConceptSource: LPSN
+                  Id: 2837
+                  LpsnRecordNumber: 5582
+              - Name: Stutzerimonas stutzeri
+                ConceptType: Species
+                ConceptId: species/stutzerimonas-stutzeri
+                ConceptSource: LPSN
+                Id: 3543
+                LpsnRecordNumber: 21513
+                Synonyms:
+                - Name: Pseudomonas chloritidismutans
+                  ConceptId: species/pseudomonas-chloritidismutans
+                  ConceptSource: LPSN
+                  Id: 2394
+                  LpsnRecordNumber: 779990
+                - Name: Pseudomonas perfectomarina
+                  ConceptId: species/pseudomonas-perfectomarina
+                  ConceptSource: LPSN
+                  Id: 1088
+                  LpsnRecordNumber: 784730
+                - Name: Pseudomonas stutzeri
+                  ConceptId: species/pseudomonas-stutzeri
+                  ConceptSource: LPSN
+                  Id: 1561
+                  LpsnRecordNumber: 780134
+        - Name: Vibrionales
+          ConceptType: Order
+          ConceptId: order/vibrionales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 768
+          Children:
+          - Name: Vibrionaceae
+            ConceptType: Family
+            ConceptId: family/vibrionaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1543
+            Children:
+            - Name: Grimontia
+              ConceptType: Genus
+              ConceptId: genus/grimontia
+              ConceptSource: LPSN
+              Id: 2452
+              LpsnRecordNumber: 515729
+              Children:
+              - Name: Grimontia hollisae
+                ConceptType: Species
+                ConceptId: species/grimontia-hollisae
+                ConceptSource: LPSN
+                Id: 1270
+                LpsnRecordNumber: 776622
+            - Name: Listonella
+              ConceptType: Genus
+              ConceptId: genus/listonella
+              ConceptSource: LPSN
+              Id: 1675
+              LpsnRecordNumber: 515973
+            - Name: Photobacterium
+              ConceptType: Genus
+              ConceptId: genus/photobacterium
+              ConceptSource: LPSN
+              Id: 45
+              LpsnRecordNumber: 516323
+              Children:
+              - Name: Photobacterium damselae
+                ConceptType: Species
+                ConceptId: species/photobacterium-damselae
+                ConceptSource: LPSN
+                LpsnRecordNumber: 779528
+                Children:
+                - Name: Photobacterium damselae subsp. damselae
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/photobacterium-damselae-damselae
+                  ConceptSource: LPSN
+                  Id: 1380
+                  LpsnRecordNumber: 779529
+                Id: 3557
+                Synonyms:
+                - Name: Vibrio damsela
+                  ConceptId: species/vibrio-damsela
+                  ConceptSource: LPSN
+                  Id: 1954
+                  LpsnRecordNumber: 783000
+                - Name: Vibrio damselae
+                  ConceptId: species/vibrio-damselae
+                  ConceptSource: LPSN
+                  Id: 3221
+                  LpsnRecordNumber: 368
+            - Name: Vibrio
+              ConceptType: Genus
+              ConceptId: genus/vibrio
+              ConceptSource: LPSN
+              Id: 1919
+              LpsnRecordNumber: 517157
+              Colistin: true
+              Children:
+              - Name: Vibrio alginolyticus
+                ConceptType: Species
+                ConceptId: species/vibrio-alginolyticus
+                ConceptSource: LPSN
+                Id: 2443
+                LpsnRecordNumber: 782990
+                Colistin: true
+                Synonyms:
+                - Name: Beneckea alginolytica
+                  ConceptId: species/beneckea-alginolytica
+                  ConceptSource: LPSN
+                  Id: 166
+                  LpsnRecordNumber: 774010
+              - Name: Vibrio cholerae
+                ConceptType: Species
+                ConceptId: species/vibrio-cholerae
+                ConceptSource: LPSN
+                Id: 92
+                LpsnRecordNumber: 782995
+                Colistin: true
+              - Name: Vibrio cincinnatiensis
+                ConceptType: Species
+                ConceptId: species/vibrio-cincinnatiensis
+                ConceptSource: LPSN
+                Id: 1352
+                LpsnRecordNumber: 785146
+                Colistin: true
+              - Name: Vibrio fluvialis
+                ConceptType: Species
+                ConceptId: species/vibrio-fluvialis
+                ConceptSource: LPSN
+                Id: 175
+                LpsnRecordNumber: 785151
+                Colistin: true
+              - Name: Vibrio furnissii
+                ConceptType: Species
+                ConceptId: species/vibrio-furnissii
+                ConceptSource: LPSN
+                Id: 1016
+                LpsnRecordNumber: 783005
+                Colistin: true
+              - Name: Vibrio harveyi
+                ConceptType: Species
+                ConceptId: species/vibrio-harveyi
+                ConceptSource: LPSN
+                Id: 2261
+                LpsnRecordNumber: 783009
+                Colistin: true
+                Synonyms:
+                - Name: Beneckea harveyi
+                  ConceptId: species/beneckea-harveyi
+                  ConceptSource: LPSN
+                  Id: 1007
+                  LpsnRecordNumber: 774011
+                - Name: Lucibacterium harveyi
+                  ConceptId: species/lucibacterium-harveyi
+                  ConceptSource: LPSN
+                  Id: 1385
+                  LpsnRecordNumber: 777606
+                - Name: Vibrio carchariae
+                  ConceptId: species/vibrio-carchariae
+                  ConceptSource: LPSN
+                  Id: 5
+                  LpsnRecordNumber: 785145
+                - Name: Vibrio trachuri
+                  ConceptId: species/vibrio-trachuri
+                  ConceptSource: LPSN
+                  Id: 1246
+                  LpsnRecordNumber: 785176
+              - Name: Vibrio metschnikovii
+                ConceptType: Species
+                ConceptId: species/vibrio-metschnikovii
+                ConceptSource: LPSN
+                Id: 1267
+                LpsnRecordNumber: 785158
+                Colistin: true
+              - Name: Vibrio mimicus
+                ConceptType: Species
+                ConceptId: species/vibrio-mimicus
+                ConceptSource: LPSN
+                Id: 2144
+                LpsnRecordNumber: 785159
+                Colistin: true
+              - Name: Vibrio parahaemolyticus
+                ConceptType: Species
+                ConceptId: species/vibrio-parahaemolyticus
+                ConceptSource: LPSN
+                Id: 1526
+                LpsnRecordNumber: 783021
+                Colistin: true
+                Synonyms:
+                - Name: Beneckea parahaemolytica
+                  ConceptId: species/beneckea-parahaemolytica
+                  ConceptSource: LPSN
+                  Id: 541
+                  LpsnRecordNumber: 783504
+              - Name: Vibrio vulnificus
+                ConceptType: Species
+                ConceptId: species/vibrio-vulnificus
+                ConceptSource: LPSN
+                Id: 2095
+                LpsnRecordNumber: 783036
+                Colistin: true
+                Synonyms:
+                - Name: Beneckea vulnifica
+                  ConceptId: species/beneckea-vulnifica
+                  ConceptSource: LPSN
+                  Id: 879
+                  LpsnRecordNumber: 774014
+      - Name: Deltaproteobacteria
+        ConceptType: Class
+        ConceptId: class/deltaproteobacteria
+        ConceptSource: LPSN
+        LpsnRecordNumber: 32
+        Children:
+        - Name: Desulfovibrionales
+          ConceptType: Order
+          ConceptId: order/desulfovibrionales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5086
+          Children:
+          - Name: Desulfovibrionaceae
+            ConceptType: Family
+            ConceptId: family/desulfovibrionaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 436
+            Children:
+            - Name: Bilophila
+              ConceptType: Genus
+              ConceptId: genus/bilophila
+              ConceptSource: LPSN
+              Id: 20
+              LpsnRecordNumber: 515237
+              Children:
+              - Name: Bilophila wadsworthia
+                ConceptType: Species
+                ConceptId: species/bilophila-wadsworthia
+                ConceptSource: LPSN
+                Id: 2397
+                LpsnRecordNumber: 774065
+            - Name: Desulfovibrio
+              ConceptType: Genus
+              ConceptId: genus/desulfovibrio
+              ConceptSource: LPSN
+              Id: 2147
+              LpsnRecordNumber: 517028
+              Children:
+              - Name: Desulfovibrio desulfuricans
+                ConceptType: Species
+                ConceptId: species/desulfovibrio-desulfuricans
+                ConceptSource: LPSN
+                Id: 1937
+                LpsnRecordNumber: 775672
+              - Name: Desulfovibrio piger
+                ConceptType: Species
+                ConceptId: species/desulfovibrio-piger
+                ConceptSource: LPSN
+                Id: 1716
+                LpsnRecordNumber: 775701
+              Synonyms:
+              - Name: Desulfomonas
+                ConceptId: genus/desulfomonas
+                ConceptSource: LPSN
+                Id: 933
+                LpsnRecordNumber: 517017
+            - Name: Nitratidesulfovibrio
+              ConceptType: Genus
+              ConceptId: genus/nitratidesulfovibrio
+              ConceptSource: LPSN
+              LpsnRecordNumber: 17403
+              Children:
+              - Name: Nitratidesulfovibrio vulgaris
+                ConceptType: Species
+                ConceptId: species/nitratidesulfovibrio-vulgaris
+                ConceptSource: LPSN
+                Id: 3493
+                LpsnRecordNumber: 17483
+                Synonyms:
+                - Name: Desulfovibrio vulgaris
+                  ConceptId: species/desulfovibrio-vulgaris
+                  ConceptSource: LPSN
+                  Id: 570
+                  LpsnRecordNumber: 783742
+      - Name: Epsilonproteobacteria
+        ConceptType: Class
+        ConceptId: class/epsilonproteobacteria
+        ConceptSource: LPSN
+        LpsnRecordNumber: 35
+        Children:
+        - Name: Campylobacterales
+          ConceptType: Order
+          ConceptId: order/campylobacterales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5080
+          Children:
+          - Name: Arcobacteraceae
+            ConceptType: Family
+            ConceptId: family/arcobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 7776
+            Children:
+            - Name: Arcobacter
+              ConceptType: Genus
+              ConceptId: genus/arcobacter
+              ConceptSource: LPSN
+              Id: 81
+              LpsnRecordNumber: 515168
+              Children:
+              - Name: Arcobacter butzleri
+                ConceptType: Species
+                ConceptId: species/arcobacter-butzleri
+                ConceptSource: LPSN
+                Id: 2349
+                LpsnRecordNumber: 773365
+                Synonyms:
+                - Name: Campylobacter butzleri
+                  ConceptId: species/campylobacter-butzleri
+                  ConceptSource: LPSN
+                  Id: 1349
+                  LpsnRecordNumber: 774371
+              - Name: Arcobacter nitrofigilis
+                ConceptType: Species
+                ConceptId: species/arcobacter-nitrofigilis
+                ConceptSource: LPSN
+                Id: 875
+                LpsnRecordNumber: 773369
+                Synonyms:
+                - Name: Campylobacter nitrofigilis
+                  ConceptId: species/campylobacter-nitrofigilis
+                  ConceptSource: LPSN
+                  Id: 676
+                  LpsnRecordNumber: 774384
+          - Name: Campylobacteraceae
+            ConceptType: Family
+            ConceptId: family/campylobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 270
+            Children:
+            - Name: Campylobacter
+              ConceptType: Genus
+              ConceptId: genus/campylobacter
+              ConceptSource: LPSN
+              Id: 1229
+              LpsnRecordNumber: 515304
+              Children:
+              - Name: Campylobacter coli
+                ConceptType: Species
+                ConceptId: species/campylobacter-coli
+                ConceptSource: LPSN
+                Id: 2220
+                LpsnRecordNumber: 774373
+              - Name: Campylobacter concisus
+                ConceptType: Species
+                ConceptId: species/campylobacter-concisus
+                ConceptSource: LPSN
+                Id: 1521
+                LpsnRecordNumber: 774374
+              - Name: Campylobacter curvus
+                ConceptType: Species
+                ConceptId: species/campylobacter-curvus
+                ConceptSource: LPSN
+                Id: 1458
+                LpsnRecordNumber: 774376
+                Synonyms:
+                - Name: Wolinella curva
+                  ConceptId: species/wolinella-curva
+                  ConceptSource: LPSN
+                  Id: 2087
+                  LpsnRecordNumber: 783115
+              - Name: Campylobacter fetus
+                ConceptType: Species
+                ConceptId: species/campylobacter-fetus
+                ConceptSource: LPSN
+                Id: 2381
+                LpsnRecordNumber: 783585
+                Children:
+                - Name: Campylobacter fetus subsp. fetus
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/campylobacter-fetus-fetus
+                  ConceptSource: LPSN
+                  Id: 1993
+                  LpsnRecordNumber: 774379
+                - Name: Campylobacter fetus subsp. venerealis
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/campylobacter-fetus-venerealis
+                  ConceptSource: LPSN
+                  Id: 1023
+                  LpsnRecordNumber: 783586
+              - Name: Campylobacter gracilis
+                ConceptType: Species
+                ConceptId: species/campylobacter-gracilis
+                ConceptSource: LPSN
+                Id: 1074
+                LpsnRecordNumber: 783587
+                Synonyms:
+                - Name: Bacteroides gracilis
+                  ConceptId: species/bacteroides-gracilis
+                  ConceptSource: LPSN
+                  Id: 2007
+                  LpsnRecordNumber: 783447
+              - Name: Campylobacter helveticus
+                ConceptType: Species
+                ConceptId: species/campylobacter-helveticus
+                ConceptSource: LPSN
+                Id: 651
+                LpsnRecordNumber: 783588
+              - Name: Campylobacter hominis
+                ConceptType: Species
+                ConceptId: species/campylobacter-hominis
+                ConceptSource: LPSN
+                Id: 2201
+                LpsnRecordNumber: 783589
+              - Name: Campylobacter hyointestinalis
+                ConceptType: Species
+                ConceptId: species/campylobacter-hyointestinalis
+                ConceptSource: LPSN
+                Id: 262
+                LpsnRecordNumber: 783590
+              - Name: Campylobacter insulaenigrae
+                ConceptType: Species
+                ConceptId: species/campylobacter-insulaenigrae
+                ConceptSource: LPSN
+                Id: 1874
+                LpsnRecordNumber: 774381
+              - Name: Campylobacter jejuni
+                ConceptType: Species
+                ConceptId: species/campylobacter-jejuni
+                ConceptSource: LPSN
+                Id: 47
+                LpsnRecordNumber: 783593
+                Children:
+                - Name: Campylobacter jejuni subsp. doylei
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/campylobacter-jejuni-doylei
+                  ConceptSource: LPSN
+                  Id: 492
+                  LpsnRecordNumber: 783594
+                - Name: Campylobacter jejuni subsp. jejuni
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/campylobacter-jejuni-jejuni
+                  ConceptSource: LPSN
+                  Id: 1461
+                  LpsnRecordNumber: 774382
+              - Name: Campylobacter lanienae
+                ConceptType: Species
+                ConceptId: species/campylobacter-lanienae
+                ConceptSource: LPSN
+                Id: 1746
+                LpsnRecordNumber: 783595
+              - Name: Campylobacter lari
+                ConceptType: Species
+                ConceptId: species/campylobacter-lari
+                ConceptSource: LPSN
+                Id: 707
+                LpsnRecordNumber: 774383
+                Synonyms:
+                - Name: Campylobacter laridis
+                  ConceptId: species/campylobacter-laridis
+                  ConceptSource: LPSN
+                  Id: 402
+                  LpsnRecordNumber: 783596
+              - Name: Campylobacter mucosalis
+                ConceptType: Species
+                ConceptId: species/campylobacter-mucosalis
+                ConceptSource: LPSN
+                Id: 441
+                LpsnRecordNumber: 783597
+                Synonyms:
+                - Name: Campylobacter sputorum subsp. mucosalis
+                  ConceptId: subspecies/campylobacter-sputorum-mucosalis
+                  ConceptSource: LPSN
+                  Id: 380
+                  LpsnRecordNumber: 783602
+              - Name: Campylobacter rectus
+                ConceptType: Species
+                ConceptId: species/campylobacter-rectus
+                ConceptSource: LPSN
+                Id: 95
+                LpsnRecordNumber: 774386
+                Synonyms:
+                - Name: Wolinella recta
+                  ConceptId: species/wolinella-recta
+                  ConceptSource: LPSN
+                  Id: 276
+                  LpsnRecordNumber: 783116
+              - Name: Campylobacter showae
+                ConceptType: Species
+                ConceptId: species/campylobacter-showae
+                ConceptSource: LPSN
+                Id: 2495
+                LpsnRecordNumber: 783601
+              - Name: Campylobacter sputorum
+                ConceptType: Species
+                ConceptId: species/campylobacter-sputorum
+                ConceptSource: LPSN
+                Id: 2335
+                LpsnRecordNumber: 774388
+                Children:
+                - Name: Campylobacter sputorum subsp. bubulus
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/campylobacter-sputorum-bubulus
+                  ConceptSource: LPSN
+                  Id: 22
+                  LpsnRecordNumber: 774389
+                - Name: Campylobacter sputorum subsp. sputorum
+                  ConceptType: Subspecies
+                  ConceptId: subspecies/campylobacter-sputorum-sputorum
+                  ConceptSource: LPSN
+                  Id: 540
+                  LpsnRecordNumber: 774390
+              - Name: Campylobacter upsaliensis
+                ConceptType: Species
+                ConceptId: species/campylobacter-upsaliensis
+                ConceptSource: LPSN
+                Id: 1405
+                LpsnRecordNumber: 774391
+              - Name: Campylobacter ureolyticus
+                ConceptType: Species
+                ConceptId: species/campylobacter-ureolyticus
+                ConceptSource: LPSN
+                Id: 471
+                LpsnRecordNumber: 788744
+                Synonyms:
+                - Name: Bacteroides ureolyticus
+                  ConceptId: species/bacteroides-ureolyticus
+                  ConceptSource: LPSN
+                  Id: 2160
+                  LpsnRecordNumber: 773978
+          - Name: Helicobacteraceae
+            ConceptType: Family
+            ConceptId: family/helicobacteraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 632
+            Children:
+            - Name: Helicobacter
+              ConceptType: Genus
+              ConceptId: genus/helicobacter
+              ConceptSource: LPSN
+              Id: 2026
+              LpsnRecordNumber: 515784
+              Children:
+              - Name: Helicobacter acinonychis
+                ConceptType: Species
+                ConceptId: species/helicobacter-acinonychis
+                ConceptSource: LPSN
+                Id: 10
+                LpsnRecordNumber: 783987
+                Synonyms:
+                - Name: Helicobacter acinonyx
+                  ConceptId: species/helicobacter-acinonyx
+                  ConceptSource: LPSN
+                  Id: 1875
+                  LpsnRecordNumber: 798500
+              - Name: Helicobacter aurati
+                ConceptType: Species
+                ConceptId: species/helicobacter-aurati
+                ConceptSource: LPSN
+                Id: 477
+                LpsnRecordNumber: 783988
+              - Name: Helicobacter bilis
+                ConceptType: Species
+                ConceptId: species/helicobacter-bilis
+                ConceptSource: LPSN
+                Id: 353
+                LpsnRecordNumber: 783989
+              - Name: Helicobacter bizzozeronii
+                ConceptType: Species
+                ConceptId: species/helicobacter-bizzozeronii
+                ConceptSource: LPSN
+                Id: 2946
+                LpsnRecordNumber: 783990
+              - Name: Helicobacter canadensis
+                ConceptType: Species
+                ConceptId: species/helicobacter-canadensis
+                ConceptSource: LPSN
+                Id: 484
+                LpsnRecordNumber: 783991
+              - Name: Helicobacter canis
+                ConceptType: Species
+                ConceptId: species/helicobacter-canis
+                ConceptSource: LPSN
+                Id: 2503
+                LpsnRecordNumber: 783992
+              - Name: Helicobacter cholecystus
+                ConceptType: Species
+                ConceptId: species/helicobacter-cholecystus
+                ConceptSource: LPSN
+                Id: 653
+                LpsnRecordNumber: 783993
+              - Name: Helicobacter cinaedi
+                ConceptType: Species
+                ConceptId: species/helicobacter-cinaedi
+                ConceptSource: LPSN
+                Id: 2082
+                LpsnRecordNumber: 776865
+                Synonyms:
+                - Name: Campylobacter cinaedi
+                  ConceptId: species/campylobacter-cinaedi
+                  ConceptSource: LPSN
+                  Id: 2015
+                  LpsnRecordNumber: 774372
+              - Name: Helicobacter felis
+                ConceptType: Species
+                ConceptId: species/helicobacter-felis
+                ConceptSource: LPSN
+                Id: 2044
+                LpsnRecordNumber: 783995
+              - Name: Helicobacter fennelliae
+                ConceptType: Species
+                ConceptId: species/helicobacter-fennelliae
+                ConceptSource: LPSN
+                Id: 118
+                LpsnRecordNumber: 776866
+                Synonyms:
+                - Name: Campylobacter fennelliae
+                  ConceptId: species/campylobacter-fennelliae
+                  ConceptSource: LPSN
+                  Id: 2433
+                  LpsnRecordNumber: 774378
+              - Name: Helicobacter ganmani
+                ConceptType: Species
+                ConceptId: species/helicobacter-ganmani
+                ConceptSource: LPSN
+                Id: 1301
+                LpsnRecordNumber: 783996
+              - Name: Helicobacter hepaticus
+                ConceptType: Species
+                ConceptId: species/helicobacter-hepaticus
+                ConceptSource: LPSN
+                Id: 2446
+                LpsnRecordNumber: 783997
+              - Name: Helicobacter mesocricetorum
+                ConceptType: Species
+                ConceptId: species/helicobacter-mesocricetorum
+                ConceptSource: LPSN
+                Id: 1657
+                LpsnRecordNumber: 783998
+              - Name: Helicobacter muridarum
+                ConceptType: Species
+                ConceptId: species/helicobacter-muridarum
+                ConceptSource: LPSN
+                Id: 788
+                LpsnRecordNumber: 783999
+              - Name: Helicobacter mustelae
+                ConceptType: Species
+                ConceptId: species/helicobacter-mustelae
+                ConceptSource: LPSN
+                Id: 1261
+                LpsnRecordNumber: 784000
+                Synonyms:
+                - Name: Campylobacter mustelae
+                  ConceptId: species/campylobacter-mustelae
+                  ConceptSource: LPSN
+                  Id: 885
+                  LpsnRecordNumber: 783598
+              - Name: Helicobacter pametensis
+                ConceptType: Species
+                ConceptId: species/helicobacter-pametensis
+                ConceptSource: LPSN
+                Id: 914
+                LpsnRecordNumber: 784001
+              - Name: Helicobacter pullorum
+                ConceptType: Species
+                ConceptId: species/helicobacter-pullorum
+                ConceptSource: LPSN
+                Id: 54
+                LpsnRecordNumber: 784002
+              - Name: Helicobacter pylori
+                ConceptType: Species
+                ConceptId: species/helicobacter-pylori
+                ConceptSource: LPSN
+                Id: 258
+                LpsnRecordNumber: 776868
+                Synonyms:
+                - Name: Campylobacter pylori
+                  ConceptId: species/campylobacter-pylori
+                  ConceptSource: LPSN
+                  Id: 2570
+                  LpsnRecordNumber: 774385
+                - Name: Helicobacter nemestrinae
+                  ConceptId: species/helicobacter-nemestrinae
+                  ConceptSource: LPSN
+                  Id: 193
+                  LpsnRecordNumber: 776867
+              - Name: Helicobacter rappini
+                ConceptType: Species
+                ConceptId: species/helicobacter-rappini
+                ConceptSource: LPSN
+                Id: 2947
+                LpsnRecordNumber: 2573
+              - Name: Helicobacter rodentium
+                ConceptType: Species
+                ConceptId: species/helicobacter-rodentium
+                ConceptSource: LPSN
+                Id: 1754
+                LpsnRecordNumber: 784003
+              - Name: Helicobacter salomonis
+                ConceptType: Species
+                ConceptId: species/helicobacter-salomonis
+                ConceptSource: LPSN
+                Id: 1843
+                LpsnRecordNumber: 784004
+              - Name: Helicobacter trogontum
+                ConceptType: Species
+                ConceptId: species/helicobacter-trogontum
+                ConceptSource: LPSN
+                Id: 880
+                LpsnRecordNumber: 784005
+              - Name: Helicobacter typhlonius
+                ConceptType: Species
+                ConceptId: species/helicobacter-typhlonius
+                ConceptSource: LPSN
+                Id: 1655
+                LpsnRecordNumber: 784006
+            - Name: Wolinella
+              ConceptType: Genus
+              ConceptId: genus/wolinella
+              ConceptSource: LPSN
+              Id: 1497
+              LpsnRecordNumber: 516927
+              Children:
+              - Name: Wolinella succinogenes
+                ConceptType: Species
+                ConceptId: species/wolinella-succinogenes
+                ConceptSource: LPSN
+                Id: 1804
+                LpsnRecordNumber: 783117
+                Synonyms:
+                - Name: Vibrio succinogenes
+                  ConceptId: species/vibrio-succinogenes
+                  ConceptSource: LPSN
+                  Id: 1892
+                  LpsnRecordNumber: 783032
+    - Name: Spirochaetota
+      ConceptType: Phylum
+      ConceptId: phylum/spirochaetota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 25883
+      Children:
+      - Name: Spirochaetia
+        ConceptType: Class
+        ConceptId: class/spirochaetia
+        ConceptSource: LPSN
+        LpsnRecordNumber: 13791
+        Children:
+        - Name: Brachyspirales
+          ConceptType: Order
+          ConceptId: order/brachyspirales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5153
+          Children:
+          - Name: Brachyspiraceae
+            ConceptType: Family
+            ConceptId: family/brachyspiraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1909
+            Children:
+            - Name: Brachyspira
+              ConceptType: Genus
+              ConceptId: genus/brachyspira
+              ConceptSource: LPSN
+              Id: 128
+              LpsnRecordNumber: 515263
+              Children:
+              - Name: Brachyspira aalborgi
+                ConceptType: Species
+                ConceptId: species/brachyspira-aalborgi
+                ConceptSource: LPSN
+                Id: 225
+                LpsnRecordNumber: 783546
+              - Name: Brachyspira pilosicoli
+                ConceptType: Species
+                ConceptId: species/brachyspira-pilosicoli
+                ConceptSource: LPSN
+                Id: 984
+                LpsnRecordNumber: 783551
+                Synonyms:
+                - Name: Serpulina pilosicoli
+                  ConceptId: species/serpulina-pilosicoli
+                  ConceptSource: LPSN
+                  Id: 1847
+                  LpsnRecordNumber: 784882
+              Synonyms:
+              - Name: Serpulina
+                ConceptId: genus/serpulina
+                ConceptSource: LPSN
+                Id: 534
+                LpsnRecordNumber: 516589
+        - Name: Leptospirales
+          ConceptType: Order
+          ConceptId: order/leptospirales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5156
+          Children:
+          - Name: Leptospiraceae
+            ConceptType: Family
+            ConceptId: family/leptospiraceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 753
+            Children:
+            - Name: Leptospira
+              ConceptType: Genus
+              ConceptId: genus/leptospira
+              ConceptSource: LPSN
+              Id: 2226
+              LpsnRecordNumber: 517268
+              Children:
+              - Name: Leptospira interrogans
+                ConceptType: Species
+                ConceptId: species/leptospira-interrogans
+                ConceptSource: LPSN
+                Id: 2235
+                LpsnRecordNumber: 784137
+        - Name: Spirochaetales
+          ConceptType: Order
+          ConceptId: order/spirochaetales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5028
+          Children:
+          - Name: Borreliaceae
+            ConceptType: Family
+            ConceptId: family/borreliaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1968
+            Children:
+            - Name: Borrelia
+              ConceptType: Genus
+              ConceptId: genus/borrelia
+              ConceptSource: LPSN
+              Id: 1507
+              LpsnRecordNumber: 515251
+              Children:
+              - Name: Borrelia afzelii
+                ConceptType: Species
+                ConceptId: species/borrelia-afzelii
+                ConceptSource: LPSN
+                Id: 560
+                LpsnRecordNumber: 774108
+              - Name: Borrelia anserina
+                ConceptType: Species
+                ConceptId: species/borrelia-anserina
+                ConceptSource: LPSN
+                Id: 938
+                LpsnRecordNumber: 783517
+              - Name: Borrelia burgdorferi
+                ConceptType: Species
+                ConceptId: species/borrelia-burgdorferi
+                ConceptSource: LPSN
+                Id: 834
+                LpsnRecordNumber: 774110
+              - Name: Borrelia caucasica
+                ConceptType: Species
+                ConceptId: species/borrelia-caucasica
+                ConceptSource: LPSN
+                Id: 162
+                LpsnRecordNumber: 783520
+              - Name: Borrelia coriaceae
+                ConceptType: Species
+                ConceptId: species/borrelia-coriaceae
+                ConceptSource: LPSN
+                Id: 1649
+                LpsnRecordNumber: 783521
+              - Name: Borrelia crocidurae
+                ConceptType: Species
+                ConceptId: species/borrelia-crocidurae
+                ConceptSource: LPSN
+                Id: 1555
+                LpsnRecordNumber: 783522
+              - Name: Borrelia duttonii
+                ConceptType: Species
+                ConceptId: species/borrelia-duttonii
+                ConceptSource: LPSN
+                Id: 1276
+                LpsnRecordNumber: 783524
+              - Name: Borrelia garinii
+                ConceptType: Species
+                ConceptId: species/borrelia-garinii
+                ConceptSource: LPSN
+                Id: 2276
+                LpsnRecordNumber: 774112
+              - Name: Borrelia hermsii
+                ConceptType: Species
+                ConceptId: species/borrelia-hermsii
+                ConceptSource: LPSN
+                Id: 1950
+                LpsnRecordNumber: 774115
+              - Name: Borrelia hispanica
+                ConceptType: Species
+                ConceptId: species/borrelia-hispanica
+                ConceptSource: LPSN
+                Id: 321
+                LpsnRecordNumber: 783527
+              - Name: Borrelia japonica
+                ConceptType: Species
+                ConceptId: species/borrelia-japonica
+                ConceptSource: LPSN
+                Id: 1663
+                LpsnRecordNumber: 783528
+              - Name: Borrelia lusitaniae
+                ConceptType: Species
+                ConceptId: species/borrelia-lusitaniae
+                ConceptSource: LPSN
+                Id: 2151
+                LpsnRecordNumber: 783530
+              - Name: Borrelia mazzottii
+                ConceptType: Species
+                ConceptId: species/borrelia-mazzottii
+                ConceptSource: LPSN
+                Id: 1070
+                LpsnRecordNumber: 783531
+              - Name: Borrelia miyamotoi
+                ConceptType: Species
+                ConceptId: species/borrelia-miyamotoi
+                ConceptSource: LPSN
+                Id: 719
+                LpsnRecordNumber: 783532
+              - Name: Borrelia parkeri
+                ConceptType: Species
+                ConceptId: species/borrelia-parkeri
+                ConceptSource: LPSN
+                Id: 1989
+                LpsnRecordNumber: 783533
+              - Name: Borrelia recurrentis
+                ConceptType: Species
+                ConceptId: species/borrelia-recurrentis
+                ConceptSource: LPSN
+                Id: 154
+                LpsnRecordNumber: 783535
+              - Name: Borrelia tanukii
+                ConceptType: Species
+                ConceptId: species/borrelia-tanukii
+                ConceptSource: LPSN
+                Id: 2103
+                LpsnRecordNumber: 783537
+              - Name: Borrelia theileri
+                ConceptType: Species
+                ConceptId: species/borrelia-theileri
+                ConceptSource: LPSN
+                Id: 1980
+                LpsnRecordNumber: 783538
+              - Name: Borrelia turicatae
+                ConceptType: Species
+                ConceptId: species/borrelia-turicatae
+                ConceptSource: LPSN
+                Id: 1520
+                LpsnRecordNumber: 783541
+              - Name: Borrelia valaisiana
+                ConceptType: Species
+                ConceptId: species/borrelia-valaisiana
+                ConceptSource: LPSN
+                Id: 1487
+                LpsnRecordNumber: 783542
+              - Name: Borrelia venezuelensis
+                ConceptType: Species
+                ConceptId: species/borrelia-venezuelensis
+                ConceptSource: LPSN
+                Id: 870
+                LpsnRecordNumber: 783543
+          - Name: Treponemataceae
+            ConceptType: Family
+            ConceptId: family/treponemataceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 1516
+            Children:
+            - Name: Treponema
+              ConceptType: Genus
+              ConceptId: genus/treponema
+              ConceptSource: LPSN
+              Id: 648
+              LpsnRecordNumber: 516856
+              Children:
+              - Name: Treponema carateum
+                ConceptType: Species
+                ConceptId: species/treponema-carateum
+                ConceptSource: LPSN
+                Id: 2957
+                LpsnRecordNumber: 785108
+              - Name: Treponema pallidum
+                ConceptType: Species
+                ConceptId: species/treponema-pallidum
+                ConceptSource: LPSN
+                Id: 2317
+                LpsnRecordNumber: 785115
+  - Name: Thermotogati
+    ConceptType: Kingdom
+    ConceptId: kingdom/thermotogati
+    ConceptSource: LPSN
+    LpsnRecordNumber: 43126
+    Children:
+    - Name: Deinococcota
+      ConceptType: Phylum
+      ConceptId: phylum/deinococcota
+      ConceptSource: LPSN
+      LpsnRecordNumber: 25887
+      Children:
+      - Name: Deinococci
+        ConceptType: Class
+        ConceptId: class/deinococci
+        ConceptSource: LPSN
+        LpsnRecordNumber: 30
+        Children:
+        - Name: Deinococcales
+          ConceptType: Order
+          ConceptId: order/deinococcales
+          ConceptSource: LPSN
+          LpsnRecordNumber: 5048
+          Children:
+          - Name: Deinococcaceae
+            ConceptType: Family
+            ConceptId: family/deinococcaceae
+            ConceptSource: LPSN
+            LpsnRecordNumber: 381
+            Children:
+            - Name: Deinococcus
+              ConceptType: Genus
+              ConceptId: genus/deinococcus
+              ConceptSource: LPSN
+              Id: 1872
+              LpsnRecordNumber: 515482
+- Name: Eukaryota
+  ConceptType: Domain
+  ConceptSource: NeoIPC
+  Children:
+  - Name: Fungi
+    ConceptType: Kingdom
+    ConceptId: 455206
+    ConceptSource: MycoBank
+    MycoBankNr: 90157
+    Children:
+    - Name: Basidiobolomyceta
+      ConceptType: Subkingdom
+      ConceptId: 566863
+      ConceptSource: MycoBank
+      MycoBankNr: 554029
+      Children:
+      - Name: Basidiobolomycota
+        ConceptType: Phylum
+        ConceptId: 452642
+        ConceptSource: MycoBank
+        MycoBankNr: 90741
+        Children:
+        - Name: Basidiobolomycotina
+          ConceptType: Subphylum
+          ConceptId: 566870
+          ConceptSource: MycoBank
+          MycoBankNr: 554036
+          Children:
+          - Name: Basidiobolomycetes
+            ConceptType: Class
+            ConceptId: 452785
+            ConceptSource: MycoBank
+            MycoBankNr: 90740
+            Children:
+            - Name: Basidiobolales
+              ConceptType: Order
+              ConceptId: 528659
+              ConceptSource: MycoBank
+              MycoBankNr: 90721
+              Children:
+              - Name: Basidiobolaceae
+                ConceptType: Family
+                ConceptId: 92702
+                ConceptSource: MycoBank
+                MycoBankNr: 80514
+                Children:
+                - Name: Basidiobolus
+                  ConceptType: Genus
+                  ConceptId: 56142
+                  ConceptSource: MycoBank
+                  Id: 1326
+                  MycoBankNr: 20068
+                  Children:
+                  - Name: Basidiobolus haptosporus
+                    ConceptType: Species
+                    ConceptId: 3016
+                    ConceptSource: MycoBank
+                    Id: 1670
+                    MycoBankNr: 284511
+                  - Name: Basidiobolus heterosporus
+                    ConceptType: Species
+                    ConceptId: 3022
+                    ConceptSource: MycoBank
+                    Id: 1484
+                    MycoBankNr: 326921
+                  - Name: Basidiobolus meristosporus
+                    ConceptType: Species
+                    ConceptId: 3026
+                    ConceptSource: MycoBank
+                    Id: 1560
+                    MycoBankNr: 293630
+                  - Name: Basidiobolus ranarum
+                    ConceptType: Species
+                    ConceptId: 3032
+                    ConceptSource: MycoBank
+                    Id: 873
+                    MycoBankNr: 224388
+    - Name: Dikarya
+      ConceptType: Subkingdom
+      ConceptId: 432186
+      ConceptSource: MycoBank
+      Id: 3428
+      MycoBankNr: 501463
+      Children:
+      - Name: Ascomycota
+        ConceptType: Phylum
+        ConceptId: 452647
+        ConceptSource: MycoBank
+        Id: 3427
+        MycoBankNr: 90031
+        Children:
+        - Name: Pezizomycotina
+          ConceptType: Subphylum
+          ConceptId: 430998
+          ConceptSource: MycoBank
+          MycoBankNr: 501468
+          Children:
+          - Name: Arthoniomycetes
+            ConceptType: Class
+            ConceptId: 431047
+            ConceptSource: MycoBank
+            MycoBankNr: 501475
+            Children:
+            - Name: Lichenostigmatales
+              ConceptType: Order
+              ConceptId: 512249
+              ConceptSource: MycoBank
+              MycoBankNr: 804670
+              Children:
+              - Name: Phaeococcomycetaceae
+                ConceptType: Family
+                ConceptId: 433099
+                ConceptSource: MycoBank
+                MycoBankNr: 81139
+                Children:
+                - Name: Phaeococcomyces
+                  ConceptType: Genus
+                  ConceptId: 39193
+                  ConceptSource: MycoBank
+                  Id: 1234
+                  MycoBankNr: 9294
+          - Name: Dothideomycetes
+            ConceptType: Class
+            ConceptId: 431106
+            ConceptSource: MycoBank
+            MycoBankNr: 501481
+            Children:
+            - Name: Botryosphaeriales
+              ConceptType: Order
+              ConceptId: 431108
+              ConceptSource: MycoBank
+              MycoBankNr: 501513
+              Children:
+              - Name: Botryosphaeriaceae
+                ConceptType: Family
+                ConceptId: 92710
+                ConceptSource: MycoBank
+                MycoBankNr: 80530
+                Children:
+                - Name: Lasiodiplodia
+                  ConceptType: Genus
+                  ConceptId: 58151
+                  ConceptSource: MycoBank
+                  Id: 159
+                  MycoBankNr: 8708
+                  Children:
+                  - Name: Lasiodiplodia theobromae
+                    ConceptType: Species
+                    ConceptId: 3290
+                    ConceptSource: MycoBank
+                    Id: 842
+                    MycoBankNr: 188476
+                    Synonyms:
+                    - Name: Botryodiplodia theobromae
+                      ConceptId: 3265
+                      ConceptSource: MycoBank
+                      Id: 2240
+                      MycoBankNr: 157658
+                - Name: Neoscytalidium
+                  ConceptType: Genus
+                  ConceptId: 426517
+                  ConceptSource: MycoBank
+                  MycoBankNr: 500868
+                  Children:
+                  - Name: Neoscytalidium dimidiatum
+                    ConceptType: Species
+                    ConceptId: 426518
+                    ConceptSource: MycoBank
+                    Id: 2145
+                    MycoBankNr: 500869
+                    Synonyms:
+                    - Name: Fusicoccum dimidiatum
+                      ConceptId: 426519
+                      ConceptSource: MycoBank
+                      Id: 996
+                      MycoBankNr: 500891
+                    - Name: Scytalidium dimidiatum
+                      ConceptId: 42400
+                      ConceptSource: MycoBank
+                      Id: 49
+                      MycoBankNr: 126371
+                    - Name: Scytalidium hyalinum
+                      ConceptId: 25234
+                      ConceptSource: MycoBank
+                      Id: 1888
+                      MycoBankNr: 323361
+                    - Name: Torula dimidiata
+                      ConceptId: 27365
+                      ConceptSource: MycoBank
+                      Id: 605
+                      MycoBankNr: 151916
+            - Name: Cladosporiales
+              ConceptType: Order
+              ConceptId: 577257
+              ConceptSource: MycoBank
+              MycoBankNr: 833140
+              Children:
+              - Name: Cladosporiaceae
+                ConceptType: Family
+                ConceptId: 551992
+                ConceptSource: MycoBank
+                MycoBankNr: 816548
+                Children:
+                - Name: Cladosporium
+                  ConceptType: Genus
+                  ConceptId: 33538
+                  ConceptSource: MycoBank
+                  Id: 1335
+                  MycoBankNr: 7681
+                  Children:
+                  - Name: Cladosporium cladosporioides
+                    ConceptType: Species
+                    ConceptId: 5453
+                    ConceptSource: MycoBank
+                    Id: 729
+                    MycoBankNr: 294915
+                  - Name: Cladosporium herbarum
+                    ConceptType: Species
+                    ConceptId: 5495
+                    ConceptSource: MycoBank
+                    Id: 1233
+                    MycoBankNr: 231458
+                  - Name: Cladosporium sphaerospermum
+                    ConceptType: Species
+                    ConceptId: 5542
+                    ConceptSource: MycoBank
+                    Id: 888
+                    MycoBankNr: 119529
+            - Name: Dothideomycetidae
+              ConceptType: Subclass
+              ConceptId: 92397
+              ConceptSource: MycoBank
+              MycoBankNr: 90782
+              Children:
+              - Name: Capnodiales
+                ConceptType: Order
+                ConceptId: 92432
+                ConceptSource: MycoBank
+                MycoBankNr: 90464
+                Children:
+                - Name: Davidiellaceae
+                  ConceptType: Family
+                  ConceptId: 440293
+                  ConceptSource: MycoBank
+                  MycoBankNr: 504453
+                  Children:
+                  - Name: Hormodendrum
+                    ConceptType: Genus
+                    ConceptId: 56712
+                    ConceptSource: MycoBank
+                    Id: 300
+                    MycoBankNr: 8558
+                - Name: Piedraiaceae
+                  ConceptType: Family
+                  ConceptId: 93023
+                  ConceptSource: MycoBank
+                  MycoBankNr: 82066
+                  Children:
+                  - Name: Piedraia
+                    ConceptType: Genus
+                    ConceptId: 57155
+                    ConceptSource: MycoBank
+                    Id: 1702
+                    MycoBankNr: 4098
+                    Children:
+                    - Name: Piedraia hortae
+                      ConceptType: Species
+                      ConceptId: 58290
+                      ConceptSource: MycoBank
+                      Id: 269
+                      MycoBankNr: 267365
+              - Name: Dothideales
+                ConceptType: Order
+                ConceptId: 92443
+                ConceptSource: MycoBank
+                MycoBankNr: 90506
+                Children:
+                - Name: Dothioraceae
+                  ConceptType: Family
+                  ConceptId: 92792
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80716
+                  Children:
+                  - Name: Sydowia
+                    ConceptType: Genus
+                    ConceptId: 57478
+                    ConceptSource: MycoBank
+                    Id: 3392
+                    MycoBankNr: 5311
+                    Synonyms:
+                    - Name: Hormonema
+                      ConceptId: 39172
+                      ConceptSource: MycoBank
+                      Id: 803
+                      MycoBankNr: 8562
+                - Name: Saccotheciaceae
+                  ConceptType: Family
+                  ConceptId: 433400
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81613
+                  Children:
+                  - Name: Aureobasidium
+                    ConceptType: Genus
+                    ConceptId: 32896
+                    ConceptSource: MycoBank
+                    Id: 2492
+                    MycoBankNr: 7297
+                    Children:
+                    - Name: Aureobasidium pullulans
+                      ConceptType: Species
+                      ConceptId: 58208
+                      ConceptSource: MycoBank
+                      Id: 2964
+                      MycoBankNr: 101771
+                      Synonyms:
+                      - Name: Pullularia pullulans
+                        ConceptId: 23244
+                        ConceptSource: MycoBank
+                        Id: 46
+                        MycoBankNr: 275660
+                    Synonyms:
+                    - Name: Pullularia
+                      ConceptId: 57855
+                      ConceptSource: MycoBank
+                      Id: 977
+                      MycoBankNr: 9639
+              - Name: Mycosphaerellales
+                ConceptType: Order
+                ConceptId: 92489
+                ConceptSource: MycoBank
+                MycoBankNr: 90557
+                Children:
+                - Name: Mycosphaerellaceae
+                  ConceptType: Family
+                  ConceptId: 92960
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81043
+                  Children:
+                  - Name: Zasmidium
+                    ConceptType: Genus
+                    ConceptId: 57651
+                    ConceptSource: MycoBank
+                    MycoBankNr: 22396
+                    Children:
+                    - Name: Zasmidium cerophilum
+                      ConceptType: Species
+                      ConceptId: 561905
+                      ConceptSource: MycoBank
+                      Id: 3393
+                      MycoBankNr: 822808
+                      Synonyms:
+                      - Name: Ramichloridium cerophilum
+                        ConceptId: 23852
+                        ConceptSource: MycoBank
+                        Id: 298
+                        MycoBankNr: 322315
+                - Name: Teratosphaeriaceae
+                  ConceptType: Family
+                  ConceptId: 440306
+                  ConceptSource: MycoBank
+                  MycoBankNr: 504465
+                  Children:
+                  - Name: Hortaea
+                    ConceptType: Genus
+                    ConceptId: 56715
+                    ConceptSource: MycoBank
+                    MycoBankNr: 11101
+                    Children:
+                    - Name: Hortaea werneckii
+                      ConceptType: Species
+                      ConceptId: 13049
+                      ConceptSource: MycoBank
+                      Id: 1624
+                      MycoBankNr: 106184
+                      Synonyms:
+                      - Name: Cladosporium werneckii
+                        ConceptId: 5580
+                        ConceptSource: MycoBank
+                        Id: 104
+                        MycoBankNr: 255465
+                      - Name: Exophiala werneckii
+                        ConceptId: 13050
+                        ConceptSource: MycoBank
+                        Id: 1674
+                        MycoBankNr: 314045
+                      - Name: Phaeoannellomyces werneckii
+                        ConceptId: 41995
+                        ConceptSource: MycoBank
+                        Id: 1503
+                        MycoBankNr: 105002
+            - Name: Eremomycetales
+              ConceptType: Order
+              ConceptId: 575272
+              ConceptSource: MycoBank
+              MycoBankNr: 831891
+              Children:
+              - Name: Eremomycetaceae
+                ConceptType: Family
+                ConceptId: 92816
+                ConceptSource: MycoBank
+                MycoBankNr: 80751
+                Children:
+                - Name: Arthrographis
+                  ConceptType: Genus
+                  ConceptId: 31980
+                  ConceptSource: MycoBank
+                  Id: 465
+                  MycoBankNr: 7222
+            - Name: Pleosporomycetidae
+              ConceptType: Subclass
+              ConceptId: 431107
+              ConceptSource: MycoBank
+              MycoBankNr: 501507
+              Children:
+              - Name: Pleosporales
+                ConceptType: Order
+                ConceptId: 92507
+                ConceptSource: MycoBank
+                MycoBankNr: 90563
+                Children:
+                - Name: Astrosphaeriellaceae
+                  ConceptType: Family
+                  ConceptId: 557725
+                  ConceptSource: MycoBank
+                  MycoBankNr: 551632
+                  Children:
+                  - Name: Pithomyces
+                    ConceptType: Genus
+                    ConceptId: 37444
+                    ConceptSource: MycoBank
+                    Id: 2126
+                    MycoBankNr: 9412
+                - Name: Coniothyriaceae
+                  ConceptType: Family
+                  ConceptId: 432784
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80635
+                  Children:
+                  - Name: Coniothyrium
+                    ConceptType: Genus
+                    ConceptId: 33790
+                    ConceptSource: MycoBank
+                    Id: 2206
+                    MycoBankNr: 7765
+                - Name: Cucurbitariaceae
+                  ConceptType: Family
+                  ConceptId: 92769
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80667
+                  Children:
+                  - Name: Pyrenochaeta
+                    ConceptType: Genus
+                    ConceptId: 39357
+                    ConceptSource: MycoBank
+                    Id: 2354
+                    MycoBankNr: 9667
+                - Name: Didymellaceae
+                  ConceptType: Family
+                  ConceptId: 453922
+                  ConceptSource: MycoBank
+                  MycoBankNr: 508292
+                  Children:
+                  - Name: Epicoccum
+                    ConceptType: Genus
+                    ConceptId: 56525
+                    ConceptSource: MycoBank
+                    Id: 1185
+                    MycoBankNr: 8188
+                - Name: Leptosphaeriaceae
+                  ConceptType: Family
+                  ConceptId: 92902
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81843
+                  Children:
+                  - Name: Leptosphaeria
+                    ConceptType: Genus
+                    ConceptId: 36137
+                    ConceptSource: MycoBank
+                    Id: 2110
+                    MycoBankNr: 2800
+                - Name: Massarinaceae
+                  ConceptType: Family
+                  ConceptId: 433001
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80979
+                  Children:
+                  - Name: Helminthosporium
+                    ConceptType: Genus
+                    ConceptId: 56683
+                    ConceptSource: MycoBank
+                    Id: 2049
+                    MycoBankNr: 8495
+                - Name: Pleosporaceae
+                  ConceptType: Family
+                  ConceptId: 93033
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81188
+                  Children:
+                  - Name: Alternaria
+                    ConceptType: Genus
+                    ConceptId: 31788
+                    ConceptSource: MycoBank
+                    Id: 874
+                    MycoBankNr: 7106
+                    Children:
+                    - Name: Alternaria alternata
+                      ConceptType: Species
+                      ConceptId: 900
+                      ConceptSource: MycoBank
+                      Id: 1869
+                      MycoBankNr: 119834
+                    - Name: Alternaria dianthicola
+                      ConceptType: Species
+                      ConceptId: 982
+                      ConceptSource: MycoBank
+                      Id: 858
+                      MycoBankNr: 284026
+                    - Name: Alternaria infectoria
+                      ConceptType: Species
+                      ConceptId: 30359
+                      ConceptSource: MycoBank
+                      Id: 1019
+                      MycoBankNr: 103987
+                    - Name: Alternaria tenuissima
+                      ConceptType: Species
+                      ConceptId: 1099
+                      ConceptSource: MycoBank
+                      Id: 1749
+                      MycoBankNr: 280005
+                    Synonyms:
+                    - Name: Macrosporium
+                      ConceptId: 56872
+                      ConceptSource: MycoBank
+                      Id: 959
+                      MycoBankNr: 8821
+                    - Name: Ulocladium
+                      ConceptId: 38773
+                      ConceptSource: MycoBank
+                      Id: 1578
+                      MycoBankNr: 10346
+                  - Name: Bipolaris
+                    ConceptType: Genus
+                    ConceptId: 55248
+                    ConceptSource: MycoBank
+                    Id: 1424
+                    MycoBankNr: 7375
+                  - Name: Curvularia
+                    ConceptType: Genus
+                    ConceptId: 34121
+                    ConceptSource: MycoBank
+                    Id: 899
+                    MycoBankNr: 7847
+                    Children:
+                    - Name: Curvularia australiensis
+                      ConceptType: Species
+                      ConceptId: 507261
+                      ConceptSource: MycoBank
+                      Id: 3402
+                      MycoBankNr: 564767
+                      Synonyms:
+                      - Name: Bipolaris australiensis
+                        ConceptId: 46415
+                        ConceptSource: MycoBank
+                        Id: 1927
+                        MycoBankNr: 112052
+                    - Name: Curvularia geniculata
+                      ConceptType: Species
+                      ConceptId: 7290
+                      ConceptSource: MycoBank
+                      Id: 785
+                      MycoBankNr: 265873
+                    - Name: Curvularia hawaiiensis
+                      ConceptType: Species
+                      ConceptId: 508048
+                      ConceptSource: MycoBank
+                      Id: 3385
+                      MycoBankNr: 800543
+                      Synonyms:
+                      - Name: Bipolaris hawaiiensis
+                        ConceptId: 46407
+                        ConceptSource: MycoBank
+                        Id: 948
+                        MycoBankNr: 309555
+                    - Name: Curvularia lunata
+                      ConceptType: Species
+                      ConceptId: 46537
+                      ConceptSource: MycoBank
+                      Id: 855
+                      MycoBankNr: 269889
+                    - Name: Curvularia spicifera
+                      ConceptType: Species
+                      ConceptId: 7369
+                      ConceptSource: MycoBank
+                      Id: 2012
+                      MycoBankNr: 278597
+                      Synonyms:
+                      - Name: Bipolaris spicifera
+                        ConceptId: 46397
+                        ConceptSource: MycoBank
+                        Id: 307
+                        MycoBankNr: 309557
+                      - Name: Brachycladium spiciferum
+                        ConceptId: 32463
+                        ConceptSource: MycoBank
+                        Id: 496
+                        MycoBankNr: 221562
+                      - Name: Drechslera spicifera
+                        ConceptId: 9117
+                        ConceptSource: MycoBank
+                        Id: 2471
+                        MycoBankNr: 313402
+                      - Name: Helminthosporium spiciferum
+                        ConceptId: 34473
+                        ConceptSource: MycoBank
+                        Id: 1934
+                        MycoBankNr: 298294
+                  - Name: Exserohilum
+                    ConceptType: Genus
+                    ConceptId: 56547
+                    ConceptSource: MycoBank
+                    Id: 544
+                    MycoBankNr: 8241
+                    Children:
+                    - Name: Exserohilum rostratum
+                      ConceptType: Species
+                      ConceptId: 25591
+                      ConceptSource: MycoBank
+                      Id: 1770
+                      MycoBankNr: 314059
+                      Synonyms:
+                      - Name: Drechslera halodes
+                        ConceptId: 8974
+                        ConceptSource: MycoBank
+                        Id: 1618
+                        MycoBankNr: 330196
+                      - Name: Drechslera rostrata
+                        ConceptId: 9069
+                        ConceptSource: MycoBank
+                        Id: 82
+                        MycoBankNr: 330213
+                      - Name: Helminthosporium halodes
+                        ConceptId: 12702
+                        ConceptSource: MycoBank
+                        Id: 1650
+                        MycoBankNr: 252515
+                      - Name: Helminthosporium rostratum
+                        ConceptId: 35257
+                        ConceptSource: MycoBank
+                        Id: 1441
+                        MycoBankNr: 254456
+                  - Name: Pyrenophora
+                    ConceptType: Genus
+                    ConceptId: 57274
+                    ConceptSource: MycoBank
+                    Id: 3361
+                    MycoBankNr: 4596
+                    Synonyms:
+                    - Name: Drechslera
+                      ConceptId: 34469
+                      ConceptSource: MycoBank
+                      Id: 97
+                      MycoBankNr: 8103
+                  - Name: Stemphylium
+                    ConceptType: Genus
+                    ConceptId: 57446
+                    ConceptSource: MycoBank
+                    Id: 144
+                    MycoBankNr: 10081
+                - Name: Trematosphaeriaceae
+                  ConceptType: Family
+                  ConceptId: 475120
+                  ConceptSource: MycoBank
+                  MycoBankNr: 519506
+                  Children:
+                  - Name: Falciformispora
+                    ConceptType: Genus
+                    ConceptId: 95185
+                    ConceptSource: MycoBank
+                    MycoBankNr: 25457
+                    Children:
+                    - Name: Falciformispora senegalensis
+                      ConceptType: Species
+                      ConceptId: 512440
+                      ConceptSource: MycoBank
+                      Id: 3522
+                      MycoBankNr: 804853
+                      Synonyms:
+                      - Name: Leptosphaeria senegalensis
+                        ConceptId: 14466
+                        ConceptSource: MycoBank
+                        Id: 2138
+                        MycoBankNr: 299640
+                    - Name: Falciformispora tompkinsii
+                      ConceptType: Species
+                      ConceptId: 512442
+                      ConceptSource: MycoBank
+                      Id: 3523
+                      MycoBankNr: 804855
+                      Synonyms:
+                      - Name: Leptosphaeria tompkinsii
+                        ConceptId: 14473
+                        ConceptSource: MycoBank
+                        Id: 1580
+                        MycoBankNr: 333276
+                  - Name: Medicopsis
+                    ConceptType: Genus
+                    ConceptId: 507290
+                    ConceptSource: MycoBank
+                    MycoBankNr: 564791
+                    Children:
+                    - Name: Medicopsis romeroi
+                      ConceptType: Species
+                      ConceptId: 507291
+                      ConceptSource: MycoBank
+                      Id: 3345
+                      MycoBankNr: 564792
+                      Synonyms:
+                      - Name: Pyrenochaeta romeroi
+                        ConceptId: 23322
+                        ConceptSource: MycoBank
+                        Id: 349
+                        MycoBankNr: 338075
+                  - Name: Trematosphaeria
+                    ConceptType: Genus
+                    ConceptId: 57535
+                    ConceptSource: MycoBank
+                    MycoBankNr: 5522
+                    Children:
+                    - Name: Trematosphaeria grisea
+                      ConceptType: Species
+                      ConceptId: 512441
+                      ConceptSource: MycoBank
+                      Id: 3526
+                      MycoBankNr: 804854
+                      Synonyms:
+                      - Name: Madurella grisea
+                        ConceptId: 14821
+                        ConceptSource: MycoBank
+                        Id: 1081
+                        MycoBankNr: 287885
+              - Name: Venturiales
+                ConceptType: Order
+                ConceptId: 458547
+                ConceptSource: MycoBank
+                MycoBankNr: 513386
+                Children:
+                - Name: Sympoventuriaceae
+                  ConceptType: Family
+                  ConceptId: 478259
+                  ConceptSource: MycoBank
+                  MycoBankNr: 563117
+                  Children:
+                  - Name: Ochroconis
+                    ConceptType: Genus
+                    ConceptId: 57037
+                    ConceptSource: MycoBank
+                    Id: 2081
+                    MycoBankNr: 9136
+                    Children:
+                    - Name: Ochroconis humicola
+                      ConceptType: Species
+                      ConceptId: 17804
+                      ConceptSource: MycoBank
+                      Id: 861
+                      MycoBankNr: 318849
+                      Synonyms:
+                      - Name: Scolecobasidium humicola
+                        ConceptId: 35599
+                        ConceptSource: MycoBank
+                        Id: 952
+                        MycoBankNr: 338922
+                  - Name: Scolecobasidium
+                    ConceptType: Genus
+                    ConceptId: 39423
+                    ConceptSource: MycoBank
+                    Id: 1539
+                    MycoBankNr: 9840
+                    Children:
+                    - Name: Scolecobasidium constrictum
+                      ConceptType: Species
+                      ConceptId: 35597
+                      ConceptSource: MycoBank
+                      Id: 691
+                      MycoBankNr: 261824
+                      Synonyms:
+                      - Name: Dactylaria constricta
+                        ConceptId: 169315
+                        ConceptSource: MycoBank
+                        Id: 2307
+                        MycoBankNr: 130188
+                      - Name: Ochroconis constricta
+                        ConceptId: 35598
+                        ConceptSource: MycoBank
+                        Id: 1429
+                        MycoBankNr: 318847
+                    Synonyms:
+                    - Name: Ochroconis
+                      ConceptId: 57037
+                      ConceptSource: MycoBank
+                      Id: 2081
+                      MycoBankNr: 9136
+                  - Name: Verruconis
+                    ConceptType: Genus
+                    ConceptId: 474623
+                    ConceptSource: MycoBank
+                    MycoBankNr: 519169
+                    Children:
+                    - Name: Verruconis gallopava
+                      ConceptType: Species
+                      ConceptId: 474625
+                      ConceptSource: MycoBank
+                      Id: 3394
+                      MycoBankNr: 519171
+                      Synonyms:
+                      - Name: Ochroconis gallopava
+                        ConceptId: 17797
+                        ConceptSource: MycoBank
+                        Id: 1853
+                        MycoBankNr: 115609
+          - Name: Eurotiomycetes
+            ConceptType: Class
+            ConceptId: 431002
+            ConceptSource: MycoBank
+            MycoBankNr: 501483
+            Children:
+            - Name: Chaetothyriomycetidae
+              ConceptType: Subclass
+              ConceptId: 92396
+              ConceptSource: MycoBank
+              MycoBankNr: 90739
+              Children:
+              - Name: Chaetothyriales
+                ConceptType: Order
+                ConceptId: 92433
+                ConceptSource: MycoBank
+                MycoBankNr: 90533
+                Children:
+                - Name: Cyphellophoraceae
+                  ConceptType: Family
+                  ConceptId: 511256
+                  ConceptSource: MycoBank
+                  MycoBankNr: 803682
+                  Children:
+                  - Name: Cyphellophora
+                    ConceptType: Genus
+                    ConceptId: 34193
+                    ConceptSource: MycoBank
+                    MycoBankNr: 7885
+                    Children:
+                    - Name: Cyphellophora europaea
+                      ConceptType: Species
+                      ConceptId: 511257
+                      ConceptSource: MycoBank
+                      Id: 3537
+                      MycoBankNr: 803683
+                      Synonyms:
+                      - Name: Phialophora europaea
+                        ConceptId: 53018
+                        ConceptSource: MycoBank
+                        Id: 2238
+                        MycoBankNr: 482897
+                - Name: Herpotrichiellaceae
+                  ConceptType: Family
+                  ConceptId: 92868
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80856
+                  Children:
+                  - Name: Cladophialophora
+                    ConceptType: Genus
+                    ConceptId: 47336
+                    ConceptSource: MycoBank
+                    Id: 1500
+                    MycoBankNr: 7677
+                    Children:
+                    - Name: Cladophialophora bantiana
+                      ConceptType: Species
+                      ConceptId: 48324
+                      ConceptSource: MycoBank
+                      Id: 2224
+                      MycoBankNr: 412791
+                  - Name: Exophiala
+                    ConceptType: Genus
+                    ConceptId: 34761
+                    ConceptSource: MycoBank
+                    Id: 2251
+                    MycoBankNr: 8233
+                    Children:
+                    - Name: Exophiala bergeri
+                      ConceptType: Species
+                      ConceptId: 53457
+                      ConceptSource: MycoBank
+                      Id: 562
+                      MycoBankNr: 460080
+                    - Name: Exophiala dermatitidis
+                      ConceptType: Species
+                      ConceptId: 10192
+                      ConceptSource: MycoBank
+                      Id: 212
+                      MycoBankNr: 314039
+                      Synonyms:
+                      - Name: Fonsecaea dermatitidis
+                        ConceptId: 35906
+                        ConceptSource: MycoBank
+                        Id: 616
+                        MycoBankNr: 491534
+                      - Name: Hormiscium dermatitidis
+                        ConceptId: 10193
+                        ConceptSource: MycoBank
+                        Id: 822
+                        MycoBankNr: 118937
+                      - Name: Hormodendrum dermatitidis
+                        ConceptId: 35286
+                        ConceptSource: MycoBank
+                        Id: 510
+                        MycoBankNr: 491663
+                      - Name: Phialophora dermatitidis
+                        ConceptId: 58517
+                        ConceptSource: MycoBank
+                        Id: 580
+                        MycoBankNr: 336294
+                      - Name: Wangiella dermatitidis
+                        ConceptId: 10105
+                        ConceptSource: MycoBank
+                        Id: 348
+                        MycoBankNr: 325539
+                    - Name: Exophiala exophialae
+                      ConceptType: Species
+                      ConceptId: 406647
+                      ConceptSource: MycoBank
+                      Id: 3374
+                      MycoBankNr: 486420
+                      Synonyms:
+                      - Name: Phaeococcomyces exophialae
+                        ConceptId: 20236
+                        ConceptSource: MycoBank
+                        Id: 2373
+                        MycoBankNr: 319527
+                    - Name: Exophiala jeanselmei
+                      ConceptType: Species
+                      ConceptId: 46560
+                      ConceptSource: MycoBank
+                      Id: 2161
+                      MycoBankNr: 314040
+                      Synonyms:
+                      - Name: Phialophora jeanselmei
+                        ConceptId: 20650
+                        ConceptSource: MycoBank
+                        Id: 762
+                        MycoBankNr: 302840
+                    - Name: Exophiala spinifera
+                      ConceptType: Species
+                      ConceptId: 29710
+                      ConceptSource: MycoBank
+                      Id: 2424
+                      MycoBankNr: 314044
+                      Synonyms:
+                      - Name: Phialophora spinifera
+                        ConceptId: 24065
+                        ConceptSource: MycoBank
+                        Id: 633
+                        MycoBankNr: 336296
+                      - Name: Rhinocladiella spinifera
+                        ConceptId: 24064
+                        ConceptSource: MycoBank
+                        Id: 1394
+                        MycoBankNr: 322470
+                    Synonyms:
+                    - Name: Wangiella
+                      ConceptId: 57948
+                      ConceptSource: MycoBank
+                      Id: 1157
+                      MycoBankNr: 10430
+                  - Name: Fonsecaea
+                    ConceptType: Genus
+                    ConceptId: 52704
+                    ConceptSource: MycoBank
+                    Id: 1297
+                    MycoBankNr: 8264
+                    Children:
+                    - Name: Fonsecaea pedrosoi
+                      ConceptType: Species
+                      ConceptId: 29711
+                      ConceptSource: MycoBank
+                      Id: 1207
+                      MycoBankNr: 253857
+                      Synonyms:
+                      - Name: Fonsecaea compacta
+                        ConceptId: 461795
+                        ConceptSource: MycoBank
+                        Id: 1112
+                        MycoBankNr: 535105
+                      - Name: Fonsecaea compactum
+                        ConceptId: 53964
+                        ConceptSource: MycoBank
+                        Id: 1095
+                        MycoBankNr: 286497
+                      - Name: Phialophora compacta
+                        ConceptId: 20606
+                        ConceptSource: MycoBank
+                        Id: 71
+                        MycoBankNr: 282479
+                      - Name: Phialophora pedrosoi
+                        ConceptId: 20701
+                        ConceptSource: MycoBank
+                        Id: 1576
+                        MycoBankNr: 289362
+                      - Name: Rhinocladiella pedrosoi
+                        ConceptId: 24045
+                        ConceptSource: MycoBank
+                        Id: 244
+                        MycoBankNr: 338306
+                  - Name: Phialophora
+                    ConceptType: Genus
+                    ConceptId: 39364
+                    ConceptSource: MycoBank
+                    Id: 2127
+                    MycoBankNr: 9342
+                    Children:
+                    - Name: Phialophora americana
+                      ConceptType: Species
+                      ConceptId: 20569
+                      ConceptSource: MycoBank
+                      Id: 167
+                      MycoBankNr: 302837
+                    - Name: Phialophora verrucosa
+                      ConceptType: Species
+                      ConceptId: 20729
+                      ConceptSource: MycoBank
+                      Id: 1891
+                      MycoBankNr: 214996
+                  - Name: Rhinocladiella
+                    ConceptType: Genus
+                    ConceptId: 39120
+                    ConceptSource: MycoBank
+                    MycoBankNr: 9720
+                    Children:
+                    - Name: Rhinocladiella aquaspersa
+                      ConceptType: Species
+                      ConceptId: 41509
+                      ConceptSource: MycoBank
+                      Id: 1187
+                      MycoBankNr: 109229
+                      Synonyms:
+                      - Name: Acrotheca aquaspersa
+                        ConceptId: 666
+                        ConceptSource: MycoBank
+                        Id: 114
+                        MycoBankNr: 308264
+                    - Name: Rhinocladiella atrovirens
+                      ConceptType: Species
+                      ConceptId: 24023
+                      ConceptSource: MycoBank
+                      Id: 1120
+                      MycoBankNr: 257799
+                - Name: Phaeoannellomyces
+                  ConceptType: Genus
+                  ConceptId: 57112
+                  ConceptSource: MycoBank
+                  Id: 518
+                  MycoBankNr: 11158
+            - Name: Eurotiomycetidae
+              ConceptType: Subclass
+              ConceptId: 436127
+              ConceptSource: MycoBank
+              MycoBankNr: 501287
+              Children:
+              - Name: Eurotiales
+                ConceptType: Order
+                ConceptId: 92453
+                ConceptSource: MycoBank
+                MycoBankNr: 90472
+                Children:
+                - Name: Aspergillaceae
+                  ConceptType: Family
+                  ConceptId: 432695
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80489
+                  Children:
+                  - Name: Aspergillus
+                    ConceptType: Genus
+                    ConceptId: 32325
+                    ConceptSource: MycoBank
+                    MycoBankNr: 7248
+                    Children:
+                    - Name: Aspergillus candidus
+                      ConceptType: Species
+                      ConceptId: 2258
+                      ConceptSource: MycoBank
+                      Id: 266
+                      MycoBankNr: 204868
+                    - Name: Aspergillus clavatus
+                      ConceptType: Species
+                      ConceptId: 2293
+                      ConceptSource: MycoBank
+                      Id: 2205
+                      MycoBankNr: 211530
+                    - Name: Aspergillus deflectus
+                      ConceptType: Species
+                      ConceptId: 2310
+                      ConceptSource: MycoBank
+                      Id: 2048
+                      MycoBankNr: 292841
+                    - Name: Aspergillus fischeri
+                      ConceptType: Species
+                      ConceptId: 17573
+                      ConceptSource: MycoBank
+                      Id: 3406
+                      MycoBankNr: 202877
+                      Synonyms:
+                      - Name: Neosartorya fischeri
+                        ConceptId: 58269
+                        ConceptSource: MycoBank
+                        Id: 2090
+                        MycoBankNr: 318630
+                    - Name: Aspergillus flavipes
+                      ConceptType: Species
+                      ConceptId: 10305
+                      ConceptSource: MycoBank
+                      Id: 902
+                      MycoBankNr: 265045
+                    - Name: Aspergillus flavus
+                      ConceptType: Species
+                      ConceptId: 58206
+                      ConceptSource: MycoBank
+                      Id: 2480
+                      MycoBankNr: 209842
+                      Children:
+                      - Name: Aspergillus flavus var. oryzae
+                        ConceptType: Variety
+                        ConceptId: 161670
+                        ConceptSource: MycoBank
+                        Id: 3396
+                        MycoBankNr: 130238
+                        Synonyms:
+                        - Name: Aspergillus oryzae
+                          ConceptId: 46515
+                          ConceptSource: MycoBank
+                          Id: 2355
+                          MycoBankNr: 184394
+                    - Name: Aspergillus fumigatus
+                      ConceptType: Species
+                      ConceptId: 58207
+                      ConceptSource: MycoBank
+                      Id: 1717
+                      MycoBankNr: 211776
+                    - Name: Aspergillus glaucus
+                      ConceptType: Species
+                      ConceptId: 10039
+                      ConceptSource: MycoBank
+                      Id: 853
+                      MycoBankNr: 161735
+                    - Name: Aspergillus nidulans
+                      ConceptType: Species
+                      ConceptId: 9412
+                      ConceptSource: MycoBank
+                      Id: 2046
+                      MycoBankNr: 182069
+                    - Name: Aspergillus niger
+                      ConceptType: Species
+                      ConceptId: 2506
+                      ConceptSource: MycoBank
+                      Id: 2197
+                      MycoBankNr: 284309
+                    - Name: Aspergillus niveus
+                      ConceptType: Species
+                      ConceptId: 10320
+                      ConceptSource: MycoBank
+                      Id: 1694
+                      MycoBankNr: 272402
+                    - Name: Aspergillus ochraceus
+                      ConceptType: Species
+                      ConceptId: 2564
+                      ConceptSource: MycoBank
+                      Id: 664
+                      MycoBankNr: 190223
+                    - Name: Aspergillus parasiticus
+                      ConceptType: Species
+                      ConceptId: 2607
+                      ConceptSource: MycoBank
+                      Id: 2150
+                      MycoBankNr: 191085
+                    - Name: Aspergillus restrictus
+                      ConceptType: Species
+                      ConceptId: 2675
+                      ConceptSource: MycoBank
+                      Id: 1723
+                      MycoBankNr: 276290
+                    - Name: Aspergillus sydowii
+                      ConceptType: Species
+                      ConceptId: 2712
+                      ConceptSource: MycoBank
+                      Id: 2288
+                      MycoBankNr: 279636
+                    - Name: Aspergillus terreus
+                      ConceptType: Species
+                      ConceptId: 46516
+                      ConceptSource: MycoBank
+                      Id: 976
+                      MycoBankNr: 191719
+                    - Name: Aspergillus ustus
+                      ConceptType: Species
+                      ConceptId: 2771
+                      ConceptSource: MycoBank
+                      Id: 2314
+                      MycoBankNr: 281216
+                    - Name: Aspergillus versicolor
+                      ConceptType: Species
+                      ConceptId: 2780
+                      ConceptSource: MycoBank
+                      Id: 2188
+                      MycoBankNr: 172159
+                    - Name: Aspergillus wentii
+                      ConceptType: Species
+                      ConceptId: 2797
+                      ConceptSource: MycoBank
+                      Id: 868
+                      MycoBankNr: 172623
+                  - Name: Penicillium
+                    ConceptType: Genus
+                    ConceptId: 39268
+                    ConceptSource: MycoBank
+                    Id: 406
+                    MycoBankNr: 9257
+                    Children:
+                    - Name: Penicillium aurantiogriseum
+                      ConceptType: Species
+                      ConceptId: 58272
+                      ConceptSource: MycoBank
+                      MycoBankNr: 247956
+                      Children:
+                      - Name: Penicillium aurantiogriseum var. aurantiogriseum
+                        ConceptType: Variety
+                        ConceptId: 41785
+                        ConceptSource: MycoBank
+                        Id: 3399
+                        MycoBankNr: 418219
+                        Synonyms:
+                        - Name: Penicillium puberulum
+                          ConceptId: 19189
+                          ConceptSource: MycoBank
+                          Id: 2376
+                          MycoBankNr: 208565
+                    - Name: Penicillium commune
+                      ConceptType: Species
+                      ConceptId: 18729
+                      ConceptSource: MycoBank
+                      Id: 2327
+                      MycoBankNr: 164241
+                    - Name: Penicillium decumbens
+                      ConceptType: Species
+                      ConceptId: 18775
+                      ConceptSource: MycoBank
+                      Id: 2403
+                      MycoBankNr: 156582
+                    - Name: Penicillium expansum
+                      ConceptType: Species
+                      ConceptId: 18829
+                      ConceptSource: MycoBank
+                      Id: 1528
+                      MycoBankNr: 159382
+                    - Name: Penicillium griseofulvum
+                      ConceptType: Species
+                      ConceptId: 18901
+                      ConceptSource: MycoBank
+                      Id: 994
+                      MycoBankNr: 120566
+                      Synonyms:
+                      - Name: Penicillium patulum
+                        ConceptId: 18512
+                        ConceptSource: MycoBank
+                        Id: 2584
+                        MycoBankNr: 203666
+                    - Name: Penicillium spinulosum
+                      ConceptType: Species
+                      ConceptId: 19325
+                      ConceptSource: MycoBank
+                      Id: 2024
+                      MycoBankNr: 215401
+                    - Name: Penicillium viridicatum
+                      ConceptType: Species
+                      ConceptId: 19530
+                      ConceptSource: MycoBank
+                      Id: 958
+                      MycoBankNr: 163349
+                - Name: Thermoascaceae
+                  ConceptType: Family
+                  ConceptId: 433312
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81467
+                  Children:
+                  - Name: Paecilomyces
+                    ConceptType: Genus
+                    ConceptId: 38965
+                    ConceptSource: MycoBank
+                    Id: 1225
+                    MycoBankNr: 9196
+                    Children:
+                    - Name: Paecilomyces variotii
+                      ConceptType: Species
+                      ConceptId: 18284
+                      ConceptSource: MycoBank
+                      Id: 1343
+                      MycoBankNr: 248517
+                - Name: Trichocomaceae
+                  ConceptType: Family
+                  ConceptId: 93123
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81485
+                  Children:
+                  - Name: Neosartorya
+                    ConceptType: Genus
+                    ConceptId: 32101
+                    ConceptSource: MycoBank
+                    Id: 2564
+                    MycoBankNr: 3480
+                  - Name: Talaromyces
+                    ConceptType: Genus
+                    ConceptId: 45965
+                    ConceptSource: MycoBank
+                    Id: 1452
+                    MycoBankNr: 5347
+                    Children:
+                    - Name: Talaromyces marneffei
+                      ConceptType: Species
+                      ConceptId: 480567
+                      ConceptSource: MycoBank
+                      Id: 171
+                      MycoBankNr: 560656
+                      Synonyms:
+                      - Name: Penicillium marneffei
+                        ConceptId: 19064
+                        ConceptSource: MycoBank
+                        Id: 1516
+                        MycoBankNr: 335749
+                    - Name: Talaromyces ruber
+                      ConceptType: Species
+                      ConceptId: 508894
+                      ConceptSource: MycoBank
+                      Id: 178
+                      MycoBankNr: 801360
+                      Synonyms:
+                      - Name: Penicillium rubrum
+                        ConceptId: 19253
+                        ConceptSource: MycoBank
+                        Id: 1794
+                        MycoBankNr: 205727
+                    - Name: Talaromyces verruculosus
+                      ConceptType: Species
+                      ConceptId: 480589
+                      ConceptSource: MycoBank
+                      Id: 3353
+                      MycoBankNr: 560678
+                      Synonyms:
+                      - Name: Penicillium verruculosum
+                        ConceptId: 19515
+                        ConceptSource: MycoBank
+                        Id: 547
+                        MycoBankNr: 166576
+              - Name: Onygenales
+                ConceptType: Order
+                ConceptId: 92495
+                ConceptSource: MycoBank
+                MycoBankNr: 90487
+                Children:
+                - Name: Ajellomycetaceae
+                  ConceptType: Family
+                  ConceptId: 436080
+                  ConceptSource: MycoBank
+                  MycoBankNr: 82148
+                  Children:
+                  - Name: Emmonsia
+                    ConceptType: Genus
+                    ConceptId: 50291
+                    ConceptSource: MycoBank
+                    Id: 1116
+                    MycoBankNr: 8151
+                  - Name: Loboa
+                    ConceptType: Genus
+                    ConceptId: 96148
+                    ConceptSource: MycoBank
+                    Id: 589
+                    MycoBankNr: 20311
+                - Name: Arthrodermataceae
+                  ConceptType: Family
+                  ConceptId: 92643
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80476
+                  Children:
+                  - Name: Arthroderma
+                    ConceptType: Genus
+                    ConceptId: 56099
+                    ConceptSource: MycoBank
+                    Id: 1332
+                    MycoBankNr: 335
+                  - Name: Microsporon
+                    ConceptType: Genus
+                    ConceptId: 60028
+                    ConceptSource: MycoBank
+                    MycoBankNr: 39188
+                    Children:
+                    - Name: Microsporon brachytomum
+                      ConceptType: Species
+                      ConceptId: 466190
+                      ConceptSource: MycoBank
+                      Id: 3408
+                      MycoBankNr: 528372
+                      Synonyms:
+                      - Name: Microsporum brachytomum
+                        ConceptId: 125267
+                        ConceptSource: MycoBank
+                        Id: 2326
+                        MycoBankNr: 102029
+                  - Name: Microsporum
+                    ConceptType: Genus
+                    ConceptId: 37615
+                    ConceptSource: MycoBank
+                    Id: 410
+                    MycoBankNr: 8939
+                    Children:
+                    - Name: Microsporum canis
+                      ConceptType: Species
+                      ConceptId: 15421
+                      ConceptSource: MycoBank
+                      Id: 2807
+                      MycoBankNr: 160689
+                  - Name: Nannizzia
+                    ConceptType: Genus
+                    ConceptId: 57825
+                    ConceptSource: MycoBank
+                    Id: 2054
+                    MycoBankNr: 3420
+                  - Name: Trichophyton
+                    ConceptType: Genus
+                    ConceptId: 38248
+                    ConceptSource: MycoBank
+                    Id: 280
+                    MycoBankNr: 10292
+                - Name: Malbrancheaceae
+                  ConceptType: Family
+                  ConceptId: 592988
+                  ConceptSource: MycoBank
+                  MycoBankNr: 843372
+                  Children:
+                  - Name: Malbranchea
+                    ConceptType: Genus
+                    ConceptId: 39926
+                    ConceptSource: MycoBank
+                    Id: 1373
+                    MycoBankNr: 8833
+                - Name: Onygenaceae
+                  ConceptType: Family
+                  ConceptId: 594428
+                  ConceptSource: MycoBank
+                  MycoBankNr: 90950
+                  Children:
+                  - Name: Chrysosporium
+                    ConceptType: Genus
+                    ConceptId: 33452
+                    ConceptSource: MycoBank
+                    Id: 1457
+                    MycoBankNr: 7645
+          - Name: Leotiomycetes
+            ConceptType: Class
+            ConceptId: 431006
+            ConceptSource: MycoBank
+            MycoBankNr: 501487
+            Children:
+            - Name: Glenosporella
+              ConceptType: Genus
+              ConceptId: 58013
+              ConceptSource: MycoBank
+              Id: 1820
+              MycoBankNr: 8336
+            - Name: Leotiomycetidae
+              ConceptType: Subclass
+              ConceptId: 92404
+              ConceptSource: MycoBank
+              MycoBankNr: 90517
+              Children:
+              - Name: Helotiales
+                ConceptType: Order
+                ConceptId: 92463
+                ConceptSource: MycoBank
+                MycoBankNr: 90476
+                Children:
+                - Name: Scytalidium
+                  ConceptType: Genus
+                  ConceptId: 39013
+                  ConceptSource: MycoBank
+                  Id: 326
+                  MycoBankNr: 9862
+              - Name: Myxotrichaceae
+                ConceptType: Family
+                ConceptId: 92966
+                ConceptSource: MycoBank
+                MycoBankNr: 81054
+                Children:
+                - Name: Oidiodendron
+                  ConceptType: Genus
+                  ConceptId: 39757
+                  ConceptSource: MycoBank
+                  Id: 2108
+                  MycoBankNr: 9141
+          - Name: Sordariomycetes
+            ConceptType: Class
+            ConceptId: 374831
+            ConceptSource: MycoBank
+            MycoBankNr: 90350
+            Children:
+            - Name: Diaporthomycetidae
+              ConceptType: Subclass
+              ConceptId: 547310
+              ConceptSource: MycoBank
+              MycoBankNr: 551051
+              Children:
+              - Name: Calosphaeriales
+                ConceptType: Order
+                ConceptId: 92431
+                ConceptSource: MycoBank
+                MycoBankNr: 90463
+                Children:
+                - Name: Pleurostomataceae
+                  ConceptType: Family
+                  ConceptId: 214418
+                  ConceptSource: MycoBank
+                  MycoBankNr: 500153
+                  Children:
+                  - Name: Pleurostoma
+                    ConceptType: Genus
+                    ConceptId: 97380
+                    ConceptSource: MycoBank
+                    Id: 3379
+                    MycoBankNr: 4247
+                    Children:
+                    - Name: Pleurostoma richardsiae
+                      ConceptType: Species
+                      ConceptId: 545813
+                      ConceptSource: MycoBank
+                      Id: 3397
+                      MycoBankNr: 814423
+                      Synonyms:
+                      - Name: Phialophora richardsiae
+                        ConceptId: 20719
+                        ConceptSource: MycoBank
+                        Id: 2331
+                        MycoBankNr: 276522
+                      - Name: Pleurostomophora richardsiae
+                        ConceptId: 214323
+                        ConceptSource: MycoBank
+                        Id: 1189
+                        MycoBankNr: 500098
+                    Synonyms:
+                    - Name: Pleurostomophora
+                      ConceptId: 120662
+                      ConceptSource: MycoBank
+                      Id: 2215
+                      MycoBankNr: 500095
+              - Name: Diaporthales
+                ConceptType: Order
+                ConceptId: 92439
+                ConceptSource: MycoBank
+                MycoBankNr: 90468
+                Children:
+                - Name: Botryodiplodia
+                  ConceptType: Genus
+                  ConceptId: 32407
+                  ConceptSource: MycoBank
+                  Id: 1714
+                  MycoBankNr: 7420
+            - Name: Hypocreomycetidae
+              ConceptType: Subclass
+              ConceptId: 431013
+              ConceptSource: MycoBank
+              MycoBankNr: 501501
+              Children:
+              - Name: Hypocreales
+                ConceptType: Order
+                ConceptId: 92466
+                ConceptSource: MycoBank
+                MycoBankNr: 90477
+                Children:
+                - Name: Bionectriaceae
+                  ConceptType: Family
+                  ConceptId: 92705
+                  ConceptSource: MycoBank
+                  MycoBankNr: 82088
+                  Children:
+                  - Name: Acremonium
+                    ConceptType: Genus
+                    ConceptId: 31504
+                    ConceptSource: MycoBank
+                    Id: 105
+                    MycoBankNr: 7028
+                    Children:
+                    - Name: Acremonium alabamense
+                      ConceptType: Species
+                      ConceptId: 36691
+                      ConceptSource: MycoBank
+                      Id: 2698
+                      MycoBankNr: 308114
+                      Synonyms:
+                      - Name: Acremonium alabamensis
+                        ConceptId: "29"
+                        ConceptSource: NeoIPC
+                        Id: 2699
+                    - Name: Acremonium potronii
+                      ConceptType: Species
+                      ConceptId: 481
+                      ConceptSource: MycoBank
+                      Id: 2301
+                      MycoBankNr: 248620
+                - Name: Cephalosporium
+                  ConceptType: Genus
+                  ConceptId: 56233
+                  ConceptSource: MycoBank
+                  Id: 1231
+                  MycoBankNr: 7525
+                - Name: Clavicipitaceae
+                  ConceptType: Family
+                  ConceptId: 92746
+                  ConceptSource: MycoBank
+                  MycoBankNr: 82061
+                  Children:
+                  - Name: Marquandomyces
+                    ConceptType: Genus
+                    ConceptId: 579534
+                    ConceptSource: MycoBank
+                    MycoBankNr: 834879
+                    Children:
+                    - Name: Marquandomyces marquandii
+                      ConceptType: Species
+                      ConceptId: 579535
+                      ConceptSource: MycoBank
+                      Id: 3410
+                      MycoBankNr: 834880
+                      Synonyms:
+                      - Name: Paecilomyces marquandii
+                        ConceptId: 18258
+                        ConceptSource: MycoBank
+                        Id: 1268
+                        MycoBankNr: 302194
+                  - Name: Metarhizium
+                    ConceptType: Genus
+                    ConceptId: 56923
+                    ConceptSource: MycoBank
+                    Id: 859
+                    MycoBankNr: 8912
+                    Children:
+                    - Name: Metarhizium anisopliae
+                      ConceptType: Species
+                      ConceptId: 58257
+                      ConceptSource: MycoBank
+                      Id: 421
+                      MycoBankNr: 101834
+                - Name: Cordycipitaceae
+                  ConceptType: Family
+                  ConceptId: 438410
+                  ConceptSource: MycoBank
+                  MycoBankNr: 504360
+                  Children:
+                  - Name: Beauveria
+                    ConceptType: Genus
+                    ConceptId: 40377
+                    ConceptSource: MycoBank
+                    Id: 141
+                    MycoBankNr: 7346
+                    Children:
+                    - Name: Beauveria bassiana
+                      ConceptType: Species
+                      ConceptId: 3049
+                      ConceptSource: MycoBank
+                      Id: 1012
+                      MycoBankNr: 199430
+                  - Name: Cordyceps
+                    ConceptType: Genus
+                    ConceptId: 56340
+                    ConceptSource: MycoBank
+                    MycoBankNr: 1240
+                    Children:
+                    - Name: Cordyceps javanica
+                      ConceptType: Species
+                      ConceptId: 559258
+                      ConceptSource: MycoBank
+                      Id: 3363
+                      MycoBankNr: 820982
+                      Synonyms:
+                      - Name: Paecilomyces javanicus
+                        ConceptId: 18240
+                        ConceptSource: MycoBank
+                        Id: 2398
+                        MycoBankNr: 302192
+                - Name: Hypocreaceae
+                  ConceptType: Family
+                  ConceptId: 92878
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80892
+                  Children:
+                  - Name: Aleurisma
+                    ConceptType: Genus
+                    ConceptId: 57736
+                    ConceptSource: MycoBank
+                    Id: 1764
+                    MycoBankNr: 7087
+                  - Name: Hypomyces
+                    ConceptType: Genus
+                    ConceptId: 36252
+                    ConceptSource: MycoBank
+                    Id: 3548
+                    MycoBankNr: 2446
+                    Synonyms:
+                    - Name: Sepedonium
+                      ConceptId: 38502
+                      ConceptSource: MycoBank
+                      Id: 1845
+                      MycoBankNr: 9876
+                  - Name: Sphaerostilbella
+                    ConceptType: Genus
+                    ConceptId: 57412
+                    ConceptSource: MycoBank
+                    Id: 3500
+                    MycoBankNr: 5122
+                    Synonyms:
+                    - Name: Gliocladium
+                      ConceptId: 39109
+                      ConceptSource: MycoBank
+                      Id: 102
+                      MycoBankNr: 8342
+                - Name: Myrotheciomycetaceae
+                  ConceptType: Family
+                  ConceptId: 566234
+                  ConceptSource: MycoBank
+                  MycoBankNr: 825408
+                  Children:
+                  - Name: Trichothecium
+                    ConceptType: Genus
+                    ConceptId: 39105
+                    ConceptSource: MycoBank
+                    Id: 1154
+                    MycoBankNr: 10303
+                - Name: Nectriaceae
+                  ConceptType: Family
+                  ConceptId: 92969
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81059
+                  Children:
+                  - Name: Bisifusarium
+                    ConceptType: Genus
+                    ConceptId: 541360
+                    ConceptSource: MycoBank
+                    MycoBankNr: 810226
+                    Children:
+                    - Name: Bisifusarium dimerum
+                      ConceptType: Species
+                      ConceptId: 541363
+                      ConceptSource: MycoBank
+                      Id: 3372
+                      MycoBankNr: 810229
+                      Synonyms:
+                      - Name: Fusarium dimerum
+                        ConceptId: 55325
+                        ConceptSource: MycoBank
+                        Id: 1113
+                        MycoBankNr: 232481
+                  - Name: Fusarium
+                    ConceptType: Genus
+                    ConceptId: 41506
+                    ConceptSource: MycoBank
+                    Id: 846
+                    MycoBankNr: 8284
+                    Children:
+                    - Name: Fusarium chlamydosporum
+                      ConceptType: Species
+                      ConceptId: 58238
+                      ConceptSource: MycoBank
+                      Id: 931
+                      MycoBankNr: 260522
+                      Synonyms:
+                      - Name: Fusarium sporotrichioides
+                        ConceptId: 46575
+                        ConceptSource: MycoBank
+                        Id: 670
+                        MycoBankNr: 145064
+                    - Name: Fusarium culmorum
+                      ConceptType: Species
+                      ConceptId: 10595
+                      ConceptSource: MycoBank
+                      Id: 2696
+                      MycoBankNr: 196997
+                    - Name: Fusarium graminearum
+                      ConceptType: Species
+                      ConceptId: 10665
+                      ConceptSource: MycoBank
+                      Id: 308
+                      MycoBankNr: 200256
+                    - Name: Fusarium incarnatum
+                      ConceptType: Species
+                      ConceptId: 46989
+                      ConceptSource: MycoBank
+                      Id: 2960
+                      MycoBankNr: 231142
+                      Synonyms:
+                      - Name: Fusarium semitectum
+                        ConceptId: 58242
+                        ConceptSource: MycoBank
+                        Id: 2102
+                        MycoBankNr: 179598
+                    - Name: Fusarium javanicum
+                      ConceptType: Species
+                      ConceptId: 10690
+                      ConceptSource: MycoBank
+                      Id: 1045
+                      MycoBankNr: 231015
+                    - Name: Fusarium oxysporum
+                      ConceptType: Species
+                      ConceptId: 10756
+                      ConceptSource: MycoBank
+                      Id: 301
+                      MycoBankNr: 218372
+                    - Name: Fusarium poae
+                      ConceptType: Species
+                      ConceptId: 10896
+                      ConceptSource: MycoBank
+                      Id: 1631
+                      MycoBankNr: 119380
+                    - Name: Fusarium tricinctum
+                      ConceptType: Species
+                      ConceptId: 11074
+                      ConceptSource: MycoBank
+                      Id: 694
+                      MycoBankNr: 142388
+                    - Name: Fusarium verticillioides
+                      ConceptType: Species
+                      ConceptId: 11090
+                      ConceptSource: MycoBank
+                      Id: 205
+                      MycoBankNr: 314223
+                  - Name: Xenoacremonium
+                    ConceptType: Genus
+                    ConceptId: 541404
+                    ConceptSource: MycoBank
+                    MycoBankNr: 810270
+                    Children:
+                    - Name: Xenoacremonium recifei
+                      ConceptType: Species
+                      ConceptId: 541406
+                      ConceptSource: MycoBank
+                      Id: 3401
+                      MycoBankNr: 810272
+                      Synonyms:
+                      - Name: Acremonium recifei
+                        ConceptId: 499
+                        ConceptSource: MycoBank
+                        Id: 1064
+                        MycoBankNr: 308188
+                      - Name: Cephalosporium recifei
+                        ConceptId: 32557
+                        ConceptSource: MycoBank
+                        Id: 628
+                        MycoBankNr: 254337
+                - Name: Ophiocordycipitaceae
+                  ConceptType: Family
+                  ConceptId: 438239
+                  ConceptSource: MycoBank
+                  MycoBankNr: 504190
+                  Children:
+                  - Name: Purpureocillium
+                    ConceptType: Genus
+                    ConceptId: 475160
+                    ConceptSource: MycoBank
+                    MycoBankNr: 519529
+                    Children:
+                    - Name: Purpureocillium lilacinum
+                      ConceptType: Species
+                      ConceptId: 475162
+                      ConceptSource: MycoBank
+                      Id: 3366
+                      MycoBankNr: 519530
+                      Synonyms:
+                      - Name: Paecilomyces lilacinus
+                        ConceptId: 18249
+                        ConceptSource: MycoBank
+                        Id: 1290
+                        MycoBankNr: 319114
+                      - Name: Penicillium lilacinum
+                        ConceptId: 19018
+                        ConceptSource: MycoBank
+                        Id: 2550
+                        MycoBankNr: 178973
+                - Name: Sarocladiaceae
+                  ConceptType: Family
+                  ConceptId: 569616
+                  ConceptSource: MycoBank
+                  MycoBankNr: 828245
+                  Children:
+                  - Name: Sarocladium
+                    ConceptType: Genus
+                    ConceptId: 39804
+                    ConceptSource: MycoBank
+                    MycoBankNr: 9790
+                    Children:
+                    - Name: Sarocladium kiliense
+                      ConceptType: Species
+                      ConceptId: 475269
+                      ConceptSource: MycoBank
+                      Id: 3382
+                      MycoBankNr: 519592
+                      Synonyms:
+                      - Name: Acremonium kiliense
+                        ConceptId: 398
+                        ConceptSource: MycoBank
+                        Id: 96
+                        MycoBankNr: 252874
+                    - Name: Sarocladium strictum
+                      ConceptType: Species
+                      ConceptId: 475271
+                      ConceptSource: MycoBank
+                      Id: 3384
+                      MycoBankNr: 519594
+                      Synonyms:
+                      - Name: Acremonium strictum
+                        ConceptId: 546
+                        ConceptSource: MycoBank
+                        Id: 2154
+                        MycoBankNr: 308201
+                - Name: Stachybotryaceae
+                  ConceptType: Family
+                  ConceptId: 545975
+                  ConceptSource: MycoBank
+                  MycoBankNr: 90922
+                  Children:
+                  - Name: Stachybotrys
+                    ConceptType: Genus
+                    ConceptId: 38058
+                    ConceptSource: MycoBank
+                    Id: 2030
+                    MycoBankNr: 10052
+                    Children:
+                    - Name: Stachybotrys chartarum
+                      ConceptType: Species
+                      ConceptId: 26245
+                      ConceptSource: MycoBank
+                      Id: 1134
+                      MycoBankNr: 306362
+              - Name: Microascales
+                ConceptType: Order
+                ConceptId: 92480
+                ConceptSource: MycoBank
+                MycoBankNr: 90484
+                Children:
+                - Name: Graphiaceae
+                  ConceptType: Family
+                  ConceptId: 602581
+                  ConceptSource: MycoBank
+                  MycoBankNr: 559717
+                  Children:
+                  - Name: Graphium
+                    ConceptType: Genus
+                    ConceptId: 39107
+                    ConceptSource: MycoBank
+                    Id: 203
+                    MycoBankNr: 8398
+                - Name: Microascaceae
+                  ConceptType: Family
+                  ConceptId: 92939
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81001
+                  Children:
+                  - Name: Acaulium
+                    ConceptType: Genus
+                    ConceptId: 57955
+                    ConceptSource: MycoBank
+                    MycoBankNr: 7011
+                    Children:
+                    - Name: Acaulium acremonium
+                      ConceptType: Species
+                      ConceptId: 545964
+                      ConceptSource: MycoBank
+                      Id: 3370
+                      MycoBankNr: 814571
+                      Synonyms:
+                      - Name: Scopulariopsis acremonium
+                        ConceptId: 25115
+                        ConceptSource: MycoBank
+                        Id: 2092
+                        MycoBankNr: 101682
+                  - Name: Lomentospora
+                    ConceptType: Genus
+                    ConceptId: 39517
+                    ConceptSource: MycoBank
+                    MycoBankNr: 8790
+                    Children:
+                    - Name: Lomentospora prolificans
+                      ConceptType: Species
+                      ConceptId: 14642
+                      ConceptSource: MycoBank
+                      Id: 3547
+                      MycoBankNr: 316957
+                      Synonyms:
+                      - Name: Scedosporium inflatum
+                        ConceptId: 41883
+                        ConceptSource: MycoBank
+                        Id: 1506
+                        MycoBankNr: 106457
+                      - Name: Scedosporium prolificans
+                        ConceptId: 45225
+                        ConceptSource: MycoBank
+                        Id: 2547
+                        MycoBankNr: 128175
+                  - Name: Microascus
+                    ConceptType: Genus
+                    ConceptId: 44790
+                    ConceptSource: MycoBank
+                    MycoBankNr: 3153
+                    Children:
+                    - Name: Microascus paisii
+                      ConceptType: Species
+                      ConceptId: 522353
+                      ConceptSource: MycoBank
+                      Id: 3355
+                      MycoBankNr: 809213
+                      Synonyms:
+                      - Name: Scopulariopsis brumptii
+                        ConceptId: 25141
+                        ConceptSource: MycoBank
+                        Id: 463
+                        MycoBankNr: 251112
+                  - Name: Scedosporium
+                    ConceptType: Genus
+                    ConceptId: 38473
+                    ConceptSource: MycoBank
+                    Id: 642
+                    MycoBankNr: 9794
+                    Children:
+                    - Name: Scedosporium apiospermum
+                      ConceptType: Species
+                      ConceptId: 24758
+                      ConceptSource: MycoBank
+                      Id: 1795
+                      MycoBankNr: 432048
+                      Synonyms:
+                      - Name: Aleurisma apiospermum
+                        ConceptId: 221047
+                        ConceptSource: MycoBank
+                        Id: 1718
+                        MycoBankNr: 250730
+                      - Name: Monosporium apiospermum
+                        ConceptId: 15801
+                        ConceptSource: MycoBank
+                        Id: 1468
+                        MycoBankNr: 144739
+                    - Name: Scedosporium boydii
+                      ConceptType: Species
+                      ConceptId: 469382
+                      ConceptSource: MycoBank
+                      Id: 145
+                      MycoBankNr: 538387
+                      Synonyms:
+                      - Name: Acladium castellanii
+                        ConceptId: 217
+                        ConceptSource: MycoBank
+                        Id: 2179
+                        MycoBankNr: 120097
+                      - Name: Allescheria boydii
+                        ConceptId: 884
+                        ConceptSource: MycoBank
+                        Id: 683
+                        MycoBankNr: 258760
+                      - Name: Petriellidium boydii
+                        ConceptId: 20053
+                        ConceptSource: MycoBank
+                        Id: 1602
+                        MycoBankNr: 319444
+                      - Name: Pseudallescheria boydii
+                        ConceptId: 20052
+                        ConceptSource: MycoBank
+                        Id: 657
+                        MycoBankNr: 110950
+                    Synonyms:
+                    - Name: Pseudallescheria
+                      ConceptId: 37160
+                      ConceptSource: MycoBank
+                      Id: 1533
+                      MycoBankNr: 4403
+                  - Name: Scopulariopsis
+                    ConceptType: Genus
+                    ConceptId: 39195
+                    ConceptSource: MycoBank
+                    Id: 2304
+                    MycoBankNr: 9854
+                    Children:
+                    - Name: Scopulariopsis brevicaulis
+                      ConceptType: Species
+                      ConceptId: 25133
+                      ConceptSource: MycoBank
+                      Id: 598
+                      MycoBankNr: 154310
+                    - Name: Scopulariopsis candida
+                      ConceptType: Species
+                      ConceptId: 15327
+                      ConceptSource: MycoBank
+                      Id: 2184
+                      MycoBankNr: 120077
+              - Name: Trichosphaeriales
+                ConceptType: Order
+                ConceptId: 92536
+                ConceptSource: MycoBank
+                MycoBankNr: 90503
+                Children:
+                - Name: Trichosphaeriaceae
+                  ConceptType: Family
+                  ConceptId: 93124
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81492
+                  Children:
+                  - Name: Verticillium
+                    ConceptType: Genus
+                    ConceptId: 39170
+                    ConceptSource: MycoBank
+                    Id: 358
+                    MycoBankNr: 10400
+            - Name: Sordariomycetidae
+              ConceptType: Subclass
+              ConceptId: 92411
+              ConceptSource: MycoBank
+              MycoBankNr: 90351
+              Children:
+              - Name: Cephalothecales
+                ConceptType: Order
+                ConceptId: 578001
+                ConceptSource: MycoBank
+                MycoBankNr: 556994
+                Children:
+                - Name: Cephalothecaceae
+                  ConceptType: Family
+                  ConceptId: 92728
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80571
+                  Children:
+                  - Name: Phialemonium
+                    ConceptType: Genus
+                    ConceptId: 39362
+                    ConceptSource: MycoBank
+                    Id: 272
+                    MycoBankNr: 11160
+                    Children:
+                    - Name: Phialemonium dimorphosporum
+                      ConceptType: Species
+                      ConceptId: 20537
+                      ConceptSource: MycoBank
+                      Id: 1439
+                      MycoBankNr: 108342
+                    - Name: Phialemonium obovatum
+                      ConceptType: Species
+                      ConceptId: 20540
+                      ConceptSource: MycoBank
+                      Id: 429
+                      MycoBankNr: 108343
+              - Name: Coniochaetales
+                ConceptType: Order
+                ConceptId: 431027
+                ConceptSource: MycoBank
+                MycoBankNr: 501515
+                Children:
+                - Name: Coniochaetaceae
+                  ConceptType: Family
+                  ConceptId: 92758
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80629
+                  Children:
+                  - Name: Coniochaeta
+                    ConceptType: Genus
+                    ConceptId: 33734
+                    ConceptSource: MycoBank
+                    Id: 3352
+                    MycoBankNr: 1209
+                    Children:
+                    - Name: Coniochaeta hoffmannii
+                      ConceptType: Species
+                      ConceptId: 510991
+                      ConceptSource: MycoBank
+                      Id: 3354
+                      MycoBankNr: 803421
+                      Synonyms:
+                      - Name: Lecythophora hoffmannii
+                        ConceptId: 20639
+                        ConceptSource: MycoBank
+                        Id: 1608
+                        MycoBankNr: 108133
+                      - Name: Phialophora hoffmannii
+                        ConceptId: 20638
+                        ConceptSource: MycoBank
+                        Id: 1309
+                        MycoBankNr: 319847
+                    - Name: Coniochaeta mutabilis
+                      ConceptType: Species
+                      ConceptId: 510989
+                      ConceptSource: MycoBank
+                      Id: 3368
+                      MycoBankNr: 803419
+                      Synonyms:
+                      - Name: Lecythophora mutabilis
+                        ConceptId: 20677
+                        ConceptSource: MycoBank
+                        Id: 1957
+                        MycoBankNr: 108134
+                    Synonyms:
+                    - Name: Lecythophora
+                      ConceptId: 39256
+                      ConceptSource: MycoBank
+                      Id: 1519
+                      MycoBankNr: 8721
+              - Name: Ophiostomatales
+                ConceptType: Order
+                ConceptId: 92496
+                ConceptSource: MycoBank
+                MycoBankNr: 90489
+                Children:
+                - Name: Ophiostomataceae
+                  ConceptType: Family
+                  ConceptId: 92985
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81089
+                  Children:
+                  - Name: Sporothrix
+                    ConceptType: Genus
+                    ConceptId: 39097
+                    ConceptSource: MycoBank
+                    Id: 478
+                    MycoBankNr: 10046
+                    Children:
+                    - Name: Sporothrix schenckii
+                      ConceptType: Species
+                      ConceptId: 46675
+                      ConceptSource: MycoBank
+                      Id: 1408
+                      MycoBankNr: 101184
+                      Synonyms:
+                      - Name: Sporotrichum beurmannii
+                        ConceptId: 26213
+                        ConceptSource: MycoBank
+                        Id: 1105
+                        MycoBankNr: 164415
+                      - Name: Sporotrichum schenckii
+                        ConceptId: 26234
+                        ConceptSource: MycoBank
+                        Id: 856
+                        MycoBankNr: 203728
+              - Name: Sordariales
+                ConceptType: Order
+                ConceptId: 92684
+                ConceptSource: MycoBank
+                MycoBankNr: 90499
+                Children:
+                - Name: Chaetomiaceae
+                  ConceptType: Family
+                  ConceptId: 92736
+                  ConceptSource: MycoBank
+                  MycoBankNr: 80582
+                  Children:
+                  - Name: Amesia
+                    ConceptType: Genus
+                    ConceptId: 556080
+                    ConceptSource: MycoBank
+                    MycoBankNr: 818829
+                    Children:
+                    - Name: Amesia atrobrunnea
+                      ConceptType: Species
+                      ConceptId: 556088
+                      ConceptSource: MycoBank
+                      Id: 3383
+                      MycoBankNr: 818832
+                      Synonyms:
+                      - Name: Chaetomium atrobrunneum
+                        ConceptId: 4409
+                        ConceptSource: MycoBank
+                        Id: 281
+                        MycoBankNr: 294685
+                  - Name: Chaetomium
+                    ConceptType: Genus
+                    ConceptId: 32766
+                    ConceptSource: MycoBank
+                    Id: 2575
+                    MycoBankNr: 953
+                    Children:
+                    - Name: Chaetomium globosum
+                      ConceptType: Species
+                      ConceptId: 4592
+                      ConceptSource: MycoBank
+                      Id: 1732
+                      MycoBankNr: 172545
+                - Name: Madurella
+                  ConceptType: Genus
+                  ConceptId: 44870
+                  ConceptSource: MycoBank
+                  Id: 2303
+                  MycoBankNr: 8824
+                  Children:
+                  - Name: Madurella mycetomatis
+                    ConceptType: Species
+                    ConceptId: 462033
+                    ConceptSource: MycoBank
+                    Id: 1627
+                    MycoBankNr: 535193
+                    Synonyms:
+                    - Name: Madurella mycetomi
+                      ConceptId: 14825
+                      ConceptSource: MycoBank
+                      Id: 513
+                      MycoBankNr: 119292
+              - Name: Thyridiaceae
+                ConceptType: Family
+                ConceptId: 93118
+                ConceptSource: MycoBank
+                MycoBankNr: 82030
+                Children:
+                - Name: Thyridium
+                  ConceptType: Genus
+                  ConceptId: 57516
+                  ConceptSource: MycoBank
+                  MycoBankNr: 5465
+                  Children:
+                  - Name: Thyridium curvatum
+                    ConceptType: Species
+                    ConceptId: 589917
+                    ConceptSource: MycoBank
+                    Id: 3373
+                    MycoBankNr: 841921
+                    Synonyms:
+                    - Name: Phialemonium curvatum
+                      ConceptId: 20531
+                      ConceptSource: MycoBank
+                      Id: 1648
+                      MycoBankNr: 108341
+              - Name: Togniniales
+                ConceptType: Order
+                ConceptId: 547334
+                ConceptSource: MycoBank
+                MycoBankNr: 551049
+                Children:
+                - Name: Togniniaceae
+                  ConceptType: Family
+                  ConceptId: 214419
+                  ConceptSource: MycoBank
+                  MycoBankNr: 500154
+                  Children:
+                  - Name: Phaeoacremonium
+                    ConceptType: Genus
+                    ConceptId: 48263
+                    ConceptSource: MycoBank
+                    Id: 2091
+                    MycoBankNr: 27679
+                    Children:
+                    - Name: Phaeoacremonium parasiticum
+                      ConceptType: Species
+                      ConceptId: 48691
+                      ConceptSource: MycoBank
+                      Id: 891
+                      MycoBankNr: 415651
+            - Name: Xylariomycetidae
+              ConceptType: Subclass
+              ConceptId: 432191
+              ConceptSource: MycoBank
+              MycoBankNr: 501509
+              Children:
+              - Name: Xylariales
+                ConceptType: Order
+                ConceptId: 92543
+                ConceptSource: MycoBank
+                MycoBankNr: 90505
+                Children:
+                - Name: Apiosporaceae
+                  ConceptType: Family
+                  ConceptId: 92635
+                  ConceptSource: MycoBank
+                  MycoBankNr: 81935
+                  Children:
+                  - Name: Nigrospora
+                    ConceptType: Genus
+                    ConceptId: 57028
+                    ConceptSource: MycoBank
+                    Id: 660
+                    MycoBankNr: 9124
+        - Name: Saccharomycotina
+          ConceptType: Subphylum
+          ConceptId: 430999
+          ConceptSource: MycoBank
+          Id: 3426
+          MycoBankNr: 501470
+          Children:
+          - Name: Dipodascomycetes
+            ConceptType: Class
+            ConceptId: 598941
+            ConceptSource: MycoBank
+            Id: 3446
+            MycoBankNr: 847281
+            Children:
+            - Name: Dipodascales
+              ConceptType: Order
+              ConceptId: 598942
+              ConceptSource: MycoBank
+              Id: 3445
+              MycoBankNr: 847282
+              Children:
+              - Name: Dipodascaceae
+                ConceptType: Family
+                ConceptId: 92786
+                ConceptSource: MycoBank
+                MycoBankNr: 80709
+                Children:
+                - Name: Geotrichum
+                  ConceptType: Genus
+                  ConceptId: 39099
+                  ConceptSource: MycoBank
+                  Id: 2111
+                  MycoBankNr: 8327
+                  Children:
+                  - Name: Geotrichum candidum
+                    ConceptType: Species
+                    ConceptId: 11454
+                    ConceptSource: MycoBank
+                    Id: 398
+                    MycoBankNr: 182997
+                  - Name: Geotrichum klebahnii
+                    ConceptType: Species
+                    ConceptId: 11513
+                    ConceptSource: MycoBank
+                    Id: 2510
+                    MycoBankNr: 331261
+                    Synonyms:
+                    - Name: Dipodascus klebahnii
+                      ConceptId: 560606
+                      ConceptSource: MycoBank
+                      Id: 3405
+                      MycoBankNr: 551674
+                    - Name: Geotrichum penicillatum
+                      ConceptId: 11518
+                      ConceptSource: MycoBank
+                      Id: 1947
+                      MycoBankNr: 314421
+                    - Name: Trichosporon penicillatum
+                      ConceptId: 27987
+                      ConceptSource: MycoBank
+                      Id: 220
+                      MycoBankNr: 340426
+                - Name: Magnusiomyces
+                  ConceptType: Genus
+                  ConceptId: 101344
+                  ConceptSource: MycoBank
+                  Id: 3482
+                  MycoBankNr: 2978
+                  Synonyms:
+                  - Name: Blastoschizomyces
+                    ConceptId: 57972
+                    ConceptSource: MycoBank
+                    Id: 2182
+                    MycoBankNr: 7395
+              - Name: Trichomonascaceae
+                ConceptType: Family
+                ConceptId: 453898
+                ConceptSource: MycoBank
+                Id: 3444
+                MycoBankNr: 530082
+                Children:
+                - Name: Blastobotrys
+                  ConceptType: Genus
+                  ConceptId: 32381
+                  ConceptSource: MycoBank
+                  Id: 3551
+                  MycoBankNr: 7384
+                  Synonyms:
+                  - Name: Stephanoascus
+                    ConceptId: 57447
+                    ConceptSource: MycoBank
+                    Id: 364
+                    MycoBankNr: 5209
+                - Name: Trichomonascus
+                  ConceptType: Genus
+                  ConceptId: 98719
+                  ConceptSource: MycoBank
+                  MycoBankNr: 5562
+                  Children:
+                  - Name: Trichomonascus ciferrii
+                    ConceptType: Species
+                    ConceptId: 454883
+                    ConceptSource: MycoBank
+                    Id: 3371
+                    MycoBankNr: 530083
+                    Synonyms:
+                    - Name: Candida ciferrii
+                      ConceptId: 105098
+                      ConceptSource: MycoBank
+                      Id: 1889
+                      MycoBankNr: 327426
+                    - Name: Stephanoascus ciferrii
+                      ConceptId: 43058
+                      ConceptSource: MycoBank
+                      Id: 2259
+                      MycoBankNr: 324077
+                - Name: Wickerhamiella
+                  ConceptType: Genus
+                  ConceptId: 98948
+                  ConceptSource: MycoBank
+                  Id: 3443
+                  MycoBankNr: 5778
+                  Children:
+                  - Name: Wickerhamiella pararugosa
+                    ConceptType: Species
+                    ConceptId: 551016
+                    ConceptSource: MycoBank
+                    Id: 3442
+                    MycoBankNr: 815736
+                    Synonyms:
+                    - Name: Candida pararugosa
+                      ConceptId: 105269
+                      ConceptSource: MycoBank
+                      Id: 1055
+                      MycoBankNr: 310318
+                    - Name: Cryptococcus aggregatus
+                      ConceptId: 105364
+                      ConceptSource: MycoBank
+                      Id: 900
+                      MycoBankNr: 456230
+                    - Name: Torulopsis aggregata
+                      ConceptId: 105365
+                      ConceptSource: MycoBank
+                      Id: 425
+                      MycoBankNr: 291457
+              - Name: Yarrowia
+                ConceptType: Genus
+                ConceptId: 99021
+                ConceptSource: MycoBank
+                MycoBankNr: 5857
+                Children:
+                - Name: Yarrowia lipolytica
+                  ConceptType: Species
+                  ConceptId: 105705
+                  ConceptSource: MycoBank
+                  Id: 3377
+                  MycoBankNr: 108643
+                  Synonyms:
+                  - Name: Azymoprocandida lipolytica
+                    ConceptId: 106180
+                    ConceptSource: MycoBank
+                    Id: 1943
+                    MycoBankNr: 326863
+                  - Name: Candida lipolytica
+                    ConceptId: 106181
+                    ConceptSource: MycoBank
+                    Id: 1707
+                    MycoBankNr: 284772
+                  - Name: Mycotorula lipolytica
+                    ConceptId: 107139
+                    ConceptSource: MycoBank
+                    Id: 2300
+                    MycoBankNr: 318349
+                  - Name: Torula lipolytica
+                    ConceptId: 107140
+                    ConceptSource: MycoBank
+                    Id: 2593
+                    MycoBankNr: 456575
+          - Name: Pichiomycetes
+            ConceptType: Class
+            ConceptId: 598928
+            ConceptSource: MycoBank
+            Id: 3425
+            MycoBankNr: 847268
+            Children:
+            - Name: Pichiales
+              ConceptType: Order
+              ConceptId: 598933
+              ConceptSource: MycoBank
+              Id: 3454
+              MycoBankNr: 847273
+              Children:
+              - Name: Pichiaceae
+                ConceptType: Family
+                ConceptId: 598934
+                ConceptSource: MycoBank
+                Id: 3453
+                MycoBankNr: 847274
+                Children:
+                - Name: Ogataea
+                  ConceptType: Genus
+                  ConceptId: 101782
+                  ConceptSource: MycoBank
+                  Id: 972
+                  MycoBankNr: 27299
+                  Children:
+                  - Name: Ogataea angusta
+                    ConceptType: Species
+                    ConceptId: 470500
+                    ConceptSource: MycoBank
+                    Id: 2139
+                    MycoBankNr: 517102
+                    Synonyms:
+                    - Name: Pichia angusta
+                      ConceptId: 105797
+                      ConceptSource: MycoBank
+                      Id: 847
+                      MycoBankNr: 107144
+                  - Name: Ogataea polymorpha
+                    ConceptType: Species
+                    ConceptId: 105863
+                    ConceptSource: MycoBank
+                    Id: 1565
+                    MycoBankNr: 362660
+                    Synonyms:
+                    - Name: Hansenula polymorpha
+                      ConceptId: 105862
+                      ConceptSource: MycoBank
+                      Id: 811
+                      MycoBankNr: 331666
+                - Name: Pichia
+                  ConceptType: Genus
+                  ConceptId: 97263
+                  ConceptSource: MycoBank
+                  Id: 573
+                  MycoBankNr: 4095
+                  Children:
+                  - Name: Pichia fermentans
+                    ConceptType: Species
+                    ConceptId: 107916
+                    ConceptSource: MycoBank
+                    Id: 3365
+                    MycoBankNr: 252130
+                    Synonyms:
+                    - Name: Candida lambica
+                      ConceptId: 106150
+                      ConceptSource: MycoBank
+                      Id: 451
+                      MycoBankNr: 108744
+                  - Name: Pichia inconspicua
+                    ConceptType: Species
+                    ConceptId: 608193
+                    ConceptSource: MycoBank
+                    Id: 3438
+                    MycoBankNr: 571647
+                    Synonyms:
+                    - Name: Candida inconspicua
+                      ConceptId: 107984
+                      ConceptSource: MycoBank
+                      Id: 1805
+                      MycoBankNr: 310280
+                    - Name: Torulopsis inconspicua
+                      ConceptId: 107985
+                      ConceptSource: MycoBank
+                      Id: 2086
+                      MycoBankNr: 306936
+                  - Name: Pichia kudriavzevii
+                    ConceptType: Species
+                    ConceptId: 105891
+                    ConceptSource: MycoBank
+                    Id: 2597
+                    MycoBankNr: 337013
+                    Synonyms:
+                    - Name: Candida krusei
+                      ConceptId: 106721
+                      ConceptSource: MycoBank
+                      Id: 62
+                      MycoBankNr: 268707
+                  Synonyms:
+                  - Name: Nakazawaea
+                    ConceptId: 101682
+                    ConceptSource: MycoBank
+                    Id: 709
+                    MycoBankNr: 27301
+            - Name: Serinales
+              ConceptType: Order
+              ConceptId: 598929
+              ConceptSource: MycoBank
+              Id: 3424
+              MycoBankNr: 847269
+              Children:
+              - Name: Debaryomycetaceae
+                ConceptType: Family
+                ConceptId: 459828
+                ConceptSource: MycoBank
+                Id: 3423
+                MycoBankNr: 513454
+                Children:
+                - Name: Candida
+                  ConceptType: Genus
+                  ConceptId: 56219
+                  ConceptSource: MycoBank
+                  Id: 3422
+                  MycoBankNr: 7487
+                  Children:
+                  - Name: Candida parapsilosis complex
+                    ConceptType: Group
+                    ConceptId: 30
+                    ConceptSource: NeoIPC
+                    Id: 2701
+                    Children:
+                    - Name: Candida metapsilosis
+                      ConceptType: Species
+                      ConceptId: 414688
+                      ConceptSource: MycoBank
+                      Id: 1312
+                      MycoBankNr: 500210
+                    - Name: Candida orthopsilosis
+                      ConceptType: Species
+                      ConceptId: 414687
+                      ConceptSource: MycoBank
+                      Id: 2427
+                      MycoBankNr: 500209
+                    - Name: Candida parapsilosis
+                      ConceptType: Species
+                      ConceptId: 106134
+                      ConceptSource: MycoBank
+                      Id: 1197
+                      MycoBankNr: 253819
+                  - Name: Candida albicans
+                    ConceptType: Species
+                    ConceptId: 106232
+                    ConceptSource: MycoBank
+                    Id: 2273
+                    MycoBankNr: 256187
+                    Synonyms:
+                    - Name: Candida stellatoidea
+                      ConceptId: 106094
+                      ConceptSource: MycoBank
+                      Id: 458
+                      MycoBankNr: 456227
+                  - Name: Candida brumptii
+                    ConceptType: Species
+                    ConceptId: 104968
+                    ConceptSource: MycoBank
+                    Id: 730
+                    MycoBankNr: 453479
+                  - Name: Candida dubliniensis
+                    ConceptType: Species
+                    ConceptId: 105119
+                    ConceptSource: MycoBank
+                    Id: 2511
+                    MycoBankNr: 254786
+                  - Name: Candida pintolopesii
+                    ConceptType: Species
+                    ConceptId: 107989
+                    ConceptSource: MycoBank
+                    Id: 396
+                    MycoBankNr: 310322
+                    Children:
+                    - Name: Candida pintolopesii var. pintolopesii
+                      ConceptType: Variety
+                      ConceptId: 108603
+                      ConceptSource: MycoBank
+                      Id: 3348
+                      MycoBankNr: 417304
+                      Synonyms:
+                      - Name: Candida pintolopesii
+                        ConceptId: 107989
+                        ConceptSource: MycoBank
+                        Id: 396
+                        MycoBankNr: 310322
+                      - Name: Torulopsis pintolopesii
+                        ConceptId: 107990
+                        ConceptSource: MycoBank
+                        Id: 1284
+                        MycoBankNr: 306944
+                  - Name: Candida sake
+                    ConceptType: Species
+                    ConceptId: 105733
+                    ConceptSource: MycoBank
+                    Id: 550
+                    MycoBankNr: 283382
+                  - Name: Candida slooffiae
+                    ConceptType: Species
+                    ConceptId: 438796
+                    ConceptSource: MycoBank
+                    Id: 3367
+                    MycoBankNr: 324002
+                    Synonyms:
+                    - Name: Candida slooffii
+                      ConceptId: 105315
+                      ConceptSource: MycoBank
+                      Id: 2052
+                      MycoBankNr: 294047
+                  - Name: Candida tropicalis
+                    ConceptType: Species
+                    ConceptId: 108021
+                    ConceptSource: MycoBank
+                    Id: 181
+                    MycoBankNr: 280770
+                  - Name: Candida zeylanoides
+                    ConceptType: Species
+                    ConceptId: 108022
+                    ConceptSource: MycoBank
+                    Id: 94
+                    MycoBankNr: 255505
+                - Name: Debaryomyces
+                  ConceptType: Genus
+                  ConceptId: 94703
+                  ConceptSource: MycoBank
+                  Id: 2966
+                  MycoBankNr: 1432
+                  Children:
+                  - Name: Debaryomyces hansenii
+                    ConceptType: Species
+                    ConceptId: 106696
+                    ConceptSource: MycoBank
+                    Id: 1232
+                    MycoBankNr: 296478
+                  Synonyms:
+                  - Name: Schwanniomyces
+                    ConceptId: 102771
+                    ConceptSource: MycoBank
+                    Id: 2254
+                    MycoBankNr: 4918
+                - Name: Diutina
+                  ConceptType: Genus
+                  ConceptId: 545142
+                  ConceptSource: MycoBank
+                  MycoBankNr: 813756
+                  Children:
+                  - Name: Diutina catenulata
+                    ConceptType: Species
+                    ConceptId: 545164
+                    ConceptSource: MycoBank
+                    Id: 3403
+                    MycoBankNr: 813778
+                    Synonyms:
+                    - Name: Candida catenulata
+                      ConceptId: 105094
+                      ConceptSource: MycoBank
+                      Id: 1264
+                      MycoBankNr: 284767
+                    - Name: Candida ravautii
+                      ConceptId: 105296
+                      ConceptSource: MycoBank
+                      Id: 1666
+                      MycoBankNr: 456225
+                  - Name: Diutina rugosa
+                    ConceptType: Species
+                    ConceptId: 545154
+                    ConceptSource: MycoBank
+                    Id: 3357
+                    MycoBankNr: 813768
+                    Synonyms:
+                    - Name: Candida rugosa
+                      ConceptId: 106157
+                      ConceptSource: MycoBank
+                      Id: 2418
+                      MycoBankNr: 284780
+                - Name: Kodamaea
+                  ConceptType: Genus
+                  ConceptId: 95884
+                  ConceptSource: MycoBank
+                  Id: 1009
+                  MycoBankNr: 27725
+                  Children:
+                  - Name: Kodamaea ohmeri
+                    ConceptType: Species
+                    ConceptId: 107892
+                    ConceptSource: MycoBank
+                    Id: 1722
+                    MycoBankNr: 436311
+                    Synonyms:
+                    - Name: Candida guilliermondii var. membranaefaciens
+                      ConceptId: 518509
+                      ConceptSource: MycoBank
+                      Id: 2694
+                      MycoBankNr: 306134
+                    - Name: Candida guilliermondii var. membranifaciens
+                      ConceptId: 108091
+                      ConceptSource: MycoBank
+                      Id: 2693
+                      MycoBankNr: 346605
+                    - Name: Pichia ohmeri
+                      ConceptId: 107893
+                      ConceptSource: MycoBank
+                      Id: 1410
+                      MycoBankNr: 337016
+                - Name: Lodderomyces
+                  ConceptType: Genus
+                  ConceptId: 96157
+                  ConceptSource: MycoBank
+                  Id: 1001
+                  MycoBankNr: 2916
+                  Children:
+                  - Name: Lodderomyces elongisporus
+                    ConceptType: Species
+                    ConceptId: 106668
+                    ConceptSource: MycoBank
+                    Id: 2267
+                    MycoBankNr: 316954
+                - Name: Meyerozyma
+                  ConceptType: Genus
+                  ConceptId: 459830
+                  ConceptSource: MycoBank
+                  Id: 1310
+                  MycoBankNr: 513456
+                  Children:
+                  - Name: Meyerozyma guilliermondii
+                    ConceptType: Species
+                    ConceptId: 459837
+                    ConceptSource: MycoBank
+                    Id: 2187
+                    MycoBankNr: 513463
+                    Synonyms:
+                    - Name: Candida guilliermondii
+                      ConceptId: 105623
+                      ConceptSource: MycoBank
+                      Id: 52
+                      MycoBankNr: 252488
+                    - Name: Pichia guilliermondii
+                      ConceptId: 106355
+                      ConceptSource: MycoBank
+                      Id: 997
+                      MycoBankNr: 337010
+                - Name: Millerozyma
+                  ConceptType: Genus
+                  ConceptId: 459831
+                  ConceptSource: MycoBank
+                  MycoBankNr: 513457
+                  Children:
+                  - Name: Millerozyma farinosa
+                    ConceptType: Species
+                    ConceptId: 459839
+                    ConceptSource: MycoBank
+                    Id: 3364
+                    MycoBankNr: 513465
+                    Synonyms:
+                    - Name: Pichia farinosa
+                      ConceptId: 106679
+                      ConceptSource: MycoBank
+                      Id: 456
+                      MycoBankNr: 226618
+                - Name: Schwanniomyces
+                  ConceptType: Genus
+                  ConceptId: 102771
+                  ConceptSource: MycoBank
+                  Id: 2254
+                  MycoBankNr: 4918
+                  Children:
+                  - Name: Schwanniomyces polymorphus
+                    ConceptType: Species
+                    ConceptId: 459852
+                    ConceptSource: MycoBank
+                    Id: 782
+                    MycoBankNr: 513478
+                    Synonyms:
+                    - Name: Debaryomyces polymorphus
+                      ConceptId: 106415
+                      ConceptSource: MycoBank
+                      Id: 2534
+                      MycoBankNr: 312744
+                    - Name: Pichia polymorpha
+                      ConceptId: 106413
+                      ConceptSource: MycoBank
+                      Id: 1475
+                      MycoBankNr: 226743
+              - Name: Metschnikowiaceae
+                ConceptType: Family
+                ConceptId: 92937
+                ConceptSource: MycoBank
+                Id: 3434
+                MycoBankNr: 80999
+                Children:
+                - Name: Candidozyma
+                  ConceptType: Genus
+                  ConceptId: 600410
+                  ConceptSource: MycoBank
+                  Id: 3433
+                  MycoBankNr: 848168
+                  Children:
+                  - Name: Candidozyma auris
+                    ConceptType: Species
+                    ConceptId: 600411
+                    ConceptSource: MycoBank
+                    Id: 3431
+                    MycoBankNr: 848169
+                    Synonyms:
+                    - Name: Candida auris
+                      ConceptId: 457202
+                      ConceptSource: MycoBank
+                      Id: 1183
+                      MycoBankNr: 508967
+                  - Name: Candidozyma duobushaemuli
+                    ConceptType: Species
+                    ConceptId: 600413
+                    ConceptSource: MycoBank
+                    Id: 3435
+                    MycoBankNr: 848171
+                    Synonyms:
+                    - Name: Candida duobushaemuli
+                      ConceptId: 598075
+                      ConceptSource: MycoBank
+                      Id: 3473
+                      MycoBankNr: 661998
+                    - Name: Candida duobushaemulonii
+                      ConceptId: 508445
+                      ConceptSource: MycoBank
+                      Id: 1354
+                      MycoBankNr: 800921
+                    - Name: Candida duobushaemulonis
+                      ConceptId: 538917
+                      ConceptSource: MycoBank
+                      Id: 3362
+                      MycoBankNr: 584804
+                  - Name: Candidozyma haemuli
+                    ConceptType: Species
+                    ConceptId: 600415
+                    ConceptSource: MycoBank
+                    Id: 3432
+                    MycoBankNr: 848173
+                    Synonyms:
+                    - Name: Candida haemuli
+                      ConceptId: 598072
+                      ConceptSource: MycoBank
+                      Id: 3472
+                      MycoBankNr: 661996
+                    - Name: Candida haemuloni
+                      ConceptId: 573337
+                      ConceptSource: MycoBank
+                      Id: 3380
+                      MycoBankNr: 634000
+                    - Name: Candida haemulonii
+                      ConceptId: 418665
+                      ConceptSource: MycoBank
+                      Id: 2243
+                      MycoBankNr: 292874
+                    - Name: Torulopsis haemulonii
+                      ConceptId: 517626
+                      ConceptSource: MycoBank
+                      Id: 558
+                      MycoBankNr: 581361
+                - Name: Clavispora
+                  ConceptType: Genus
+                  ConceptId: 94364
+                  ConceptSource: MycoBank
+                  Id: 1127
+                  MycoBankNr: 1095
+                  Children:
+                  - Name: Clavispora lusitaniae
+                    ConceptType: Species
+                    ConceptId: 105362
+                    ConceptSource: MycoBank
+                    Id: 2157
+                    MycoBankNr: 111257
+                    Synonyms:
+                    - Name: Candida lusitaniae
+                      ConceptId: 105204
+                      ConceptSource: MycoBank
+                      Id: 1192
+                      MycoBankNr: 294031
+                - Name: Sungouiella
+                  ConceptType: Genus
+                  ConceptId: 600440
+                  ConceptSource: MycoBank
+                  Id: 3451
+                  MycoBankNr: 848198
+                  Children:
+                  - Name: Sungouiella intermedia
+                    ConceptType: Species
+                    ConceptId: 600444
+                    ConceptSource: MycoBank
+                    Id: 3439
+                    MycoBankNr: 848202
+                    Synonyms:
+                    - Name: Candida intermedia
+                      ConceptId: 104982
+                      ConceptSource: MycoBank
+                      Id: 1466
+                      MycoBankNr: 252746
+          - Name: Saccharomycetes
+            ConceptType: Class
+            ConceptId: 92387
+            ConceptSource: MycoBank
+            MycoBankNr: 90790
+            Children:
+            - Name: Saccharomycetidae
+              ConceptType: Subclass
+              ConceptId: 92409
+              ConceptSource: MycoBank
+              MycoBankNr: 90341
+              Children:
+              - Name: Saccharomycetales
+                ConceptType: Order
+                ConceptId: 92517
+                ConceptSource: MycoBank
+                MycoBankNr: 90510
+                Children:
+                - Name: Azymocandida
+                  ConceptType: Genus
+                  ConceptId: 99433
+                  ConceptSource: MycoBank
+                  MycoBankNr: 7301
+                  Children:
+                  - Name: Azymocandida mycoderma
+                    ConceptType: Species
+                    ConceptId: 106773
+                    ConceptSource: MycoBank
+                    Id: 3349
+                    MycoBankNr: 326854
+                    Synonyms:
+                    - Name: Candida vini
+                      ConceptId: 108012
+                      ConceptSource: MycoBank
+                      Id: 1651
+                      MycoBankNr: 310359
+          - Name: Sporopachydermiomycetes
+            ConceptType: Class
+            ConceptId: 598935
+            ConceptSource: MycoBank
+            MycoBankNr: 847275
+            Children:
+            - Name: Sporopachydermiales
+              ConceptType: Order
+              ConceptId: 598936
+              ConceptSource: MycoBank
+              MycoBankNr: 847276
+              Children:
+              - Name: Sporopachydermiaceae
+                ConceptType: Family
+                ConceptId: 598937
+                ConceptSource: MycoBank
+                MycoBankNr: 847277
+                Children:
+                - Name: Sporopachydermia
+                  ConceptType: Genus
+                  ConceptId: 98297
+                  ConceptSource: MycoBank
+                  Id: 738
+                  MycoBankNr: 5165
+      - Name: Basidiomycota
+        ConceptType: Phylum
+        ConceptId: 92345
+        ConceptSource: MycoBank
+        MycoBankNr: 90050
+        Children:
+        - Name: Agaricomycotina
+          ConceptType: Subphylum
+          ConceptId: 431129
+          ConceptSource: MycoBank
+          MycoBankNr: 501465
+          Children:
+          - Name: Agaricomycetes
+            ConceptType: Class
+            ConceptId: 430993
+            ConceptSource: MycoBank
+            MycoBankNr: 501297
+            Children:
+            - Name: Agaricomycetidae
+              ConceptType: Subclass
+              ConceptId: 432192
+              ConceptSource: MycoBank
+              MycoBankNr: 501298
+              Children:
+              - Name: Agaricales
+                ConceptType: Order
+                ConceptId: 58806
+                ConceptSource: MycoBank
+                MycoBankNr: 90508
+                Children:
+                - Name: Pleurotineae
+                  ConceptType: Suborder
+                  ConceptId: 547370
+                  ConceptSource: MycoBank
+                  MycoBankNr: 551136
+                  Children:
+                  - Name: Schizophyllaceae
+                    ConceptType: Family
+                    ConceptId: 58958
+                    ConceptSource: MycoBank
+                    MycoBankNr: 81263
+                    Children:
+                    - Name: Schizophyllum
+                      ConceptType: Genus
+                      ConceptId: 38475
+                      ConceptSource: MycoBank
+                      Id: 798
+                      MycoBankNr: 18512
+                      Children:
+                      - Name: Schizophyllum commune
+                        ConceptType: Species
+                        ConceptId: 24763
+                        ConceptSource: MycoBank
+                        Id: 723
+                        MycoBankNr: 208403
+            - Name: Corticiales
+              ConceptType: Order
+              ConceptId: 431029
+              ConceptSource: MycoBank
+              MycoBankNr: 501299
+              Children:
+              - Name: Corticiaceae
+                ConceptType: Family
+                ConceptId: 58854
+                ConceptSource: MycoBank
+                MycoBankNr: 80648
+                Children:
+                - Name: Necator
+                  ConceptType: Genus
+                  ConceptId: 59733
+                  ConceptSource: MycoBank
+                  Id: 1883
+                  MycoBankNr: 9082
+            - Name: Polyporales
+              ConceptType: Order
+              ConceptId: 58781
+              ConceptSource: MycoBank
+              MycoBankNr: 90565
+              Children:
+              - Name: Fomitopsidaceae
+                ConceptType: Family
+                ConceptId: 58879
+                ConceptSource: MycoBank
+                MycoBankNr: 81772
+                Children:
+                - Name: Sporotrichum
+                  ConceptType: Genus
+                  ConceptId: 38572
+                  ConceptSource: MycoBank
+                  MycoBankNr: 10049
+                  Children:
+                  - Name: Sporotrichum gougerotii
+                    ConceptType: Species
+                    ConceptId: 26224
+                    ConceptSource: MycoBank
+                    Id: 3400
+                    MycoBankNr: 201834
+                    Synonyms:
+                    - Name: Phialophora gougerotii
+                      ConceptId: 75786
+                      ConceptSource: MycoBank
+                      Id: 797
+                      MycoBankNr: 302839
+                  - Name: Sporotrichum pruinosum
+                    ConceptType: Species
+                    ConceptId: 26227
+                    ConceptSource: MycoBank
+                    Id: 1379
+                    MycoBankNr: 254123
+          - Name: Tremellomycetes
+            ConceptType: Class
+            ConceptId: 431010
+            ConceptSource: MycoBank
+            MycoBankNr: 90764
+            Children:
+            - Name: Tremellomycetidae
+              ConceptType: Subclass
+              ConceptId: 92413
+              ConceptSource: MycoBank
+              MycoBankNr: 90378
+              Children:
+              - Name: Cystofilobasidiales
+                ConceptType: Order
+                ConceptId: 92438
+                ConceptSource: MycoBank
+                MycoBankNr: 90537
+                Children:
+                - Name: Mrakiaceae
+                  ConceptType: Family
+                  ConceptId: 543520
+                  ConceptSource: MycoBank
+                  MycoBankNr: 812173
+                  Children:
+                  - Name: Tausonia
+                    ConceptType: Genus
+                    ConceptId: 98515
+                    ConceptSource: MycoBank
+                    MycoBankNr: 28378
+                    Children:
+                    - Name: Tausonia pullulans
+                      ConceptType: Species
+                      ConceptId: 543537
+                      ConceptSource: MycoBank
+                      Id: 3404
+                      MycoBankNr: 812190
+                      Synonyms:
+                      - Name: Trichosporon pullulans
+                        ConceptId: 106256
+                        ConceptSource: MycoBank
+                        Id: 1247
+                        MycoBankNr: 291595
+            - Name: Trichosporonales
+              ConceptType: Order
+              ConceptId: 431034
+              ConceptSource: MycoBank
+              MycoBankNr: 501541
+              Children:
+              - Name: Trichosporonaceae
+                ConceptType: Family
+                ConceptId: 433332
+                ConceptSource: MycoBank
+                MycoBankNr: 81493
+                Children:
+                - Name: Apiotrichum
+                  ConceptType: Genus
+                  ConceptId: 99300
+                  ConceptSource: MycoBank
+                  MycoBankNr: 7190
+                  Children:
+                  - Name: Apiotrichum loubieri
+                    ConceptType: Species
+                    ConceptId: 544800
+                    ConceptSource: MycoBank
+                    Id: 3412
+                    MycoBankNr: 813417
+                    Synonyms:
+                    - Name: Trichosporon loubieri
+                      ConceptId: 105763
+                      ConceptSource: MycoBank
+                      Id: 317
+                      MycoBankNr: 324992
+                  - Name: Apiotrichum mycotoxinovorans
+                    ConceptType: Species
+                    ConceptId: 551099
+                    ConceptSource: MycoBank
+                    Id: 3398
+                    MycoBankNr: 623118
+                    Synonyms:
+                    - Name: Trichosporon mycotoxinivorans
+                      ConceptId: 517631
+                      ConceptSource: MycoBank
+                      Id: 488
+                      MycoBankNr: 581367
+                - Name: Cutaneotrichosporon
+                  ConceptType: Genus
+                  ConceptId: 544780
+                  ConceptSource: MycoBank
+                  MycoBankNr: 813397
+                  Children:
+                  - Name: Cutaneotrichosporon cutaneum
+                    ConceptType: Species
+                    ConceptId: 544781
+                    ConceptSource: MycoBank
+                    Id: 3358
+                    MycoBankNr: 813398
+                    Synonyms:
+                    - Name: Trichosporon cutaneum
+                      ConceptId: 106246
+                      ConceptSource: MycoBank
+                      Id: 2180
+                      MycoBankNr: 122298
+                  - Name: Cutaneotrichosporon mucoides
+                    ConceptType: Species
+                    ConceptId: 544785
+                    ConceptSource: MycoBank
+                    Id: 3360
+                    MycoBankNr: 813402
+                    Synonyms:
+                    - Name: Trichosporon mucoides
+                      ConceptId: 107481
+                      ConceptSource: MycoBank
+                      Id: 1773
+                      MycoBankNr: 361474
+                - Name: Trichosporon
+                  ConceptType: Genus
+                  ConceptId: 39406
+                  ConceptSource: MycoBank
+                  Id: 83
+                  MycoBankNr: 10296
+                  Children:
+                  - Name: Trichosporon asteroides
+                    ConceptType: Species
+                    ConceptId: 106293
+                    ConceptSource: MycoBank
+                    Id: 3413
+                    MycoBankNr: 456617
+                    Synonyms:
+                    - Name: Fissuricella filamenta
+                      ConceptId: 106484
+                      ConceptSource: MycoBank
+                      Id: 1992
+                      MycoBankNr: 314141
+                    - Name: Prototheca filamenta
+                      ConceptId: 106485
+                      ConceptSource: MycoBank
+                      Id: 2209
+                      MycoBankNr: 321038
+                  - Name: Trichosporon beigelii
+                    ConceptType: Species
+                    ConceptId: 35058
+                    ConceptSource: MycoBank
+                    Id: 1798
+                    MycoBankNr: 432135
+                  - Name: Trichosporon inkin
+                    ConceptType: Species
+                    ConceptId: 106913
+                    ConceptSource: MycoBank
+                    Id: 1834
+                    MycoBankNr: 340422
+                    Synonyms:
+                    - Name: Sarcinosporon inkin
+                      ConceptId: 106914
+                      ConceptSource: MycoBank
+                      Id: 2540
+                      MycoBankNr: 323077
+                  - Name: Trichosporon ovoides
+                    ConceptType: Species
+                    ConceptId: 107484
+                    ConceptSource: MycoBank
+                    Id: 571
+                    MycoBankNr: 456627
+                  Synonyms:
+                  - Name: Sarcinosporon
+                    ConceptId: 97989
+                    ConceptSource: MycoBank
+                    Id: 1935
+                    MycoBankNr: 9785
+        - Name: Pucciniomycotina
+          ConceptType: Subphylum
+          ConceptId: 431018
+          ConceptSource: MycoBank
+          MycoBankNr: 501469
+          Children:
+          - Name: Cystobasidiomycetes
+            ConceptType: Class
+            ConceptId: 431120
+            ConceptSource: MycoBank
+            MycoBankNr: 501480
+            Children:
+            - Name: Cystobasidiales
+              ConceptType: Order
+              ConceptId: 431392
+              ConceptSource: MycoBank
+              MycoBankNr: 501518
+              Children:
+              - Name: Cystobasidiaceae
+                ConceptType: Family
+                ConceptId: 432810
+                ConceptSource: MycoBank
+                MycoBankNr: 80674
+                Children:
+                - Name: Cystobasidium
+                  ConceptType: Genus
+                  ConceptId: 59766
+                  ConceptSource: MycoBank
+                  MycoBankNr: 17446
+                  Children:
+                  - Name: Cystobasidium minutum
+                    ConceptType: Species
+                    ConceptId: 522483
+                    ConceptSource: MycoBank
+                    Id: 3369
+                    MycoBankNr: 809340
+                    Synonyms:
+                    - Name: Rhodotorula minuta
+                      ConceptId: 107149
+                      ConceptSource: MycoBank
+                      Id: 113
+                      MycoBankNr: 271309
+          - Name: Microbotryomycetes
+            ConceptType: Class
+            ConceptId: 431127
+            ConceptSource: MycoBank
+            MycoBankNr: 501489
+            Children:
+            - Name: Sporidiobolales
+              ConceptType: Order
+              ConceptId: 431128
+              ConceptSource: MycoBank
+              MycoBankNr: 90592
+              Children:
+              - Name: Sporidiobolaceae
+                ConceptType: Family
+                ConceptId: 93096
+                ConceptSource: MycoBank
+                MycoBankNr: 82101
+                Children:
+                - Name: Rhodotorula
+                  ConceptType: Genus
+                  ConceptId: 58480
+                  ConceptSource: MycoBank
+                  Id: 819
+                  MycoBankNr: 9741
+                  Children:
+                  - Name: Rhodotorula glutinis
+                    ConceptType: Species
+                    ConceptId: 105404
+                    ConceptSource: MycoBank
+                    Id: 2472
+                    MycoBankNr: 266169
+                  - Name: Rhodotorula mucilaginosa
+                    ConceptType: Species
+                    ConceptId: 107159
+                    ConceptSource: MycoBank
+                    Id: 1866
+                    MycoBankNr: 271749
+                    Synonyms:
+                    - Name: Rhodotorula mucilaginosa var. mucilaginosa
+                      ConceptId: 108500
+                      ConceptSource: MycoBank
+                      Id: 3347
+                      MycoBankNr: 425170
+                    - Name: Rhodotorula pilimanae
+                      ConceptId: 106579
+                      ConceptSource: MycoBank
+                      Id: 695
+                      MycoBankNr: 305282
+                - Name: Sporobolomyces
+                  ConceptType: Genus
+                  ConceptId: 57425
+                  ConceptSource: MycoBank
+                  Id: 1953
+                  MycoBankNr: 10025
+                  Children:
+                  - Name: Sporobolomyces roseus
+                    ConceptType: Species
+                    ConceptId: 26055
+                    ConceptSource: MycoBank
+                    Id: 1311
+                    MycoBankNr: 306337
+                  - Name: Sporobolomyces salmonicolor
+                    ConceptType: Species
+                    ConceptId: 104995
+                    ConceptSource: MycoBank
+                    Id: 1768
+                    MycoBankNr: 323852
+        - Name: Ustilaginomycotina
+          ConceptType: Subphylum
+          ConceptId: 430996
+          ConceptSource: MycoBank
+          MycoBankNr: 501473
+          Children:
+          - Name: Exobasidiomycetes
+            ConceptType: Class
+            ConceptId: 431003
+            ConceptSource: MycoBank
+            MycoBankNr: 501484
+            Children:
+            - Name: Exobasidiomycetidae
+              ConceptType: Subclass
+              ConceptId: 92401
+              ConceptSource: MycoBank
+              MycoBankNr: 90148
+              Children:
+              - Name: Microstromatales
+                ConceptType: Order
+                ConceptId: 92483
+                ConceptSource: MycoBank
+                MycoBankNr: 90554
+                Children:
+                - Name: Quambalariaceae
+                  ConceptType: Family
+                  ConceptId: 426540
+                  ConceptSource: MycoBank
+                  MycoBankNr: 500889
+                  Children:
+                  - Name: Quambalaria
+                    ConceptType: Genus
+                    ConceptId: 374192
+                    ConceptSource: MycoBank
+                    MycoBankNr: 28451
+                    Children:
+                    - Name: Quambalaria cyanescens
+                      ConceptType: Species
+                      ConceptId: 426541
+                      ConceptSource: MycoBank
+                      Id: 3389
+                      MycoBankNr: 500890
+                      Synonyms:
+                      - Name: Sporothrix cyanescens
+                        ConceptId: 26135
+                        ConceptSource: MycoBank
+                        Id: 2204
+                        MycoBankNr: 323930
+            - Name: Pityrosporum
+              ConceptType: Genus
+              ConceptId: 60040
+              ConceptSource: MycoBank
+              Id: 1597
+              MycoBankNr: 9415
+              Children:
+              - Name: Pityrosporum orbiculare
+                ConceptType: Species
+                ConceptId: 177537
+                ConceptSource: MycoBank
+                Id: 523
+                MycoBankNr: 303738
+          - Name: Malasseziomycetes
+            ConceptType: Class
+            ConceptId: 519456
+            ConceptSource: MycoBank
+            MycoBankNr: 805514
+            Children:
+            - Name: Malasseziales
+              ConceptType: Order
+              ConceptId: 452935
+              ConceptSource: MycoBank
+              MycoBankNr: 90629
+              Children:
+              - Name: Malasseziaceae
+                ConceptType: Family
+                ConceptId: 461400
+                ConceptSource: MycoBank
+                MycoBankNr: 515089
+                Children:
+                - Name: Malassezia
+                  ConceptType: Genus
+                  ConceptId: 60020
+                  ConceptSource: MycoBank
+                  Id: 1614
+                  MycoBankNr: 8831
+                  Children:
+                  - Name: Malassezia furfur
+                    ConceptType: Species
+                    ConceptId: 75770
+                    ConceptSource: MycoBank
+                    Id: 1542
+                    MycoBankNr: 121793
+                    Synonyms:
+                    - Name: Pityrosporum furfur
+                      ConceptId: 75773
+                      ConceptSource: MycoBank
+                      Id: 1634
+                      MycoBankNr: 320560
+                    - Name: Pityrosporum ovale
+                      ConceptId: 106796
+                      ConceptSource: MycoBank
+                      Id: 2002
+                      MycoBankNr: 456448
+                  - Name: Malassezia globosa
+                    ConceptType: Species
+                    ConceptId: 105959
+                    ConceptSource: MycoBank
+                    Id: 801
+                    MycoBankNr: 437919
+                  - Name: Malassezia pachydermatis
+                    ConceptType: Species
+                    ConceptId: 106475
+                    ConceptSource: MycoBank
+                    Id: 1904
+                    MycoBankNr: 253759
+                    Synonyms:
+                    - Name: Pityrosporum canis
+                      ConceptId: 106471
+                      ConceptSource: MycoBank
+                      Id: 1803
+                      MycoBankNr: 337075
+                    - Name: Pityrosporum pachydermatis
+                      ConceptId: 106476
+                      ConceptSource: MycoBank
+                      Id: 235
+                      MycoBankNr: 273228
+                  - Name: Malassezia restricta
+                    ConceptType: Species
+                    ConceptId: 105961
+                    ConceptSource: MycoBank
+                    Id: 1797
+                    MycoBankNr: 437921
+                  - Name: Malassezia sympodialis
+                    ConceptType: Species
+                    ConceptId: 105963
+                    ConceptSource: MycoBank
+                    Id: 72
+                    MycoBankNr: 130281
+          - Name: Ustilaginomycetes
+            ConceptType: Class
+            ConceptId: 92392
+            ConceptSource: MycoBank
+            MycoBankNr: 90393
+            Children:
+            - Name: Ustilaginales
+              ConceptType: Order
+              ConceptId: 453005
+              ConceptSource: MycoBank
+              MycoBankNr: 90456
+              Children:
+              - Name: Ustilaginaceae
+                ConceptType: Family
+                ConceptId: 93135
+                ConceptSource: MycoBank
+                MycoBankNr: 81513
+                Children:
+                - Name: Moesziomyces
+                  ConceptType: Genus
+                  ConceptId: 96438
+                  ConceptSource: MycoBank
+                  MycoBankNr: 16221
+                  Children:
+                  - Name: Moesziomyces bullatus
+                    ConceptType: Species
+                    ConceptId: 153940
+                    ConceptSource: MycoBank
+                    Id: 2702
+                    MycoBankNr: 317784
+                    Synonyms:
+                    - Name: Pseudozyma aphidis
+                      ConceptId: 48360
+                      ConceptSource: MycoBank
+                      Id: 2703
+                      MycoBankNr: 415206
+                - Name: Pseudozyma
+                  ConceptType: Genus
+                  ConceptId: 49651
+                  ConceptSource: MycoBank
+                  Id: 2334
+                  MycoBankNr: 25732
+                - Name: Ustilago
+                  ConceptType: Genus
+                  ConceptId: 57586
+                  ConceptSource: MycoBank
+                  Id: 2482
+                  MycoBankNr: 16391
+    - Name: Incertae sedis
+      ConceptType: Kingdom
+      ConceptId: 507885
+      ConceptSource: MycoBank
+      MycoBankNr: 800381
+      Children:
+      - Name: Plasmodium
+        ConceptType: Genus
+        ConceptId: 525373
+        ConceptSource: MycoBank
+        Id: 401
+        MycoBankNr: 583195
+      - Name: Sarcocystis
+        ConceptType: Genus
+        ConceptId: 525390
+        ConceptSource: MycoBank
+        Id: 88
+        MycoBankNr: 584190
+    - Name: Mucoromyceta
+      ConceptType: Subkingdom
+      ConceptId: 566850
+      ConceptSource: MycoBank
+      MycoBankNr: 554016
+      Children:
+      - Name: Mortierellomycota
+        ConceptType: Phylum
+        ConceptId: 566852
+        ConceptSource: MycoBank
+        MycoBankNr: 554018
+        Children:
+        - Name: Mortierellomycotina
+          ConceptType: Subphylum
+          ConceptId: 477655
+          ConceptSource: MycoBank
+          MycoBankNr: 539369
+          Children:
+          - Name: Mortierellomycetes
+            ConceptType: Class
+            ConceptId: 523065
+            ConceptSource: MycoBank
+            MycoBankNr: 550332
+            Children:
+            - Name: Mortierellales
+              ConceptType: Order
+              ConceptId: 92668
+              ConceptSource: MycoBank
+              MycoBankNr: 90555
+              Children:
+              - Name: Mortierellaceae
+                ConceptType: Family
+                ConceptId: 551711
+                ConceptSource: MycoBank
+                MycoBankNr: 816415
+                Children:
+                - Name: Actinomortierella
+                  ConceptType: Genus
+                  ConceptId: 99141
+                  ConceptSource: MycoBank
+                  MycoBankNr: 20012
+                  Children:
+                  - Name: Actinomortierella wolfii
+                    ConceptType: Species
+                    ConceptId: 581115
+                    ConceptSource: MycoBank
+                    Id: 2962
+                    MycoBankNr: 835797
+                    Synonyms:
+                    - Name: Mortierella wolfii
+                      ConceptId: 16191
+                      ConceptSource: MycoBank
+                      Id: 872
+                      MycoBankNr: 334519
+                - Name: Mortierella
+                  ConceptType: Genus
+                  ConceptId: 38178
+                  ConceptSource: MycoBank
+                  Id: 288
+                  MycoBankNr: 20345
+      - Name: Mucoromycota
+        ConceptType: Phylum
+        ConceptId: 452644
+        ConceptSource: MycoBank
+        MycoBankNr: 90756
+        Children:
+        - Name: Mucoromycotina
+          ConceptType: Subphylum
+          ConceptId: 431097
+          ConceptSource: MycoBank
+          MycoBankNr: 501281
+          Children:
+          - Name: Mucoromycetes
+            ConceptType: Class
+            ConceptId: 452787
+            ConceptSource: MycoBank
+            MycoBankNr: 90755
+            Children:
+            - Name: Mucorales
+              ConceptType: Order
+              ConceptId: 92487
+              ConceptSource: MycoBank
+              MycoBankNr: 90437
+              Children:
+              - Name: Cunninghamellaceae
+                ConceptType: Family
+                ConceptId: 92771
+                ConceptSource: MycoBank
+                MycoBankNr: 80668
+                Children:
+                - Name: Cunninghamella
+                  ConceptType: Genus
+                  ConceptId: 56384
+                  ConceptSource: MycoBank
+                  Id: 565
+                  MycoBankNr: 20150
+                  Children:
+                  - Name: Cunninghamella bertholletiae
+                    ConceptType: Species
+                    ConceptId: 34081
+                    ConceptSource: MycoBank
+                    Id: 1678
+                    MycoBankNr: 230361
+              - Name: Lichtheimiaceae
+                ConceptType: Family
+                ConceptId: 455938
+                ConceptSource: MycoBank
+                MycoBankNr: 508680
+                Children:
+                - Name: Rhizomucor
+                  ConceptType: Genus
+                  ConceptId: 38933
+                  ConceptSource: MycoBank
+                  Id: 1191
+                  MycoBankNr: 20481
+                  Children:
+                  - Name: Rhizomucor miehei
+                    ConceptType: Species
+                    ConceptId: 24309
+                    ConceptSource: MycoBank
+                    Id: 403
+                    MycoBankNr: 322483
+                  - Name: Rhizomucor pusillus
+                    ConceptType: Species
+                    ConceptId: 24314
+                    ConceptSource: MycoBank
+                    Id: 1630
+                    MycoBankNr: 322484
+                    Synonyms:
+                    - Name: Mucor pusillus
+                      ConceptId: 24315
+                      ConceptSource: MycoBank
+                      Id: 990
+                      MycoBankNr: 247701
+              - Name: Mucoraceae
+                ConceptType: Family
+                ConceptId: 92955
+                ConceptSource: MycoBank
+                MycoBankNr: 81030
+                Children:
+                - Name: Mucor
+                  ConceptType: Genus
+                  ConceptId: 37938
+                  ConceptSource: MycoBank
+                  Id: 2697
+                  MycoBankNr: 25484
+                  Children:
+                  - Name: Mucor circinelloides
+                    ConceptType: Species
+                    ConceptId: 58323
+                    ConceptSource: MycoBank
+                    Id: 1330
+                    MycoBankNr: 198947
+                    Synonyms:
+                    - Name: Mucor javanicus
+                      ConceptId: 16366
+                      ConceptSource: MycoBank
+                      Id: 1428
+                      MycoBankNr: 241505
+                  - Name: Mucor hiemalis
+                    ConceptType: Species
+                    ConceptId: 46607
+                    ConceptSource: MycoBank
+                    Id: 1465
+                    MycoBankNr: 249401
+                  - Name: Mucor janssenii
+                    ConceptType: Species
+                    ConceptId: 16364
+                    ConceptSource: MycoBank
+                    Id: 1645
+                    MycoBankNr: 242235
+                  - Name: Mucor ramosissimus
+                    ConceptType: Species
+                    ConceptId: 16473
+                    ConceptSource: MycoBank
+                    Id: 735
+                    MycoBankNr: 276099
+              - Name: Saksenaeaceae
+                ConceptType: Family
+                ConceptId: 58726
+                ConceptSource: MycoBank
+                MycoBankNr: 81250
+                Children:
+                - Name: Apophysomyces
+                  ConceptType: Genus
+                  ConceptId: 56081
+                  ConceptSource: MycoBank
+                  Id: 449
+                  MycoBankNr: 20045
+                  Children:
+                  - Name: Apophysomyces elegans
+                    ConceptType: Species
+                    ConceptId: 1492
+                    ConceptSource: MycoBank
+                    Id: 1828
+                    MycoBankNr: 308868
+                - Name: Saksenaea
+                  ConceptType: Genus
+                  ConceptId: 57336
+                  ConceptSource: MycoBank
+                  Id: 617
+                  MycoBankNr: 20503
+                  Children:
+                  - Name: Saksenaea vasiformis
+                    ConceptType: Species
+                    ConceptId: 43039
+                    ConceptSource: MycoBank
+                    Id: 2350
+                    MycoBankNr: 305482
+              - Name: Syncephalastraceae
+                ConceptType: Family
+                ConceptId: 93104
+                ConceptSource: MycoBank
+                MycoBankNr: 81447
+                Children:
+                - Name: Syncephalastrum
+                  ConceptType: Genus
+                  ConceptId: 57484
+                  ConceptSource: MycoBank
+                  Id: 1061
+                  MycoBankNr: 20556
+                  Children:
+                  - Name: Syncephalastrum racemosum
+                    ConceptType: Species
+                    ConceptId: 26698
+                    ConceptSource: MycoBank
+                    Id: 1360
+                    MycoBankNr: 201627
+              - Name: Thamnidiaceae
+                ConceptType: Family
+                ConceptId: 93111
+                ConceptSource: MycoBank
+                MycoBankNr: 81852
+                Children:
+                - Name: Cokeromyces
+                  ConceptType: Genus
+                  ConceptId: 56320
+                  ConceptSource: MycoBank
+                  Id: 248
+                  MycoBankNr: 23001
+                  Children:
+                  - Name: Cokeromyces recurvatus
+                    ConceptType: Species
+                    ConceptId: 5852
+                    ConceptSource: MycoBank
+                    Id: 17
+                    MycoBankNr: 295277
+    - Name: Zoopagomyceta
+      ConceptType: Subkingdom
+      ConceptId: 566842
+      ConceptSource: MycoBank
+      MycoBankNr: 554008
+      Children:
+      - Name: Entomophthoromycota
+        ConceptType: Phylum
+        ConceptId: 482537
+        ConceptSource: MycoBank
+        MycoBankNr: 564375
+        Children:
+        - Name: Entomophthoromycotina
+          ConceptType: Subphylum
+          ConceptId: 436126
+          ConceptSource: MycoBank
+          MycoBankNr: 501282
+          Children:
+          - Name: Entomophthoromycetes
+            ConceptType: Class
+            ConceptId: 482543
+            ConceptSource: MycoBank
+            MycoBankNr: 564381
+            Children:
+            - Name: Entomophthorales
+              ConceptType: Order
+              ConceptId: 92449
+              ConceptSource: MycoBank
+              MycoBankNr: 90424
+              Children:
+              - Name: Conidiobolaceae
+                ConceptType: Family
+                ConceptId: 594448
+                ConceptSource: MycoBank
+                MycoBankNr: 844347
+                Children:
+                - Name: Conidiobolus
+                  ConceptType: Genus
+                  ConceptId: 56330
+                  ConceptSource: MycoBank
+                  Id: 200
+                  MycoBankNr: 20144
+                  Children:
+                  - Name: Conidiobolus coronatus
+                    ConceptType: Species
+                    ConceptId: 6175
+                    ConceptSource: MycoBank
+                    Id: 2265
+                    MycoBankNr: 283037
+                    Synonyms:
+                    - Name: Entomophthora coronata
+                      ConceptId: 9664
+                      ConceptSource: MycoBank
+                      Id: 706
+                      MycoBankNr: 262031
+                  - Name: Conidiobolus incongruus
+                    ConceptType: Species
+                    ConceptId: 6189
+                    ConceptSource: MycoBank
+                    Id: 489
+                    MycoBankNr: 328753
+  - Name: Protozoa
+    ConceptType: Kingdom
+    ConceptId: 92339
+    ConceptSource: MycoBank
+    MycoBankNr: 99001
+    Children:
+    - Name: Microsporidia
+      ConceptType: Phylum
+      ConceptId: 92482
+      ConceptSource: MycoBank
+      MycoBankNr: 99056
+      Children:
+      - Name: Microsporea
+        ConceptType: Class
+        ConceptId: 92380
+        ConceptSource: MycoBank
+        MycoBankNr: 99022
+        Children:
+        - Name: Enterocytozoonidae
+          ConceptType: Family
+          ConceptId: 514308
+          ConceptSource: MycoBank
+          MycoBankNr: 90399
+          Children:
+          - Name: Enterocytozoon
+            ConceptType: Genus
+            ConceptId: 454994
+            ConceptSource: MycoBank
+            Id: 1582
+            MycoBankNr: 30481
+        - Name: Microsporidium
+          ConceptType: Genus
+          ConceptId: 452350
+          ConceptSource: MycoBank
+          Id: 1030
+          MycoBankNr: 30525
+    - Name: Myxomycota
+      ConceptType: Phylum
+      ConceptId: 92366
+      ConceptSource: MycoBank
+      MycoBankNr: 90262
+      Children:
+      - Name: Prototheca
+        ConceptType: Genus
+        ConceptId: 58525
+        ConceptSource: MycoBank
+        Id: 252
+        MycoBankNr: 22315
+        Children:
+        - Name: Prototheca wickerhamii
+          ConceptType: Species
+          ConceptId: 58547
+          ConceptSource: MycoBank
+          Id: 2478
+          MycoBankNr: 304229
+        - Name: Prototheca zopfii
+          ConceptType: Species
+          ConceptId: 58548
+          ConceptSource: MycoBank
+          Id: 2411
+          MycoBankNr: 169728
+    - Name: Rhinosporidium
+      ConceptType: Genus
+      ConceptId: 97839
+      ConceptSource: MycoBank
+      Id: 2061
+      MycoBankNr: 4701
+

--- a/metadata/common/pathogens/po/NeoIPC-Infectious-Agents.pot
+++ b/metadata/common/pathogens/po/NeoIPC-Infectious-Agents.pot
@@ -1,0 +1,24077 @@
+# SOME DESCRIPTIVE TITLE
+# Copyright (C) YEAR Free Software Foundation, Inc.
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2025-08-17 16:26+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#. type: Hash Value: Hierarchies ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Unknown"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Not listed"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Species"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Simplexvirus humanalpha1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Herpes simplex virus type 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human alphaherpesvirus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Simplexvirus humanalpha2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Herpes simplex virus type 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human alphaherpesvirus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human herpes simplex virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Genus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Simplexvirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Varicellovirus humanalpha3"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human alphaherpesvirus 3"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Varicella zoster virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Varicellovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Subfamily"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphaherpesvirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cytomegalovirus humanbeta5"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human betaherpesvirus 5"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human cytomegalovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cytomegalovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Roseolovirus humanbeta6a"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human betaherpesvirus 6A"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human herpesvirus 6A"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Roseolovirus humanbeta6b"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human betaherpesvirus 6B"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human herpesvirus 6B"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human herpesvirus 6"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Roseolovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betaherpesvirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lymphocryptovirus humangamma4"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Epstein-Barr virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human gammaherpesvirus 4"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lymphocryptovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhadinovirus humangamma8"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human gammaherpesvirus 8"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human herpesvirus 8"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kaposi's sarcoma-associated herpesvirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhadinovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gammaherpesvirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Family"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoherpesviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Herpesviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Order"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Herpesvirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Class"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Herviviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phylum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peploviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kingdom"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Heunggongvirae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Realm"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Duplodnaviria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betapolyomavirus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "BK polyomavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human polyomavirus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betapolyomavirus macacae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Simian virus 40"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betapolyomavirus secuhominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human polyomavirus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "JC polyomavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "JC virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betapolyomavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Polyomaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sepolyvirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human papillomavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Firstpapillomavirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Papillomaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Zurhausenvirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Papovaviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human bocavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bocaparvovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bocavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erythroparvovirus primate1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "B19 virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erythrovirus B19"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Primate erythroparvovirus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erythroparvovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parvovirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parvoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Piccovirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Quintoviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cossaviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shotokuvirae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Monodnaviria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orbivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rotavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sedoreoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coltivirus dermacentoris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Colorado tick fever coltivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Colorado tick fever virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coltivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoreovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Spinareoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Reovirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Resentoviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Duplornaviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paslahepevirus balayani"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatitis E virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paslahepevirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthohepevirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepeviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rubivirus rubellae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rubella virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rubivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Matonaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepelivirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphavirus chikungunya"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chikungunya virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphavirus eastern"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eastern equine encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "North American eastern equine encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphavirus madariaga"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Madariaga virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "South American eastern equine encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphavirus venezuelan"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Venezuelan equine encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphavirus western"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Western equine encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Togaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Martellivirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alsuviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepacivirus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepacivirus C"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatitis C virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepacivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoflavivirus denguei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dengue virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoflavivirus encephalitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tick-borne encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoflavivirus flavi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yellow fever virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoflavivirus louisense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saint Louis encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "St. Louis encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoflavivirus nilense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "West Nile virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoflavivirus zikaense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Zika virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoflavivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human pegivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pegivirus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatitis G virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pegivirus C"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pegivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flaviviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Amarillovirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flasuviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kitrinoviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoebolavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ebolavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthomarburgvirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Marburgvirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Filoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human parainfluenza virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Respirovirus laryngotracheitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human parainfluenza virus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human respirovirus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Respirovirus pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human parainfluenza virus 3"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human respirovirus 3"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Respirovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Feraresvirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Morbillivirus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Measles morbillivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Measles virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Morbillivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoparamyxovirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthorubulavirus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human orthorubulavirus 4"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human parainfluenza virus 4"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthorubulavirus laryngotracheitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human orthorubulavirus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human parainfluenza virus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthorubulavirus parotitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mumps orthorubulavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mumps virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthorubulavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rubulavirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paramyxoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metapneumovirus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human metapneumovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metapneumovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthopneumovirus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human orthopneumovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human respiratory syncytial virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthopneumovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pneumoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lyssavirus rabies"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rabies virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lyssavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alpharhabdovirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhabdoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mononegavirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Monjiviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Subphylum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haploviricotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthobunyavirus encephalitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "California encephalitis orthobunyavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "California encephalitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthobunyavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peribunyaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Elliovirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mammarenavirus choriomeningitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lymphocytic choriomeningitis mammarenavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lymphocytic choriomeningitis virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mammarenavirus lassaense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lassa mammarenavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lassa virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mammarenavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arenaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthonairovirus haemorrhagiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Crimean-Congo hemorrhagic fever orthonairovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Crimean-Congo hemorrhagic fever virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthonairovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nairoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phlebovirus riftense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rift Valley fever phlebovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rift Valley fever virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phlebovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phenuiviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hareavirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bunyaviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphainfluenzavirus influenzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Influenza A virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphainfluenzavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betainfluenzavirus influenzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Influenza B virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betainfluenzavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gammainfluenzavirus influenzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Influenza C virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gammainfluenzavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deltainfluenzavirus influenzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Influenza D virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deltainfluenzavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Influenza virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthomyxoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Articulavirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Insthoviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Polyploviricotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Negarnaviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serotype"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Severe acute respiratory syndrome coronavirus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "SARS-CoV-2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betacoronavirus pandemicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Severe acute respiratory syndrome-related coronavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Subgenus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarbecovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betacoronavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthocoronavirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human coronavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coronaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Suborder"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cornidovirineae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nidovirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Norovirus norwalkense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Norwalk virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Norovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Caliciviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Echovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human coxsackievirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human coxsackievirus A"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human coxsackievirus B"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human rhinovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterovirus betacoxsackie"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterovirus B"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Poliovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Poliovirus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Poliovirus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Poliovirus 3"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterovirus coxsackiepol"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterovirus C"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ensavirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatovirus ahepa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatitis A virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatovirus A"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Heptrevirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Picornaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Picornavirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pisoniviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Astroviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stellavirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stelpaviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pisuviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthornavirae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthohepadnavirus hominoidei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatitis B virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthohepadnavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepadnaviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Blubervirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deltaretrovirus priTlym1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human T-lymphotropic virus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Primate T-lymphotropic virus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deltaretrovirus priTlym2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human T-lymphotropic virus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Primate T-lymphotropic virus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deltaretrovirus priTlym3"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Primate T-lymphotropic virus 3"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deltaretrovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lentivirus humimdef1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human immunodeficiency virus 1"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lentivirus humimdef2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human immunodeficiency virus 2"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human immunodeficiency virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lentivirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthoretrovirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Retroviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ortervirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Revtraviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Artverviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pararnavirae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Riboviria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deltavirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hepatitis D virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kolmioviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ribozyviria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Molluscipoxvirus molluscum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Molluscum contagiosum virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Molluscipoxvirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthopoxvirus monkeypox"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Monkeypox virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthopoxvirus vaccinia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vaccinia virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthopoxvirus variola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Variola virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orthopoxvirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parapoxvirus orf"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orf virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parapoxvirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yatapoxvirus tanapox"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tanapox virus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yatapoxvirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chordopoxvirinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Poxviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chitovirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pokkesviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nucleocytoviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Human adenovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mastadenovirus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Adenoviridae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rowavirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pharingeaviricetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Polisuviricotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Preplasmiviricota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bamfordvirae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Varidnaviria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Viruses"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobaculum massiliense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobaculum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces bovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces dentalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces gerencseriae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces graevenitzii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces israelii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces naeslundii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces oricola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces oris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces radicidentis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces urogenitalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces viscosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinotignum schaalii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobaculum schaalii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinotignum urinale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobaculum urinale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinotignum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcanobacterium haemolyticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcanobacterium pluranimalium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcanobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bowdeniella nasicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces nasicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bowdeniella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gleimia europaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces europaeus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gleimia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mobiluncus curtisii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mobiluncus holmesii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falcivibrio vaginalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mobiluncus mulieris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falcivibrio grandis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mobiluncus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pauljensenia hongkongensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces hongkongensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pauljensenia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schaalia cardiffensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces cardiffensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schaalia funkei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces funkei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schaalia georgiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces georgiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schaalia meyeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces meyeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schaalia odontolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces odontolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schaalia radingae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces radingae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schaalia turicensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces turicensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schaalia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trueperella bernardiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces bernardiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcanobacterium bernardiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trueperella pyogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcanobacterium pyogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium pyogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trueperella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Winkia neuii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomyces neuii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Winkia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomycetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomycetales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alloscardovia omnicolens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alloscardovia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium adolescentis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium angulatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium bifidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium breve"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium catenulatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium dentium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium gallicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Subspecies"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium longum subsp. infantis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium infantis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium longum subsp. suis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium suis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium longum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium pseudocatenulatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium scardovii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gardnerella vaginalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gardnerella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parascardovia denticolens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium denticolens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parascardovia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scardovia inopinata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacterium inopinatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scardovia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bifidobacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces albus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces bikiniensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces candidus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces clavuligerus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces filamentosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces roseosporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces griseus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces caviscabies"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces erumpens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces setonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces lincolnensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces somaliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces spectabilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces thermovulgaris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces venezuelae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptomycetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kitasatosporales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium casei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium epidermidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium linens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium luteolum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium mcbrellneri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium ravenspurgense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium sanguinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cellulomonas hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cellulomonas humilata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cellulomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cellulomonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brachybacterium muris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brachybacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermabacter hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermabacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermabacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermacoccus nishinomiyaensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus nishinomiyaensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermacoccus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermacoccaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arsenicicoccus bolidensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arsenicicoccus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermatophilus congolensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermatophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dermatophilaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Janibacter hoylei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Janibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Intrasporangiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Jonesia denitrificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeria denitrificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Jonesia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Jonesiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kytococcus sedentarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus sedentarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kytococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kytococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agromyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curtobacterium citreum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium albidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curtobacterium albidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curtobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leifsonia aquatica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leifsonia xyli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leifsonia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium arborescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium hydrocarbonoxydans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium imperiale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium imperiale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium lacticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium liquefaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aureobacterium liquefaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium maritypicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium marinotypicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium oxydans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium oxydans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium paraoxydans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium resistens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoclavibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter agilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter citreus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter crystallopoietes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter flavus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter gandavensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter globiformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter koreensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter luteolus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter methylotrophus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter oryzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter pascens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter psychrolactophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter ramosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter rhombi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter roseus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter russicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter woluwensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falsarthrobacter nasiphocae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter nasiphocae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falsarthrobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Glutamicibacter arilaitensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter arilaitensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Glutamicibacter bergerei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter bergerei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Glutamicibacter creatinolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter creatinolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Glutamicibacter nicotianae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter mysorens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter nicotianae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Glutamicibacter protophormiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter protophormiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Glutamicibacter uratoxydans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter uratoxydans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Glutamicibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kocuria rosea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kocuria erythromyxa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus roseus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kocuria varians"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kocuria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus antarcticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus flavus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus luteus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus lylae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nesterenkonia halobia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus halobius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nesterenkonia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenarthrobacter aurescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter aurescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenarthrobacter histidinolovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter histidinolovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenarthrobacter ilicis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter ilicis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenarthrobacter nicotinovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter nicotinovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenarthrobacter nitroguajacolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter nitroguajacolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenarthrobacter ureafaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter ureafaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenarthrobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paeniglutamicibacter gangotriensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter gangotriensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paeniglutamicibacter kerguelensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter kerguelensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paeniglutamicibacter psychrophenolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter psychrophenolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paeniglutamicibacter sulfureus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter sulfureus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paeniglutamicibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudarthrobacter chlorophenolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter chlorophenolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudarthrobacter oxydans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter oxydans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudarthrobacter polychromogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter polychromogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudarthrobacter scleromae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter scleromae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudarthrobacter sulfonivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter sulfonivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudarthrobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoglutamicibacter albus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter albus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoglutamicibacter cumminsii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter cumminsii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoglutamicibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rothia aeria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rothia dentocariosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rothia kristinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kocuria kristinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcus kristinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rothia mucilaginosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stomatococcus mucilaginosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rothia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cellulosimicrobium cellulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cellulomonas cellulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cellulosimicrobium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Oerskovia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Promicromonosporaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tropheryma whipplei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tropheryma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tropherymataceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micrococcales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micromonospora chalcea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micromonospora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micromonosporaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micromonosporales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium accolens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium afermentans subsp. afermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium afermentans subsp. lipophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium afermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium ammoniagenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium ammoniagenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium amycolatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium appendicis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium aquatimens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium aquilae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium argentoratense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium atypicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium aurimucosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium nigricans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium auris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium auriscanis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium belfantii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium beticola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium bovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium callunae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium camporealense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium camporealensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium capitovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium casei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium caspium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium ciconiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium confusum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium coyleae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium cystitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium dentalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium diphtheriae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium durum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium efficiens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium falsenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium felinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium flavescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium fournieri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium freiburgense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium freneyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium genitalium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium glaucum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium glucuronolyticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium seminale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium glutamicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium lilium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium gottingense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium halotolerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium hansenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium imitans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium jeikeium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium kroppenstedtii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium kutscheri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium lipophiloflavum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium lowii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium macginleyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium massiliense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium mastitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium matruchotii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacterionema matruchotii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium mediolanum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium minutissimum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium mucifaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium mycetoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium oculi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium otitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Turicella otitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium phocae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium pilbarense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium pilosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium propinquum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium pseudodiphtheriticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium pseudogenitalium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium pseudotuberculosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium pyruviciproducens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium renale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium resistens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium riegelii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium rouxii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium rubrum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium simulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium singulare"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium sphenisci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium spheniscorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium sputi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium striatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium suicordis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium sundsvallense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium terpenotabidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium testudinoris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium thomssenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium timonense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium tuberculostearicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium tuscaniense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium tuscaniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium ulcerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium urealyticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium ureicelerivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium variabile"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter variabilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium mooreparkense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium variabilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium vitaeruminis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium vitaeruminis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacterium vitarumen"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium vitarumen"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium xerosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Turicella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dietzia maris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dietzia cinnamea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dietzia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dietziaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordonia bronchialis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus bronchialis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordonia otitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordonia polyisoprenivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordonia rubripertincta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordonia rubropertinctus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus rubropertinctus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordonia sputi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordonia terrae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus terrae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordonia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gordoniaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium arosiense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium avium subsp. paratuberculosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium paratuberculosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium avium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium bouchedurhonense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium colombiense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium intracellulare subsp. chimaera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium chimaera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium intracellulare"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium marseillense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium timonense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium avium complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium conceptionense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium fortuitum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium mageritense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium peregrinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium porcinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium senegalense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium septicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium fortuitum complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium arupense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium heraklionense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium hiberniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium kumamotonense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium longobardum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium nonchromogenicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium senuense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium terrae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium terrae complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium mungi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium tuberculosis subsp. canetti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium canetti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium tuberculosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium africanum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium bovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium caprae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium microti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium pinnipedii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium tuberculosis complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium abscessus subsp. massiliense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium massiliense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium abscessus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium agri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium aichiense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium alsense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium alvei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium asiaticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium aubagnense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium aurum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium austroafricanum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium vanbaalenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium bacteremicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium basiliense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium boenickei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium bohemicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium branderi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium brisbanense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium brumae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium canariasense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium celatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium chelonae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium chesapeaki"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium chitae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium chlorophenolicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus chlorophenolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium chubuense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium confluentis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium conspicuum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium cookii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium cosmeticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium diernhoferi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium doricum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium duvalii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium elephantis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium europaeum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium fallax"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium farcinogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium flavescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium florentinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium fragae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium frederiksbergense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium gadium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium gastri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium genavense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium gilvum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium goodii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium gordonae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium grossiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium haemophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium hassiacum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium heckeshornense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium heidelbergense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium hodleri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium holsaticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium houstonense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium immunogenum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium interjectum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium intermedium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium iranicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium kansasii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium komossense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium koreense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium kubicae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium kyorinense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium lacus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium lentiflavum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium leprae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium lepromatosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium llatzerense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium madagascariense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium malmoense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium mantenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium marinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium monacense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium montefiorense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium moriokaense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium mucogenicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium murale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium nebraskense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium neoaurum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium neworleansense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium noviomagense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium novocastrense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium obuense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium palustre"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium paraffinicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium parafortuitum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium paragordonae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium parakoreense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium parascrofulaceum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium paraseoulense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium parmense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium phlei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium phocaicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium poriferae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium psychrotolerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium rhodesiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium riyadhense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium saskatchewanense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium scrofulaceum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium seoulense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium setense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium sherrisii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium shimoidei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium shinjukuense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium shottsii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium simiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium smegmatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium sphagni"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium szulgai"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium thermoresistibile"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium tokaiense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium triplex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium triviale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium tusciae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium ulcerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium vaccae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium wolinskyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium xenopi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia abscessus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia asteroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia cyriacigeorgica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia farcinica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia nova"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia otitidiscaviarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia asteroides complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia africana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia anaemiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia aobensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia araoensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia arthritidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia asiatica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia beijingensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia brasiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia brevicatena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Micropolyspora brevicatena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia carnea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia elegans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia higoensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia inohanensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia kruczakiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia mexicana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia niigatensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia paucivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia pseudobrasiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia sienata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia testacea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia transvalensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia veterana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia yamanashiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus chubuensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus equi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium equi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus erythropolis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus fascians"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium fascians"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus luteus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus globerulus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus gordoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus hoagii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium hoagii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus obuensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus rhodochrous"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus roseus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tsukamurella inchonensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tsukamurella paurometabola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corynebacterium paurometabolum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodococcus aurantiacus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tsukamurella pulmonis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tsukamurella strandjordii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tsukamurella tyrosinosolvens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tsukamurella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tsukamurellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycobacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidipropionibacterium acidipropionici"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium acidipropionici"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidipropionibacterium jensenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium jensenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidipropionibacterium microaerophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium microaerophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidipropionibacterium thoenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium thoenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidipropionibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arachnia propionica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium propionicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arachnia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cutibacterium acnes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium acnes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cutibacterium avidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium avidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cutibacterium granulosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium granulosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cutibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium australiense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium cyclohexanicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium freudenreichii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propioniferax innocua"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium innocuum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propioniferax"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionimicrobium lymphophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacterium lymphophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionimicrobium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Propionibacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Amycolatopsis orientalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardia orientalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Amycolatopsis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharomonospora glauca"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharomonospora viridis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharomonospora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharopolyspora rectivirgula"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharopolyspora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudonocardiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudonocardiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardiopsis dassonvillei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardiopsis synnemataformans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardiopsis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nocardiopsidaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomadura latina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomadura madurae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomadura pelletieri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomadura"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thermomonosporaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptosporangiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Atopobium fossor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium fossor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Atopobium minutum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus minutus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Atopobium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fannyhessea vaginae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Atopobium vaginae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fannyhessea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lancefieldella parvula"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Atopobium parvulum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus parvulus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus parvulus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lancefieldella rimae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Atopobium rimae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus rimae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lancefieldella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Atopobiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Collinsella aerofaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium aerofaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Collinsella intestinalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Collinsella stercoris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Collinsella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coriobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coriobacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cryptobacterium curtum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cryptobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eggerthella lenta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium lentum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eggerthella sinensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eggerthella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Slackia exigua"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium exiguum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Slackia heliotrinireducens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Slackia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eggerthellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eggerthellales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coriobacteriia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Patulibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Patulibacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Solirubrobacterales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thermoleophilia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomycetota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kyrpidia tusciae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus tusciae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kyrpidia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alicyclobacillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalicoccobacillus gibsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus gibsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shouchella gibsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalicoccobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalicoccus saliphilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus saliphilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalicoccus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalihalobacillus alcalophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus alcalophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalihalobacillus algicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus algicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalihalobacillus macyae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus macyae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalihalobacillus pseudalcaliphilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pseudalcaliphilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalihalobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalihalophilus pseudofirmus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pseudofirmus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alkalihalophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerobacillus arseniciselenatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus arseniciselenatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus anthracis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus cereus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus cytotoxicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus mycoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus weihenstephanensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pseudomycoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus thuringiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus cereus group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus amyloliquefaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus atrophaeus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus mojavensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pumilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus subtilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus subtilis subsp. subtilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus tequilensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus vallismortis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus subtilis group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus aeolius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus aerius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus benzoevorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus carboniphilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus circulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Niallia circulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus coagulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Weizmannia coagulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus decisifrondis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus horti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus inaquosorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus subtilis subsp. inaquosorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus infantis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus infernus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus licheniformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus methanolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus nealsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Niallia nealsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus smithii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus sonorensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus spizizenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus subtilis subsp. spizizenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus thermoamylovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus thermocloacae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus velezensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ectobacillus funiculus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus funiculus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ectobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Evansella clarkii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus clarkii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Evansella vedderi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus vedderi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Evansella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exiguobacterium acetylicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exiguobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falsibacillus pallidus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pallidus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falsibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ferdinandcohnia humi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus humi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ferdinandcohnia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fictibacillus barbaricus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus barbaricus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fictibacillus gelatini"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus gelatini"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fictibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geobacillus kaustophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus kaustophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geobacillus stearothermophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geobacillus thermocatenulatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus thermocatenulatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geobacillus thermodenitrificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus thermodenitrificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gottfriedia luciferensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus luciferensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gottfriedia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gracilibacillus dipsosauri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus dipsosauri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gracilibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halalkalibacter krulwichiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus krulwichiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halalkalibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halalkalibacterium halodurans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus halodurans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus okuhidensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halalkalibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Heyndrickxia oleronia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus oleronius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Heyndrickxia shackletonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus shackletonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Margalitia shackletonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Heyndrickxia sporothermodurans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus sporothermodurans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Heyndrickxia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lederbergia galactosidilytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus galactosidilyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lederbergia lenta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus lentus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lederbergia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metabacillus fastidiosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus fastidiosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metabacillus idriensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus idriensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metabacillus indicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus indicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metabacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parageobacillus thermantarcticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus thermantarcticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parageobacillus thermoglucosidasius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus thermoglucosidasius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geobacillus thermoglucosidasius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parageobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peribacillus asahii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus asahii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peribacillus butanolivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus butanolivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peribacillus muralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus muralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peribacillus psychrosaccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus psychrosaccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peribacillus simplex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus simplex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peribacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Priestia endophytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus endophyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Priestia flexa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus flexus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Priestia megaterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus megaterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Priestia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudalkalibacillus decolorationis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus decolorationis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudalkalibacillus hwajinpoensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus hwajinpoensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudalkalibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudobacillus badius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus badius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rossellomorea aquimaris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus aquimaris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rossellomorea marisflavi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus marisflavi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rossellomorea vietnamensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus vietnamensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rossellomorea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salipaludibacillus agaradhaerens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus agaradhaerens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salipaludibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salisediminibacterium selenitireducens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus selenitireducens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salisediminibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schinkia azotoformans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus azotoformans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schinkia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shouchella clausii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus clausii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shouchella patagoniensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus patagoniensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shouchella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Siminovitchia farraginis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus farraginis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Siminovitchia fordii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus fordii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Siminovitchia fortis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus fortis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Siminovitchia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sutcliffiella cohnii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus cohnii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sutcliffiella halmapala"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus halmapalus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sutcliffiella horikoshii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus horikoshii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sutcliffiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Virgibacillus halodenitrificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus halodenitrificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Virgibacillus pantothenticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pantothenticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Virgibacillus salexigens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus salexigens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Virgibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bhargavaea ginsengi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus ginsengi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bhargavaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Jeotgalibacillus marinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus marinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Jeotgalibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kurthia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lysinibacillus odysseyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus odysseyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lysinibacillus sphaericus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus sphaericus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lysinibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Psychrobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rummeliibacillus pycnus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pycnus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rummeliibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Solibacillus silvestris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus silvestris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Solibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporosarcina pasteurii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pasteurii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporosarcina psychrophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus psychrophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporosarcina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ureibacillus massiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus massiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ureibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Caryophanaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cytobacillus firmus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus firmus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cytobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mesobacillus boroniphilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus boroniphilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mesobacillus jeotgali"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus jeotgali"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mesobacillus subterraneus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus subterraneus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mesobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus bataviensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus bataviensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus drentensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus drentensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus fumarioli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus fumarioli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus niacini"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus niacini"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus novalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus novalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus pocheonensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pocheonensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus soli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus soli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus vireti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus vireti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Robertmurraya korlensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus korlensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Robertmurraya siralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus siralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Robertmurraya"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cytobacillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gemella bergeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gemella bergeriae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gemella haemolysans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gemella morbillorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus morbillorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gemella sanguinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gemella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gemellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeria grayi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeria innocua"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeria ivanovii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeria monocytogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeria seeligeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeria welshimeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listeriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aneurinibacillus aneurinilyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus aneurinilyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus aneurinolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aneurinibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacillus agri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus agri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus galactophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacillus brevis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus brevis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacillus centrosporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus centrosporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacillus laterosporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus laterosporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacillus parabrevis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus parabrevis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus agaridevorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus alvei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus alvei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus edaphicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus edaphicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus ehimensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus ehimensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus larvae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus larvae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pulvifaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus lentimorbus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus lentimorbus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus macerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus macerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus mucilaginosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus mucilaginosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus pabuli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus pabuli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus polymyxa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus polymyxa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus popilliae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus popilliae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus provencensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus thiaminolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus thiaminolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus urinalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus validus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus validus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus gordonae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paenibacillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pullulanibacillus naganoensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus naganoensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pullulanibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporolactobacillus laevolacticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillus laevolacticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporolactobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporolactobacillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Macrococcus bovicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Macrococcus carouselicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Macrococcus caseolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus caseolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Macrococcus equipercicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Macrococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus arlettae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus auricularis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus borealis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus capitis subsp. capitis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus capitis subsp. urealyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus capitis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus caprae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus carnosus subsp. carnosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus carnosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus carnosus subsp. utilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus casei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus succinus subsp. casei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus cohnii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus cohnii subsp. cohnii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus condimenti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus epidermidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus equorum subsp. equorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus equorum subsp. linens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus equorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus felis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus fleurettii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mammaliicoccus fleurettii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus gallinarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus haemolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus hominis subsp. hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus hominis subsp. novobiosepticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus kloosii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus lentus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mammaliicoccus lentus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus sciuri subsp. lentus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus lugdunensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus massiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus muscae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus nepalensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus pasteuri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus pettenkoferi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus piscifermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus pseudolugdunensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus saccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptococcus saccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus saprophyticus subsp. saprophyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus saprophyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus saprophyticus subsp. bovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus sciuri subsp. sciuri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus sciuri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mammaliicoccus sciuri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus sciuri subsp. carnaticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus sciuri subsp. rodentium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus simulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus succinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus succinus subsp. succinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus ureilyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus cohnii subsp. urealyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus vitulinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mammaliicoccus vitulinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus pulvereri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus warneri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus xylosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coagulase-negative staphylococci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus argenteus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus aureus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus coagulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus schleiferi subsp. coagulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus cornubiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus delphini"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus intermedius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus lutrae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus pseudintermedius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus schleiferi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus schleiferi subsp. schleiferi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coagulase-positive staphylococci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus chromogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus hyicus subsp. chromogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus hyicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus hyicus subsp. hyicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coagulase-variable staphylococci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Staphylococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kroppenstedtia eburnea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kroppenstedtia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thermoactinomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thermoactinomycetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Caryophanales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Abiotrophia defectiva"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus defectivus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Abiotrophia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aerococcus christensenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aerococcus sanguinicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aerococcus urinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aerococcus urinaeequi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pediococcus urinaeequi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aerococcus urinaehominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aerococcus viridans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aerococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dolosicoccus paucivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dolosicoccus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Facklamia hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Facklamia ignava"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Facklamia languida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Facklamia sourekii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Facklamia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Globicatella sanguinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Globicatella sulfidifaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Globicatella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ignavigranum ruoffiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ignavigranum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ruoffia tabacinasalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Facklamia tabacinasalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ruoffia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aerococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alloiococcus otitis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alloiococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dolosigranulum pigrum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dolosigranulum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Granulicatella adiacens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Abiotrophia adiacens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus adjacens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Granulicatella elegans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Abiotrophia elegans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Granulicatella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Carnobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus asini"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus avium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus casseliflavus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus flavescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus cecorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus cecorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus dispar"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus durans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus durans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus faecalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus faecalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus faecium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus faecium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus gallinarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus gallinarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus gilvus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus haemoperoxidus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus hermanniensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus hirae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus italicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus saccharominimus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus malodoratus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus moraviensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus mundtii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus pallens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus phoeniculicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus pseudoavium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus raffinosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus ratti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus saccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus saccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus sulfureus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus villorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tetragenococcus halophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tetragenococcus solitarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus solitarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tetragenococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vagococcus fluvialis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vagococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacticaseibacillus casei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus casei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacticaseibacillus paracasei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus paracasei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacticaseibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactiplantibacillus plantarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus arizonensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus plantarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactiplantibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus acidophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus amylovorus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus crispatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus delbrueckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus gasseri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus iners"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus jensenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus johnsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus kalixensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus rhamnosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacticaseibacillus rhamnosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus ultunensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Latilactobacillus sakei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus sakei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Latilactobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lentilactobacillus buchneri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus buchneri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lentilactobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leuconostoc citreum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leuconostoc amelibiosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leuconostoc lactis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leuconostoc mesenteroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leuconostoc pseudomesenteroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leuconostoc"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Levilactobacillus brevis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus brevis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Levilactobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ligilactobacillus salivarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus salivarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ligilactobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Limosilactobacillus antri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus antri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Limosilactobacillus fermentum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus cellobiosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus fermentum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Limosilactobacillus gastricus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus gastricus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Limosilactobacillus oris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus oris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Limosilactobacillus reuteri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus reuteri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Limosilactobacillus vaginalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus vaginalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Limosilactobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pediococcus acidilactici"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pediococcus pentosaceus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pediococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Weissella confusa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus confusus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Weissella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactococcus garvieae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterococcus seriolicida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactococcus lactis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus lactis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alpha-hemolytic streptococci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Beta-hemolytic streptococci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gamma-hemolytic streptococci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus anginosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus constellatus subsp. constellatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus constellatus subsp. pharyngis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus constellatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus intermedius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus anginosus group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus milleri group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus equinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus bovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus gallolyticus subsp. gallolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus gallolyticus subsp. macedonicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus gallolyticus subsp. pasteurianus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus pasteurianus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus gallolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus caprinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus infantarius subsp. coli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus infantarius subsp. infantarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus infantarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus bovis group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus cristatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus oligofermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus infantis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus mitis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus oralis subsp. dentisani"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus dentisani"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus oralis subsp. tigurinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus tigurinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus oralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus peroris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus pseudopneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus mitis group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus hyovaginalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus mutans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus ratti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus sobrinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus mutans group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus salivarius subsp. salivarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus salivarius subsp. thermophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus thermophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus salivarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus vestibularis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus salivarius group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus gordonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus parasanguinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus sanguinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus sanguis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus sanguinis group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Viridans streptococci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus acidominimus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus agalactiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Group B streptococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus alactolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus intestinalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus australis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus criceti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus devriesei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus downei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus dysgalactiae subsp. dysgalactiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus dysgalactiae subsp. equisimilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus dysgalactiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus entericus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus equi subsp. equi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus equi subsp. zooepidemicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus equi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus ferus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus gallinaceus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus halichoeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus hongkongensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus iniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus shiloi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus lactarius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus lutetiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus macacae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus massiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus merionis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus minor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus ovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus parauberis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus pluranimalium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus porcinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus pseudoporcinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus pyogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Group A streptococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus sinensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus suis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus thoraltensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus uberis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus urinalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacilli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Catabacter hongkongensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Christensenella hongkongensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Catabacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Christensenella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Christensenellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium argentinense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium baratii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium barati"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium paraperfringens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium perenne"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium beijerinckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium botulinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium budayi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium budayi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium butyricum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium cadaveris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium carnis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium celatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium chauvoei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium cochlearium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium lentoputrescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium cocleatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium combesii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium combesii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium disporicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium fallax"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium haemolyticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium hydrogeniformans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium innocuum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium intestinale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium leptum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium malenominatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium moniliforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium moniliforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium neonatale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium novyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium paraputrificum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium perfringens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium putrefaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium ramosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium sardiniense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium absonum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium septicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium spiroforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium sporogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium subterminale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium symbiosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium tertium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium tetani"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hathewaya histolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium histolyticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hathewaya limosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium limosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hathewaya"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hungatella hathewayi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium hathewayi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hungatella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarcina ventriculi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium ventriculi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarcina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium barkeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium barkeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium brachy"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium callanderi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium infirmum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium limosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium minutum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium nodatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium ramulus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium saphenum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium siraeum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium sulci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium sulci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium tenue"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium ventriosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium yurii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoramibacter alactolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium alactolyticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoramibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agathobacter rectalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium rectale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agathobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerobutyricum hallii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium hallii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerobutyricum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerostipes hadrus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium hadrum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerostipes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Blautia coccoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Blautia hansenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ruminococcus hansenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptococcus hansenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Blautia producta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus productus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ruminococcus productus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Blautia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Butyrivibrio fibrisolvens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Butyrivibrio hungatei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Butyrivibrio"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Catonella morbi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Catonella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coprococcus eutactus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coprococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dorea formicigenerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dorea longicatena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dorea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterocloster aldenensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium aldenense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterocloster bolteae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium bolteae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterocloster citroniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium citroniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterocloster clostridioformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium clostridioforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterocloster lavalensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium lavalense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterocloster"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalicatena contorta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium contortum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalicatena orotica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium oroticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalicatena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lachnoanaerobaculum orale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lachnoanaerobaculum saburreum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium saburreum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lachnoanaerobaculum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lachnospira eligens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium eligens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lachnospira"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacrimispora amygdalina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium amygdalinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacrimispora celerecrescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium celerecrescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacrimispora indolis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium indolis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacrimispora sphenoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium sphenoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lacrimispora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mediterraneibacter gnavus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ruminococcus gnavus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mediterraneibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Robinsoniella peoriensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Robinsoniella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lachnospiraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalibacterium prausnitzii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium prausnitzii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalispora sporosphaeroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium sporosphaeroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalispora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavonifractor plautii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium orbiscindens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium plautii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium plauti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium plautii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavonifractor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoflavonifractor capillosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides capillosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoflavonifractor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ruminococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Oscillospiraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptococcus niger"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerococcus hydrogenalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus hydrogenalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerococcus lactolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus lactolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerococcus octavius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus octavius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerococcus prevotii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus prevotii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerococcus tetradius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus tetradius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerococcus vaginalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus vaginalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ezakiella coagulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides coagulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ezakiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Finegoldia magna"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus magnus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Finegoldia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gallicola barnesae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gallicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helcococcus kunzii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helcococcus sueciensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helcococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parvimonas micra"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus micros"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parvimonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptoniphilus asaccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptococcus asaccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus asaccharolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptoniphilus harei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptoniphilus ivorii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptoniphilus lacrimalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptoniphilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptoniphilaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mogibacterium diversum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mogibacterium neglectum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mogibacterium timidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium timidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mogibacterium vescum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mogibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerovoracaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Asaccharospora irregularis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium irregulare"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium irregularis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Asaccharospora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridioides difficile"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium difficile"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridioides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Filifactor alocis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium alocis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Filifactor villosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium villosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Filifactor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Intestinibacter bartlettii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium bartlettii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Intestinibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paeniclostridium ghonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium ghoni"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium ghonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paeniclostridium sordellii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium sordellii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paeniclostridium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paraclostridium bifermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium bifermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paraclostridium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus anaerobius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Terrisporobacter glycolicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium glycolicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Terrisporobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Peptostreptococcales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tissierella praeacuta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides praeacutus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridium hastiforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tissierella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tissierellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tissierellales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clostridia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Catenibacterium mitsuokai"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Catenibacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eggerthia catenaformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus catenaformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eggerthia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kandleria vitulina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lactobacillus vitulinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kandleria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coprobacillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Amedibacillus dolichus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium dolichum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Amedibacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerorhabdus furcosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerorhabdus furcosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides furcosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerorhabdus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bulleidia extructa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bulleidia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erysipelothrix inopinata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erysipelothrix rhusiopathiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erysipelothrix tonsillarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erysipelothrix"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalitalea cylindroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium cylindroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Faecalitalea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Holdemanella biformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eubacterium biforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Holdemanella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Holdemania filiformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Holdemania"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Solobacterium moorei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Solobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erysipelotrichaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Turicibacter sanguinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Turicibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Turicibacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erysipelotrichales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erysipelotrichia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidaminococcus fermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidaminococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidaminococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidaminococcales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Centipeda periodontii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Centipeda"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Megamonas hypermegale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides hypermegas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Megamonas hypermegas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Megamonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mitsuokella multacida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides multiacidus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mitsuokella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonas artemidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonas dianae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonas flueggei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonas infelix"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonas noxia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonas sputigena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Selenomonadales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dialister micraerophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dialister pneumosintes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dialister"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Megasphaera elsdenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Megasphaera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella atypica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella caviae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella criceti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella dispar"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella montpellierensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella parvula"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella alcalescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella ratti"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella rodentium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Veillonellales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Negativicutes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acholeplasma laidlawii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acholeplasma oculi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acholeplasma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acholeplasmataceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acholeplasmatales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma spermatophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmataceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmatales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metamycoplasma buccale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma buccale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metamycoplasma faucium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma faucium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metamycoplasma hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metamycoplasma orale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma orale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metamycoplasma salivarium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma salivarium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metamycoplasma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmopsis fermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma fermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmopsis lipophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma lipophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmopsis primatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma primatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmopsis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metamycoplasmataceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malacoplasma penetrans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma penetrans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malacoplasma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmoides genitalium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma genitalium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmoides pirum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma pirum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmoides pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasma pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ureaplasma parvum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ureaplasma urealyticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ureaplasma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmoidaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmoidales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mollicutes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycoplasmatota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacillati"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium canifelinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium gonidiaformans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium equinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium mortiferum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium naviforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium necrogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium necrophorum subsp. necrophorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium necrophorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium necrophorum subsp. funduliforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium nucleatum subsp. nucleatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium nucleatum subsp. polymorphum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium polymorphum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium nucleatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium nucleatum subsp. fusiforme"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium vincentii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium periodonticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium russii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium ulcerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium varium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptotrichia buccalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptotrichia trevisanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptotrichia wadei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptotrichia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoleptotrichia goodfellowii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptotrichia goodfellowii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoleptotrichia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sneathia sanguinegens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sneathia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptobacillus moniliformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Streptobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptotrichiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacteriia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacteriota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusobacteriati"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides fragilis group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides caccae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides denticanum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides eggerthii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides faecis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides fluxus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides fragilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides galacturonicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides nordii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides ovatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides pectinophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides pyogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides suis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides tectus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides salyersiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides stercoris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides thetaiotaomicron"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides uniformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides zoogleoformans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella zoogleoformans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phocaeicola dorei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides dorei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phocaeicola massiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides massiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phocaeicola vulgatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides vulgatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phocaeicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroidaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dysgonomonas capnocytophagoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dysgonomonas gadei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dysgonomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dysgonomonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Butyricimonas virosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Butyricimonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Odoribacter splanchnicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides splanchnicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Odoribacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Odoribacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas asaccharolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas cangingivalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas canoris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas catoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas circumdentaria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas crevioricanis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas cansulci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas endodontalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides endodontalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas gingivalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides gingivalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas gingivicanis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas gulae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas levii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides levii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas macacae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides macacae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides salivosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas salivosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas somerae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Porphyromonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alloprevotella tannerae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella tannerae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alloprevotella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella oralis group"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella bivia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides bivius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella buccae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides buccae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides capillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides pentosaceus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella buccalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides buccalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella corporis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides corporis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella dentalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mitsuokella dentalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella denticola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides denticola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella disiens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides disiens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella enoeca"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella heparinolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides heparinolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella intermedia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides intermedius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella loescheii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella marshii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella melaninogenica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides melaninogenicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella multiformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella multisaccharivorax"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella nigrescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella oralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides oralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella oris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides oris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella oulorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides oulorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella oulora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella pallens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella ruminicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides ruminicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella salivae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella shahii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella veroralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides veroralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prevotellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alistipes putredinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides putredinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alistipes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rikenellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parabacteroides chongii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parabacteroides distasonis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides distasonis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parabacteroides goldsteinii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides goldsteinii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parabacteroides gordonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parabacteroides merdae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides merdae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Parabacteroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tannerella forsythia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides forsythus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tannerella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tannerellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroidales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroidia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnocytophaga canimorsus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnocytophaga cynodegmi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnocytophaga gingivalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnocytophaga granulosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnocytophaga haemolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnocytophaga ochracea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides ochraceus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnocytophaga sputigena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnocytophaga"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium devorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Myroides odoratus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium odoratum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Myroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bergeyella zoohelcum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Weeksella zoohelcum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bergeyella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chryseobacterium gleum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium gleum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chryseobacterium indologenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium indologenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chryseobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Elizabethkingia meningoseptica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chryseobacterium meningosepticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium meningosepticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Elizabethkingia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Empedobacter brevis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium breve"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Empedobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Riemerella anatipestifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella anatipestifer"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella anatipestifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Riemerella anatipestifer"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Riemerella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Weeksella virosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Weeksella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Weeksellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacteriia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pedobacter antarcticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pedobacter piscium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium piscium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pedobacter heparinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cytophaga heparina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium heparinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium heparinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pedobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium faecium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium mizutaii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium mizutae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium multivorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium multivorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium spiritivorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium spiritivorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium yabuuchiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium thalpophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavobacterium thalpophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingobacteriia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroidota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydia abortus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydophila abortus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydia pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydophila pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydia psittaci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydophila psittaci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydia trachomatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydiia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chlamydiota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevundimonas diminuta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas diminuta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevundimonas vesicularis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas vesicularis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brevundimonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Caulobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Caulobacterales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aureimonas altamirensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aurantimonas altamirensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aureimonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aurantimonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bartonella bacilliformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bartonella clarridgeiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bartonella elizabethae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rochalimaea elizabethae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bartonella henselae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rochalimaea henselae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bartonella quintana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rochalimaea quintana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bartonella vinsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rochalimaea vinsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bartonella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bartonellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella anthropi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ochrobactrum anthropi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella intermedia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ochrobactrum intermedium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella melitensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella abortus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella neotomae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella ovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella suis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ochrobactrum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brucellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Methylobacterium mesophilicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Methylobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Methylorubrum zatmanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Methylobacterium zatmanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Methylorubrum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Methylobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Afipia clevelandensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Afipia felis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Afipia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nitrobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agrobacterium radiobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizobium radiobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agrobacterium rubi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizobium rubi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agrobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Allorhizobium vitis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizobium vitis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Allorhizobium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizobium viscosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter viscosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizobium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizobiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Azorhizobium caulinodans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Azorhizobium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xanthobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hyphomicrobiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paracoccus yeei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paracoccus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paracoccaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodobacterales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Roseomonas cervicalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Roseomonas gilardii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Roseomonas mucosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Roseomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acetobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Azospirillum brasilense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Azospirillum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Inquilinus limosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Inquilinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Azospirillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodospirillales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaplasma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ehrlichia sennetsu"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neorickettsia sennetsu"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ehrlichia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neorickettsia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ehrlichiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orientia tsutsugamushi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia tsutsugamushi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Orientia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia akari"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia conorii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia parkeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia prowazekii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia rickettsii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia sibirica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia typhi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rickettsiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingomonas parapaucimobilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingomonas paucimobilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas paucimobilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingomonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphingomonadales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alphaproteobacteria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Achromobacter denitrificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Achromobacter piechaudii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alcaligenes piechaudii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Achromobacter ruhlandii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Achromobacter xylosoxidans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Achromobacter xylosoxidans subsp. xylosoxidans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alcaligenes xylosoxidans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alcaligenes xylosoxidans subsp. xylosoxidans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Achromobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alcaligenes faecalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alcaligenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella avium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella bronchiseptica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella hinzii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella holmesii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella parapertussis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella pertussis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella petrii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella trematum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bordetella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kerstersia gyiorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kerstersia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Oligella ureolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Oligella urethralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella urethralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Oligella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alcaligenaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia ambifaria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia anthina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia cenocepacia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia cepacia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas cepacia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia dolosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia multivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia pyrrocinia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas pyrrocinia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia stabilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia vietnamiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia cepacia complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia arboris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia contaminans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia diffusa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia gladioli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas antimicrobica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas cocovenenans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas gladioli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia lata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia latens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia mallei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas mallei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia metallica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia pseudomallei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas pseudomallei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia thailandensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia ubonensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cupriavidus basilensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cupriavidus gilardii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ralstonia gilardii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wautersia gilardii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cupriavidus metallidurans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cupriavidus necator"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cupriavidus pauculus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wautersia paucula"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cupriavidus respiraculi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ralstonia respiraculi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cupriavidus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pandoraea apista"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pandoraea norimbergensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pandoraea pnomenusa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pandoraea pulmonicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pandoraea sputorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pandoraea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paraburkholderia fungorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia fungorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paraburkholderia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ralstonia insidiosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ralstonia mannitolilytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ralstonia pickettii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderia pickettii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas pickettii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ralstonia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wautersia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidovorax delafieldii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas delafieldii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidovorax facilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas facilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidovorax temperans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acidovorax"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Comamonas aquatica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Comamonas kerstersii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Comamonas terrigena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Comamonas testosteroni"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas testosteroni"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Comamonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Delftia acidovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Comamonas acidovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas acidovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Delftia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Comamonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Herbaspirillum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Massilia timonae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Massilia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Oxalobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aquabacterium parvum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aquabacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphaerotilaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sutterella wadsworthensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sutterella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sutterellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Burkholderiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chromobacterium violaceum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chromobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chromobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alysiella crassa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Simonsiella crassa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alysiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eikenella corrodens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eikenella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kingella denitrificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kingella kingae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kingella oralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kingella potus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kingella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria animaloris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria bacilliformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria cinerea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria dentiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria dumasiana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria elongata subsp. elongata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria elongata subsp. glycolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria elongata subsp. nitroreducens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria elongata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria flava"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria flavescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria gonorrhoeae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria iguanae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria lactamica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria macacae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria meningitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria mucosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria oralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria perflava"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria polysaccharea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria shayeganii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria sicca"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria subflava"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria wadsworthii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria weaveri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria zoodegmatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Simonsiella muelleri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Simonsiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Spirillum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Spirillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Spirillales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Betaproteobacteria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas bestiarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas caviae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas punctata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas encheleia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas enteropelogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas trota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas eucrenophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas hydrophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas jandaei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas media"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas molluscorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas popoffii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas salmonicida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas schubertii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas simiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas sobria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas veronii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerobiospirillum succiniciproducens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerobiospirillum thomasii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Anaerobiospirillum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Succinivibrio dextrinosolvens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Succinivibrio"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Succinivibrionaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aeromonadales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shewanella algae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shewanella putrefaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shewanella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shewanellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alteromonadales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Francisella tularensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Francisella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Francisellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Beggiatoales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cardiobacterium hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cardiobacterium valvarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cardiobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dichelobacter nodosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides nodosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dichelobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Suttonella indologenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kingella indologenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Suttonella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cardiobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cardiobacteriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alishewanella fetalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alishewanella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chromatiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chromatiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Budvicia aquatica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Budvicia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leminorella grimontii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leminorella richardii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leminorella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pragia fontium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pragia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Budviciaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Averyella dalhousiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Averyella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Buttiauxella agrestis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Buttiauxella brennerae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Buttiauxella ferragutiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Buttiauxella gaviniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Buttiauxella izardii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Buttiauxella noackiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Buttiauxella warmboldiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Buttiauxella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cedecea davisae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cedecea lapagei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cedecea neteri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cedecea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter amalonaticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Levinea amalonatica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter braakii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter farmeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter freundii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter gillenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter koseri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter diversus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter murliniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter pasteurii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter rodentium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter sedlakii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter werkmanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter youngae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Citrobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cronobacter dublinensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cronobacter malonaticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cronobacter muytjensii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cronobacter sakazakii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter sakazakii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cronobacter turicensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cronobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter asburiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter bugandensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter cancerogenus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia cancerogena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter cloacae subsp. dissolvens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter dissolvens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia dissolvens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter cloacae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter hormaechei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter kobei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter ludwigii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter cloacae complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter huaxiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter quasihormaechei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter wuhouensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Escherichia albertii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Escherichia coli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Escherichia fergusonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Escherichia hermannii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Escherichia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella aerogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter aerogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella granulomatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Calymmatobacterium granulomatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella grimontii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella ornithinolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Raoultella ornithinolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella oxytoca"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella pasteurii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella planticola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella trevisanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Raoultella planticola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella pneumoniae subsp. ozaenae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella ozaenae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella pneumoniae subsp. pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella pneumoniae subsp. rhinoscleromatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella rhinoscleromatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella pneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella quasipneumoniae subsp. quasipneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella quasipneumoniae subsp. similipneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella quasipneumoniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella terrigena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Raoultella terrigena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella variicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella singaporensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Klebsiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Calymmatobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Raoultella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kluyvera ascorbata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kluyvera cryocrescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kluyvera georgiana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kluyvera intermedia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter intermedius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kluyvera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kosakonia cowanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter cowanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kosakonia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leclercia adecarboxylata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Escherichia adecarboxylata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leclercia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lelliottia amnigena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter amnigenus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lelliottia nimipressuralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter nimipressuralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia nimipressuralis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lelliottia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Plesiomonas shigelloides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Plesiomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pluralibacter gergoviae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter gergoviae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pluralibacter pyrinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter pyrinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pluralibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudescherichia vulneris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Escherichia vulneris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudescherichia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella bongori"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. arizonae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. diarizonae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Bareilly"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Bareilly"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Choleraesuis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella choleraesuis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Enteritidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enteritidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Infantis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Infantis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Isangi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Isangi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Kottbus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Kottbus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Livingstone"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Livingstone"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Montevideo"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Montevideo"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Newport"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Newport"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Ohio"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Ohio"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Senftenberg"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Senftenberg"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Tennessee"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Tennessee"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Typhi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella typhi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Typhimurium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella typhimurium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Urbana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Urbana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Virchow"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Virchow"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica Worthington"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella Worthington"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. enterica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. houtenae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. indica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica subsp. salamae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella enterica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Salmonella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shigella boydii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shigella dysenteriae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shigella flexneri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shigella sonnei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Shigella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trabulsiella guamensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trabulsiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yokenella regensburgei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Koserella trabulsii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yokenella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia persicina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia persicinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mixta calida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea calida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mixta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea agglomerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacter agglomerans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea ananatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia ananas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia ananatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwinia uredovora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea ananas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea brenneri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea conspicua"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea dispersa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea eucrina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea septica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pantoea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tatumella ptyseos"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tatumella saanichensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tatumella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Erwiniaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Edwardsiella hoshinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Edwardsiella ictaluri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Edwardsiella tarda"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Edwardsiella anguillimortifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Edwardsiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hafnia alvei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hafnia paralvei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hafnia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Obesumbacterium proteus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Obesumbacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hafniaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moellerella wisconsensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moellerella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Morganella morganii subsp. sibonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Morganella morganii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Morganella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Photorhabdus asymbiotica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Photorhabdus luminescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xenorhabdus luminescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Photorhabdus temperata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Photorhabdus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Proteus faecis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Proteus hauseri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Proteus mirabilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Proteus myxofaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cosenzaea myxofaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Proteus penneri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Proteus vulgaris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Proteus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cosenzaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Providencia alcalifaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Providencia heimbachae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Providencia rettgeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Proteus rettgeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Providencia rustigianii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Providencia friedericiana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Providencia stuartii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Providencia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xenorhabdus nematophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xenorhabdus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Morganellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pectobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sodalis praecaptivus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sodalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pectobacteriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ewingella americana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ewingella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rahnella aquatilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rahnella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia entomophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia ficaria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia fonticola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia grimesii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia liquefaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia marcescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia odorifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia plymuthica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia proteamaculans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia quinivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia rubidaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia marinorubra"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia ureilytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serratia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia aldovae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia aleksiciae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia bercovieri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia canariae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia enterocolitica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia frederiksenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia intermedia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia kristensenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia mollaretii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia pestis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia pseudotuberculosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia rohdei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia ruckeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersinia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yersiniaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterobacterales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coxiella burnetii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coxiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coxiellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella adelaidensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella anisa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella beliardensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella birminghamensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella bozemanae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fluoribacter bozemanae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella bozemanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella brunensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella busanensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella cardiaca"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella cherrii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella cincinnatiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella drancourtii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella drozanskii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella dumoffii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fluoribacter dumoffii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella erythra"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella fairfieldensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella fallonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella feeleii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella geestiana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella gormanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fluoribacter gormanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella hackeliae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella indianapolisensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella israelensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella jamestowniensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella jordanis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella lansingensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella londiniensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella longbeachae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella lytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella maceachernii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella micdadei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella pittsburghensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tatlockia micdadei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella moravica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella nagasakiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella nautarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella oakridgensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella parisiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella pneumophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella quateirensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella quinlivanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella rowbothamii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella rubrilucens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella sainthelensi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella santicrucis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella shakespearei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella spiritensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella steelei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella steigerwaltii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella taurinensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella tucsonensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella wadsworthii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella waltersii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella worsleiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fluoribacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Legionellales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoxanthomonas koreensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudoxanthomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stenotrophomonas beteli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas beteli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas betle"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stenotrophomonas maltophilia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas maltophilia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xanthomonas maltophilia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stenotrophomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xanthomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lysobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dyella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodanobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lysobacterales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Balneatrix alpica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Balneatrix"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Balneatricaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halomonas venusta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halomonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Oceanospirillales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobacillus equuli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobacillus hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobacillus lignieresii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobacillus suis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobacillus ureae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella ureae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobacillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aggregatibacter actinomycetemcomitans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinobacillus actinomycetemcomitans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus actinomycetemcomitans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aggregatibacter aphrophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus aphrophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aggregatibacter segnis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus segnis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aggregatibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus aegyptius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus ducreyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus haemoglobinophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Canicola haemoglobinophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus haemolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus influenzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus massiliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus parahaemolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus parainfluenzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus paraphrohaemolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus pittmaniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus sputorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Haemophilus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mannheimia haemolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella haemolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mannheimia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella aerogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella bettyae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella caballi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella dagmatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella multocida subsp. gallicida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella multocida subsp. multocida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella multocida subsp. septica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella multocida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella stomatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rodentibacter pneumotropicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurella pneumotropica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rodentibacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pasteurellales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter baumannii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter calcoaceticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter nosocomialis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter pittii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter calcoaceticus-Acinetobacter baumannii complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter baylyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter beijerinckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter bereziniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter guillouiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter gyllenbergii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter haemolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter johnsonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter junii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter lwoffii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter parvus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter radioresistens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter schindleri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter seifertii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter septicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter ursingii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter variabilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acinetobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella atlantae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella boevrei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella bovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella caprae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella catarrhalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Branhamella catarrhalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella cuniculi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria cuniculi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella lacunata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella lincolnii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella nonliquefaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella oblonga"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella osloensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella ovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neisseria ovis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Psychrobacter immobilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Psychrobacter phenylpyruvicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxella phenylpyruvica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Psychrobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moraxellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halopseudomonas pertucinogena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas pertucinogena"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Halopseudomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas aeruginosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas alcaligenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas andersonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas asiatica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas chlororaphis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas fluorescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas fulva"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas japonica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas juntendi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas luteola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chryseomonas luteola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chryseomonas polytricha"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas marginalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas mendocina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas monteilii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas mosselii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas oleovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas pseudoalcaligenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas oryzihabitans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Flavimonas oryzihabitans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas otitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas poae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas putida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrobacter siderocapsulatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas veronii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas yangonensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chryseomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stutzerimonas nosocomialis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas nosocomialis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stutzerimonas stutzeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas chloritidismutans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas perfectomarina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonas stutzeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stutzerimonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonadaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonadales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Grimontia hollisae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Grimontia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Listonella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Photobacterium damselae subsp. damselae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Photobacterium damselae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio damsela"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio damselae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Photobacterium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio alginolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Beneckea alginolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio cholerae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio cincinnatiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio fluvialis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio furnissii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio harveyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Beneckea harveyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lucibacterium harveyi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio carchariae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio trachuri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio metschnikovii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio mimicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio parahaemolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Beneckea parahaemolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio vulnificus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Beneckea vulnifica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrionaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrionales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gammaproteobacteria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bilophila wadsworthia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bilophila"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Desulfovibrio desulfuricans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Desulfovibrio piger"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Desulfovibrio"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Desulfomonas"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nitratidesulfovibrio vulgaris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Desulfovibrio vulgaris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nitratidesulfovibrio"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Desulfovibrionaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Desulfovibrionales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deltaproteobacteria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcobacter butzleri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter butzleri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcobacter nitrofigilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter nitrofigilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arcobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter coli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter concisus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter curvus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wolinella curva"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter fetus subsp. fetus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter fetus subsp. venerealis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter fetus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter gracilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides gracilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter helveticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter hominis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter hyointestinalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter insulaenigrae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter jejuni subsp. doylei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter jejuni subsp. jejuni"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter jejuni"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter lanienae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter lari"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter laridis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter mucosalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter sputorum subsp. mucosalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter rectus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wolinella recta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter showae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter sputorum subsp. bubulus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter sputorum subsp. sputorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter sputorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter upsaliensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter ureolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteroides ureolyticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter acinonychis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter acinonyx"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter aurati"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter bilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter bizzozeronii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter canadensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter cholecystus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter cinaedi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter cinaedi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter felis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter fennelliae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter fennelliae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter ganmani"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter hepaticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter mesocricetorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter muridarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter mustelae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter mustelae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter pametensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter pullorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter pylori"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacter pylori"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter nemestrinae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter rappini"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter rodentium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter salomonis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter trogontum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter typhlonius"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacter"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wolinella succinogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Vibrio succinogenes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wolinella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helicobacteraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Campylobacterales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Epsilonproteobacteria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonadota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brachyspira aalborgi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brachyspira pilosicoli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serpulina pilosicoli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brachyspira"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serpulina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brachyspiraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brachyspirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptospira interrogans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptospira"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptospiraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptospirales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia afzelii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia anserina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia burgdorferi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia caucasica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia coriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia crocidurae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia duttonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia garinii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia hermsii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia hispanica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia japonica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia lusitaniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia mazzottii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia miyamotoi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia parkeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia recurrentis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia tanukii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia theileri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia turicatae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia valaisiana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia venezuelensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borrelia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Borreliaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Treponema carateum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Treponema pallidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Treponema"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Treponemataceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Spirochaetales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Spirochaetia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Spirochaetota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudomonadati"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deinococcus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deinococcaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deinococcales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deinococci"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Deinococcota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thermotogati"
+msgstr ""
+
+#. type: Hash Value: Hierarchies ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Domain"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bacteria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolus haptosporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolus heterosporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolus meristosporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolus ranarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolomycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolomycota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Subkingdom"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiobolomyceta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phaeococcomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phaeococcomycetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lichenostigmatales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthoniomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lasiodiplodia theobromae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Botryodiplodia theobromae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lasiodiplodia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neoscytalidium dimidiatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusicoccum dimidiatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scytalidium dimidiatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scytalidium hyalinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Torula dimidiata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neoscytalidium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Botryosphaeriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Botryosphaeriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladosporium cladosporioides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladosporium herbarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladosporium sphaerospermum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladosporium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladosporiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladosporiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hormodendrum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Davidiellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Piedraia hortae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Piedraia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Piedraiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Capnodiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sydowia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hormonema"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dothioraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aureobasidium pullulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pullularia pullulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aureobasidium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pullularia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccotheciaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dothideales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Zasmidium cerophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ramichloridium cerophilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Zasmidium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycosphaerellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hortaea werneckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladosporium werneckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exophiala werneckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phaeoannellomyces werneckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hortaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Teratosphaeriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycosphaerellales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Subclass"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dothideomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrographis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eremomycetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eremomycetales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pithomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Astrosphaeriellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coniothyrium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coniothyriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pyrenochaeta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cucurbitariaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Epicoccum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Didymellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptosphaeria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptosphaeriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helminthosporium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Massarinaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alternaria alternata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alternaria dianthicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alternaria infectoria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alternaria tenuissima"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Alternaria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Macrosporium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ulocladium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bipolaris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curvularia australiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bipolaris australiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curvularia geniculata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curvularia hawaiiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bipolaris hawaiiensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curvularia lunata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curvularia spicifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bipolaris spicifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Brachycladium spiciferum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Drechslera spicifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helminthosporium spiciferum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Curvularia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exserohilum rostratum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Drechslera halodes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Drechslera rostrata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helminthosporium halodes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helminthosporium rostratum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exserohilum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pyrenophora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Drechslera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stemphylium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleosporaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falciformispora senegalensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptosphaeria senegalensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falciformispora tompkinsii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leptosphaeria tompkinsii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Falciformispora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Medicopsis romeroi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pyrenochaeta romeroi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Medicopsis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trematosphaeria grisea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Madurella grisea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trematosphaeria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trematosphaeriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleosporales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ochroconis humicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scolecobasidium humicola"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ochroconis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scolecobasidium constrictum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dactylaria constricta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ochroconis constricta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scolecobasidium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Verruconis gallopava"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ochroconis gallopava"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Verruconis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sympoventuriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Venturiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleosporomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dothideomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cyphellophora europaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora europaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cyphellophora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cyphellophoraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladophialophora bantiana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cladophialophora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exophiala bergeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exophiala dermatitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fonsecaea dermatitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hormiscium dermatitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hormodendrum dermatitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora dermatitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wangiella dermatitidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exophiala exophialae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phaeococcomyces exophialae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exophiala jeanselmei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora jeanselmei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exophiala spinifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora spinifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhinocladiella spinifera"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exophiala"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wangiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fonsecaea pedrosoi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fonsecaea compacta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fonsecaea compactum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora compacta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora pedrosoi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhinocladiella pedrosoi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fonsecaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora americana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora verrucosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhinocladiella aquaspersa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acrotheca aquaspersa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhinocladiella atrovirens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhinocladiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Herpotrichiellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phaeoannellomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chaetothyriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chaetothyriomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus candidus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus clavatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus deflectus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus fischeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neosartorya fischeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus flavipes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children ConceptType
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Variety"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus flavus var. oryzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus oryzae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus flavus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus fumigatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus glaucus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus nidulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus niger"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus niveus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus ochraceus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus parasiticus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus restrictus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus sydowii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus terreus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus ustus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus versicolor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus wentii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium aurantiogriseum var. aurantiogriseum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium puberulum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium aurantiogriseum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium commune"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium decumbens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium expansum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium griseofulvum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium patulum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium spinulosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium viridicatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aspergillaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paecilomyces variotii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paecilomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thermoascaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Neosartorya"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Talaromyces marneffei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium marneffei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Talaromyces ruber"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium rubrum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Talaromyces verruculosus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium verruculosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Talaromyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichocomaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eurotiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Emmonsia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Loboa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ajellomycetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthroderma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microsporon brachytomum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microsporum brachytomum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microsporon"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microsporum canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microsporum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nannizzia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichophyton"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Arthrodermataceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malbranchea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malbrancheaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chrysosporium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Onygenaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Onygenales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eurotiomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eurotiomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Glenosporella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scytalidium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Helotiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Oidiodendron"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Myxotrichaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leotiomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Leotiomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleurostoma richardsiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora richardsiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleurostomophora richardsiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleurostoma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleurostomophora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleurostomataceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Calosphaeriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Botryodiplodia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Diaporthales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Diaporthomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acremonium alabamense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acremonium alabamensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acremonium potronii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acremonium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bionectriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cephalosporium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Marquandomyces marquandii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paecilomyces marquandii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Marquandomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metarhizium anisopliae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metarhizium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clavicipitaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Beauveria bassiana"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Beauveria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cordyceps javanica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paecilomyces javanicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cordyceps"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cordycipitaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aleurisma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hypomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sepedonium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sphaerostilbella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Gliocladium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hypocreaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichothecium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Myrotheciomycetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bisifusarium dimerum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium dimerum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Bisifusarium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium chlamydosporum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium sporotrichioides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium culmorum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium graminearum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium incarnatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium semitectum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium javanicum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium oxysporum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium poae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium tricinctum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium verticillioides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fusarium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xenoacremonium recifei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acremonium recifei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cephalosporium recifei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xenoacremonium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nectriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Purpureocillium lilacinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Paecilomyces lilacinus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Penicillium lilacinum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Purpureocillium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ophiocordycipitaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarocladium kiliense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acremonium kiliense"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarocladium strictum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acremonium strictum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarocladium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarocladiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stachybotrys chartarum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stachybotrys"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stachybotryaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hypocreales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Graphium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Graphiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acaulium acremonium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scopulariopsis acremonium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acaulium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lomentospora prolificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scedosporium inflatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scedosporium prolificans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lomentospora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microascus paisii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scopulariopsis brumptii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microascus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scedosporium apiospermum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Aleurisma apiospermum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Monosporium apiospermum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scedosporium boydii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Acladium castellanii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Allescheria boydii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Petriellidium boydii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudallescheria boydii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scedosporium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudallescheria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scopulariopsis brevicaulis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scopulariopsis candida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Scopulariopsis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microascaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microascales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Verticillium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosphaeriaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosphaeriales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hypocreomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialemonium dimorphosporum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialemonium obovatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialemonium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cephalothecaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cephalothecales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coniochaeta hoffmannii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lecythophora hoffmannii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora hoffmannii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coniochaeta mutabilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lecythophora mutabilis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coniochaeta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lecythophora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coniochaetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Coniochaetales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporothrix schenckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporotrichum beurmannii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporotrichum schenckii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporothrix"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ophiostomataceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ophiostomatales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Amesia atrobrunnea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chaetomium atrobrunneum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Amesia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chaetomium globosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chaetomium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Chaetomiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Madurella mycetomatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Madurella mycetomi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Madurella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sordariales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thyridium curvatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialemonium curvatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thyridium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thyridiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phaeoacremonium parasiticum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phaeoacremonium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Togniniaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Togniniales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sordariomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nigrospora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Apiosporaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xylariales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Xylariomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sordariomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pezizomycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geotrichum candidum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geotrichum klebahnii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dipodascus klebahnii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geotrichum penicillatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon penicillatum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Geotrichum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Magnusiomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Blastoschizomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dipodascaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Blastobotrys"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stephanoascus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichomonascus ciferrii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida ciferrii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Stephanoascus ciferrii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichomonascus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wickerhamiella pararugosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida pararugosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cryptococcus aggregatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Torulopsis aggregata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Wickerhamiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichomonascaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yarrowia lipolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Azymoprocandida lipolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida lipolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mycotorula lipolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Torula lipolytica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Yarrowia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dipodascales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dipodascomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ogataea angusta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia angusta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ogataea polymorpha"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Hansenula polymorpha"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ogataea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia fermentans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida lambica"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia inconspicua"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida inconspicua"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Torulopsis inconspicua"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia kudriavzevii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida krusei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Nakazawaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida metapsilosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida orthopsilosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida parapsilosis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida parapsilosis complex"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida albicans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida stellatoidea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida brumptii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida dubliniensis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida pintolopesii var. pintolopesii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida pintolopesii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Torulopsis pintolopesii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida sake"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida slooffiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida slooffii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida tropicalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida zeylanoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Debaryomyces hansenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Debaryomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schwanniomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Diutina catenulata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida catenulata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida ravautii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Diutina rugosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida rugosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Diutina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kodamaea ohmeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida guilliermondii var. membranaefaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida guilliermondii var. membranifaciens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia ohmeri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Kodamaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lodderomyces elongisporus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lodderomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Meyerozyma guilliermondii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida guilliermondii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia guilliermondii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Meyerozyma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Millerozyma farinosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia farinosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Millerozyma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schwanniomyces polymorphus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Debaryomyces polymorphus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichia polymorpha"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Debaryomycetaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candidozyma auris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida auris"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candidozyma duobushaemuli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida duobushaemuli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida duobushaemulonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida duobushaemulonis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candidozyma haemuli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida haemuli"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida haemuloni"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida haemulonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Torulopsis haemulonii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candidozyma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clavispora lusitaniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida lusitaniae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Clavispora"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sungouiella intermedia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida intermedia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sungouiella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Metschnikowiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Serinales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pichiomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Azymocandida mycoderma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Candida vini"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Azymocandida"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharomycetales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporopachydermia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporopachydermiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporopachydermiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporopachydermiomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saccharomycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ascomycota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schizophyllum commune"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schizophyllum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Schizophyllaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pleurotineae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agaricales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agaricomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Necator"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corticiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Corticiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporotrichum gougerotii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Phialophora gougerotii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporotrichum pruinosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporotrichum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fomitopsidaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Polyporales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agaricomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tausonia pullulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon pullulans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tausonia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mrakiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cystofilobasidiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tremellomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Apiotrichum loubieri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon loubieri"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Apiotrichum mycotoxinovorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon mycotoxinivorans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Apiotrichum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cutaneotrichosporon cutaneum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon cutaneum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cutaneotrichosporon mucoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon mucoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cutaneotrichosporon"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon asteroides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fissuricella filamenta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prototheca filamenta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon beigelii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon inkin"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarcinosporon inkin"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon ovoides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporon"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarcinosporon"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporonaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Trichosporonales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Tremellomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Agaricomycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cystobasidium minutum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodotorula minuta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cystobasidium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cystobasidiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cystobasidiales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cystobasidiomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodotorula glutinis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodotorula mucilaginosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodotorula mucilaginosa var. mucilaginosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodotorula pilimanae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhodotorula"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporobolomyces roseus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporobolomyces salmonicolor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporobolomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporidiobolaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporidiobolales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microbotryomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pucciniomycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Quambalaria cyanescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sporothrix cyanescens"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Quambalaria"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Quambalariaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microstromatales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exobasidiomycetidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pityrosporum orbiculare"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pityrosporum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Exobasidiomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malassezia furfur"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pityrosporum furfur"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pityrosporum ovale"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malassezia globosa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malassezia pachydermatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pityrosporum canis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pityrosporum pachydermatis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malassezia restricta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malassezia sympodialis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malassezia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malasseziaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malasseziales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Malasseziomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moesziomyces bullatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudozyma aphidis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Moesziomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Pseudozyma"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ustilago"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ustilaginaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ustilaginales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ustilaginomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Ustilaginomycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Basidiomycota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Dikarya"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Plasmodium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Sarcocystis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Incertae sedis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomortierella wolfii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mortierella wolfii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Actinomortierella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mortierella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mortierellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mortierellales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mortierellomycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mortierellomycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mortierellomycota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cunninghamella bertholletiae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cunninghamella"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cunninghamellaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizomucor miehei"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizomucor pusillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucor pusillus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhizomucor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Lichtheimiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucor circinelloides"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucor javanicus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucor hiemalis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucor janssenii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucor ramosissimus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucor"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucoraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Apophysomyces elegans"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Apophysomyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saksenaea vasiformis"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saksenaea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Saksenaeaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Syncephalastrum racemosum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Syncephalastrum"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Syncephalastraceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cokeromyces recurvatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Cokeromyces"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Thamnidiaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucorales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucoromycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucoromycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucoromycota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Mucoromyceta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Conidiobolus coronatus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Synonyms Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Entomophthora coronata"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Conidiobolus incongruus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Conidiobolus"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Conidiobolaceae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Entomophthorales"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Entomophthoromycetes"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Entomophthoromycotina"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Entomophthoromycota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Zoopagomyceta"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Fungi"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterocytozoon"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Enterocytozoonidae"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microsporidium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microsporea"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Microsporidia"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prototheca wickerhamii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prototheca zopfii"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Prototheca"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Myxomycota"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Rhinosporidium"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Children Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Protozoa"
+msgstr ""
+
+#. type: Hash Value: Hierarchies Name
+#: metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml:1
+#, no-wrap
+msgid "Eukaryota"
+msgstr ""

--- a/metadata/common/pathogens/po4a.cfg
+++ b/metadata/common/pathogens/po4a.cfg
@@ -1,0 +1,4 @@
+[po_directory] metadata/common/pathogens/po
+[options] --master-charset UTF-8 --localized-charset UTF-8 --wrap-po newlines
+
+[type: yaml] metadata/common/pathogens/NeoIPC-Infectious-Agents.yaml $lang:metadata/common/pathogens/NeoIPC-Infectious-Agents.$lang.yaml opt:"-o keys='Name ConceptType'"


### PR DESCRIPTION
This YAML-formatted list now contains a pragmatic hierarchy that is primarily taxonomy-based, but occasionally includes levels that reflect diagnostics.

This allows data to be entered when it is not possible or necessary to diagnose the infectious agent at species level.