### PR TITLE
Resolve report -OutputDir against PowerShell's location, not .NET's CWD

### DIFF
--- a/scripts/New-PartnerCertificate.ps1
+++ b/scripts/New-PartnerCertificate.ps1
@@ -84,7 +84,7 @@ if ($OutputDir) {
     # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
     $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
     $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
-    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+    if (-not (Test-Path -LiteralPath $outputDirPath -PathType Container)) {
         New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
     $outputDirExplicit = $true

--- a/scripts/New-PartnerCertificate.ps1
+++ b/scripts/New-PartnerCertificate.ps1
@@ -78,12 +78,15 @@ $reportDirPath = Resolve-Path -LiteralPath "$PSScriptRoot/../reports/Partner-Cer
 
 # Resolve OutputDir BEFORE changing directory (it's relative to the caller's CWD)
 if ($OutputDir) {
-    $outputDirPath = Resolve-Path -LiteralPath $OutputDir -ErrorAction SilentlyContinue
-    if (-not $outputDirPath) {
-        New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
-        $outputDirPath = Resolve-Path -LiteralPath $OutputDir
+    # Resolve a relative -OutputDir against the caller's location ($PWD), not .NET's
+    # [Environment]::CurrentDirectory (PowerShell does not keep them in sync). Fall
+    # back to the .NET CWD only when $PWD has no filesystem path (a non-FileSystem
+    # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
+    $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
+    $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
+    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+        New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
-    $outputDirPath = $outputDirPath.Path
     $outputDirExplicit = $true
 } else {
     $outputDirPath = Join-Path $reportDirPath '_output'

--- a/scripts/New-PartnerReports.ps1
+++ b/scripts/New-PartnerReports.ps1
@@ -276,12 +276,15 @@ if ($DataFile) {
 # Resolve OutputDir BEFORE changing directory (it's relative to the caller's CWD)
 $outputDirPath = $null
 if ($OutputDir) {
-    $outputDirPath = Resolve-Path -LiteralPath $OutputDir -ErrorAction SilentlyContinue
-    if (-not $outputDirPath) {
-        New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
-        $outputDirPath = Resolve-Path -LiteralPath $OutputDir
+    # Resolve a relative -OutputDir against the caller's location ($PWD), not .NET's
+    # [Environment]::CurrentDirectory (PowerShell does not keep them in sync). Fall
+    # back to the .NET CWD only when $PWD has no filesystem path (a non-FileSystem
+    # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
+    $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
+    $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
+    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+        New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
-    $outputDirPath = $outputDirPath.Path
 }
 
 # Resolve ValidationExceptionFile BEFORE changing directory (relative to caller's CWD)

--- a/scripts/New-PartnerReports.ps1
+++ b/scripts/New-PartnerReports.ps1
@@ -282,7 +282,7 @@ if ($OutputDir) {
     # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
     $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
     $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
-    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+    if (-not (Test-Path -LiteralPath $outputDirPath -PathType Container)) {
         New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
 }

--- a/scripts/New-PatientDataReport.ps1
+++ b/scripts/New-PatientDataReport.ps1
@@ -73,12 +73,15 @@ $reportDirPath = Resolve-Path -LiteralPath "$PSScriptRoot/../reports/Patient-Dat
 
 # Resolve OutputDir BEFORE changing directory (it's relative to the caller's CWD)
 if ($OutputDir) {
-    $outputDirPath = Resolve-Path -LiteralPath $OutputDir -ErrorAction SilentlyContinue
-    if (-not $outputDirPath) {
-        New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
-        $outputDirPath = Resolve-Path -LiteralPath $OutputDir
+    # Resolve a relative -OutputDir against the caller's location ($PWD), not .NET's
+    # [Environment]::CurrentDirectory (PowerShell does not keep them in sync). Fall
+    # back to the .NET CWD only when $PWD has no filesystem path (a non-FileSystem
+    # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
+    $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
+    $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
+    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+        New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
-    $outputDirPath = $outputDirPath.Path
     $outputDirExplicit = $true
 } else {
     $outputDirPath = Join-Path $reportDirPath '_output'

--- a/scripts/New-PatientDataReport.ps1
+++ b/scripts/New-PatientDataReport.ps1
@@ -79,7 +79,7 @@ if ($OutputDir) {
     # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
     $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
     $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
-    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+    if (-not (Test-Path -LiteralPath $outputDirPath -PathType Container)) {
         New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
     $outputDirExplicit = $true

--- a/scripts/New-ReferenceReport.ps1
+++ b/scripts/New-ReferenceReport.ps1
@@ -158,7 +158,7 @@ if ($OutputDir) {
     # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
     $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
     $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
-    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+    if (-not (Test-Path -LiteralPath $outputDirPath -PathType Container)) {
         New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
 } else {

--- a/scripts/New-ReferenceReport.ps1
+++ b/scripts/New-ReferenceReport.ps1
@@ -150,17 +150,19 @@ $scriptTimestamp = (Get-Date -AsUTC).ToString("yyyy-MM-dd_HHmmss'Z'")
 $repoRoot = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')
 $reportDirPath = Resolve-Path -LiteralPath (Join-Path $repoRoot 'reports/Reference-Report')
 
-# Resolve OutputDir (relative to caller's CWD); fall back to the report's _output
-$effectiveOutputDir = if ($OutputDir) { $OutputDir } else { Join-Path $reportDirPath '_output' }
-$outputDirPath = Resolve-Path -LiteralPath $effectiveOutputDir -ErrorAction SilentlyContinue
-if (-not $outputDirPath) {
-    # Resolve to absolute path without requiring the directory to exist.
-    # New-Item respects -WhatIf and won't create it during dry runs, so
-    # Resolve-Path would fail. The directory is created on first write by
-    # Set-Content / ConvertTo-Json inside the build report function.
-    $outputDirPath = [System.IO.Path]::GetFullPath($effectiveOutputDir)
+# Resolve OutputDir relative to the caller's location ($PWD); fall back to the report's _output.
+if ($OutputDir) {
+    # Resolve a relative -OutputDir against the caller's location ($PWD), not .NET's
+    # [Environment]::CurrentDirectory (PowerShell does not keep them in sync). Fall
+    # back to the .NET CWD only when $PWD has no filesystem path (a non-FileSystem
+    # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
+    $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
+    $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
+    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+        New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
+    }
 } else {
-    $outputDirPath = $outputDirPath.Path
+    $outputDirPath = Join-Path $reportDirPath '_output'
 }
 
 $buildReportFilePath = Join-Path $outputDirPath "${scriptTimestamp}_NeoIPC-Surveillance-Reference-Report-Build.json"

--- a/scripts/New-ValidationReport.ps1
+++ b/scripts/New-ValidationReport.ps1
@@ -91,12 +91,15 @@ $reportDirPath = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..' 'report
 
 # Resolve OutputDir BEFORE changing directory (it's relative to the caller's CWD)
 if ($OutputDir) {
-    $outputDirPath = Resolve-Path -LiteralPath $OutputDir -ErrorAction SilentlyContinue
-    if (-not $outputDirPath) {
-        New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
-        $outputDirPath = Resolve-Path -LiteralPath $OutputDir
+    # Resolve a relative -OutputDir against the caller's location ($PWD), not .NET's
+    # [Environment]::CurrentDirectory (PowerShell does not keep them in sync). Fall
+    # back to the .NET CWD only when $PWD has no filesystem path (a non-FileSystem
+    # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
+    $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
+    $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
+    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+        New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
-    $outputDirPath = $outputDirPath.Path
     $outputDirExplicit = $true
 } else {
     $outputDirPath = Join-Path $reportDirPath '_output'

--- a/scripts/New-ValidationReport.ps1
+++ b/scripts/New-ValidationReport.ps1
@@ -97,7 +97,7 @@ if ($OutputDir) {
     # PSDrive). GetFullPath creates nothing (stays -WhatIf-safe); New-Item makes the dir.
     $base = if ([System.IO.Path]::IsPathFullyQualified($PWD.ProviderPath)) { $PWD.ProviderPath } else { [Environment]::CurrentDirectory }
     $outputDirPath = [System.IO.Path]::GetFullPath($OutputDir, $base)
-    if (-not (Test-Path -LiteralPath $outputDirPath)) {
+    if (-not (Test-Path -LiteralPath $outputDirPath -PathType Container)) {
         New-Item -ItemType Directory -Path $outputDirPath -Force | Out-Null
     }
     $outputDirExplicit = $true


### PR DESCRIPTION
The report wrapper scripts (`scripts/New-*.ps1`) accept a `-OutputDir`. A relative one was resolved with .NET path APIs that use `[Environment]::CurrentDirectory`, which PowerShell does not keep in sync with its own location (`$PWD`). So a relative `-OutputDir` (e.g. `./data`) could resolve against the wrong base — landing files outside the intended directory — and the build-report write then failed on the missing directory because `Set-Content` does not create missing parents.

The four non-Reference wrappers avoided the wrong-base half, but — declaring `SupportsShouldProcess` — carried a latent `-WhatIf` failure: a suppressed `New-Item` followed by a `Resolve-Path` that throws on the not-yet-created directory.

All five wrappers now resolve `-OutputDir` against `$PWD` and create the directory up front, which keeps `-WhatIf` dry runs side-effect-free, with a fallback for the exotic case of a caller sitting on a non-filesystem PSDrive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
