### PR TITLE
Add the NeoIPC Core data-dictionary generator

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
         # runtime the NeoIPC-Tools module and data-dictionary generator require.
         runs-on: ubuntu-26.04
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
               with:
                 submodules: true
 
             - name: Set up .NET 10 (for the data-dictionary .xlsx writer)
-              uses: actions/setup-dotnet@v4
+              uses: actions/setup-dotnet@v5
               with:
                 dotnet-version: '10.0.x'
 
@@ -58,7 +58,7 @@ jobs:
                 Install-Module -Name Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
                 # powershell-yaml: the metadata assembler reads the infectious-agents / sharing YAML when
                 # building the package the data dictionary flattens.
-                Install-Module -Name powershell-yaml -Force -Scope CurrentUser -SkipPublisherCheck
+                Install-Module -Name powershell-yaml -MinimumVersion 0.4.2 -Force -Scope CurrentUser -SkipPublisherCheck
                 Invoke-Pester -Path scripts/modules/NeoIPC-Tools/Tests/DataDictionary.Tests.ps1 -CI
 
             - name: Generate data dictionary
@@ -69,7 +69,7 @@ jobs:
                 ./scripts/New-NeoIPCDataDictionary.ps1 -OutputDirectory ./artifacts/data-dictionary
 
             - name: Upload artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                 name: NeoIPC-Docs-Preview
                 path: ./artifacts/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
               shell: bash
               run: |
                 sudo apt-get update -qq
-                sudo apt-get install -qq pandoc librsvg2-bin bison flex libffi-dev libxml2-dev libgdk-pixbuf2.0-dev libcairo2-dev libpango1.0-dev libwebp-dev fonts-lyx fonts-noto-core gettext liblocale-gettext-perl libtext-wrapi18n-perl libsyntax-keyword-try-perl libtimedate-perl libyaml-tiny-perl libpod-parser-perl libmodule-build-perl
+                sudo apt-get install -qq pandoc librsvg2-bin bison flex libffi-dev libxml2-dev libgdk-pixbuf-2.0-dev libcairo2-dev libpango1.0-dev libwebp-dev fonts-lyx fonts-noto-core gettext liblocale-gettext-perl libtext-wrapi18n-perl libsyntax-keyword-try-perl libtimedate-perl libyaml-tiny-perl libpod-parser-perl libmodule-build-perl
                 sudo gem install mathematical:1.6.18 asciidoctor-pdf asciidoctor-bibtex asciidoctor-diagram asciimath asciidoctor-mathematical
                 sudo npm install -g @linthtml/linthtml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,18 @@ on:
 
 jobs:
     build-docs:
-        runs-on: ubuntu-latest
+        # Pinned to an explicit image for reproducibility; 26.04 provides the .NET 10 / PowerShell 7.6
+        # runtime the NeoIPC-Tools module and data-dictionary generator require.
+        runs-on: ubuntu-26.04
         steps:
             - uses: actions/checkout@v4
               with:
                 submodules: true
+
+            - name: Set up .NET 10 (for the data-dictionary .xlsx writer)
+              uses: actions/setup-dotnet@v4
+              with:
+                dotnet-version: '10.0.x'
 
             - name: Prepare environment
               shell: bash
@@ -38,6 +45,23 @@ jobs:
             - name: Build
               shell: pwsh
               run: ./scripts/Make-NeoIPC-Core-Protocol.ps1 -InformationAction Continue -WarningAction:Stop
+
+            - name: Provision and test NeoIPC-Tools
+              shell: pwsh
+              run: |
+                # Provision the DocumentFormat.OpenXml assembly the .xlsx writer loads, then run the module
+                # tests so the OpenXmlValidator-backed XLSX schema-validity gate runs in CI (it is skipped only
+                # when the assembly is absent).
+                dotnet publish scripts/modules/NeoIPC-Tools/lib -o scripts/modules/NeoIPC-Tools/lib/bin -c Release --nologo
+                Install-Module -Name Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
+                Invoke-Pester -Path scripts/modules/NeoIPC-Tools/Tests/DataDictionary.Tests.ps1 -CI
+
+            - name: Generate data dictionary
+              shell: pwsh
+              run: |
+                # Generate the CSV + .xlsx data dictionary into the uploaded artifacts. Assembled from the
+                # metadata/ directory alone — no DHIS2 API.
+                ./scripts/New-NeoIPCDataDictionary.ps1 -OutputDirectory ./artifacts/data-dictionary
 
             - name: Upload artifacts
               uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,9 @@ jobs:
               run: |
                 sudo apt-get update -qq
                 sudo apt-get install -qq pandoc librsvg2-bin bison flex libffi-dev libxml2-dev libgdk-pixbuf-2.0-dev libcairo2-dev libpango1.0-dev libwebp-dev fonts-lyx fonts-noto-core gettext liblocale-gettext-perl libtext-wrapi18n-perl libsyntax-keyword-try-perl libtimedate-perl libyaml-tiny-perl libpod-parser-perl libmodule-build-perl
-                sudo gem install mathematical:1.7.0 asciidoctor-pdf asciidoctor-bibtex asciidoctor-diagram asciimath asciidoctor-mathematical
+                # CMAKE_POLICY_VERSION_MINIMUM lets the gems' bundled mtex2MML (an old cmake_minimum_required)
+                # configure under the CMake 4 on Ubuntu 26.04; passed through sudo, which otherwise resets env.
+                sudo env CMAKE_POLICY_VERSION_MINIMUM=3.5 gem install mathematical:1.7.0 asciidoctor-pdf asciidoctor-bibtex asciidoctor-diagram asciimath asciidoctor-mathematical
                 sudo npm install -g @linthtml/linthtml
 
             - name: Run po4a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,9 @@ jobs:
                 # when the assembly is absent).
                 dotnet publish scripts/modules/NeoIPC-Tools/lib -o scripts/modules/NeoIPC-Tools/lib/bin -c Release --nologo
                 Install-Module -Name Pester -MinimumVersion 5.5 -Force -Scope CurrentUser -SkipPublisherCheck
+                # powershell-yaml: the metadata assembler reads the infectious-agents / sharing YAML when
+                # building the package the data dictionary flattens.
+                Install-Module -Name powershell-yaml -Force -Scope CurrentUser -SkipPublisherCheck
                 Invoke-Pester -Path scripts/modules/NeoIPC-Tools/Tests/DataDictionary.Tests.ps1 -CI
 
             - name: Generate data dictionary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
               run: |
                 sudo apt-get update -qq
                 sudo apt-get install -qq pandoc librsvg2-bin bison flex libffi-dev libxml2-dev libgdk-pixbuf-2.0-dev libcairo2-dev libpango1.0-dev libwebp-dev fonts-lyx fonts-noto-core gettext liblocale-gettext-perl libtext-wrapi18n-perl libsyntax-keyword-try-perl libtimedate-perl libyaml-tiny-perl libpod-parser-perl libmodule-build-perl
-                sudo gem install mathematical:1.6.18 asciidoctor-pdf asciidoctor-bibtex asciidoctor-diagram asciimath asciidoctor-mathematical
+                sudo gem install mathematical:1.7.0 asciidoctor-pdf asciidoctor-bibtex asciidoctor-diagram asciimath asciidoctor-mathematical
                 sudo npm install -g @linthtml/linthtml
 
             - name: Run po4a

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,9 @@ reports/**/*_files/**
 reports/**/_output
 reports/ICHE-Health-Intervention-Codes.csv
 data/
+# Provisioned (not committed) DocumentFormat.OpenXml assemblies for the data-dictionary .xlsx writer
+# (restored by `dotnet publish` of lib/NeoIPC-Tools.Dependencies.csproj; see that file + the data-dictionary README).
+scripts/modules/NeoIPC-Tools/lib/bin/
+scripts/modules/NeoIPC-Tools/lib/obj/
 # Scratch / throwaway artifacts, never committed (the durable procedures live in the relevant READMEs).
 /tmp/

--- a/doc/protocol/NeoIPC-Core-Protocol.adoc
+++ b/doc/protocol/NeoIPC-Core-Protocol.adoc
@@ -516,6 +516,8 @@ include::definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc[]
 The following data items appear in the NeoIPC documentation sheets or in the reporting platform.
 Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools.
 
+NOTE: A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol.
+
 [#data-dictionary-patient-master-data]
 === Patient Master Data
 [#data-dictionary-patient-master-data-enrolment]

--- a/docs/data-dictionary.md
+++ b/docs/data-dictionary.md
@@ -1,0 +1,51 @@
+# NeoIPC Core data dictionary
+
+A technology-agnostic **data dictionary** for the NeoIPC Core surveillance program — a spreadsheet that sits
+between the machine-readable DHIS2 metadata and the end-user protocol. It documents everything collected
+(patient attributes, per-event data elements, the event dates, and every code list in full, including the
+pathogen and antimicrobial lists) in language meant for both epidemiologists and technical implementers.
+
+It is a **generated release artifact**, distributed alongside the protocol and metadata releases — **not**
+committed to source. Generate it on demand (below); CI also produces a fresh copy with every build.
+
+## Sheets
+
+| Sheet | Contents |
+|-------|----------|
+| About | Cover sheet: program identity, counts, provenance |
+| Variables | One row per collected item — patient attributes, per-event data elements, and the event dates |
+| Code lists | One row per (code list, value) — every option set in full |
+| Forms & dates | One row per module/form and its event date |
+
+Four CSVs (one per sheet, UTF-8 with BOM, LF) plus a multi-tab `.xlsx`. The CSVs are dependency-free; the
+`.xlsx` is the polished workbook. For long code lists, the *Variables* sheet's "Allowed values" cell points to
+the *Code lists* sheet in the same workbook — nothing is omitted.
+
+## Generate
+
+```sh
+# CSV + .xlsx (default), written to artifacts/data-dictionary/. The .xlsx needs DocumentFormat.OpenXml (below).
+./scripts/New-NeoIPCDataDictionary.ps1
+
+# CSV only (no extra dependency):
+./scripts/New-NeoIPCDataDictionary.ps1 -Format Csv
+```
+
+The `.xlsx` writer uses the MIT-licensed [DocumentFormat.OpenXml](https://github.com/dotnet/Open-XML-SDK) SDK,
+restored with `dotnet` (the .NET 10 SDK). Provision it once:
+
+```sh
+# In the assembled workspace:
+./scripts/Invoke-Workspace.ps1 -InstallDeps
+
+# Standalone Surveillance-Toolkit checkout:
+dotnet publish scripts/modules/NeoIPC-Tools/lib -o scripts/modules/NeoIPC-Tools/lib/bin
+```
+
+CI (`.github/workflows/build.yml`) generates the data dictionary into the uploaded build artifact on every build.
+
+## How it is built
+
+`Export-NeoIPCDataDictionary` (in the `NeoIPC-Tools` module) flattens the assembled metadata package
+(`New-NeoIPCMetadataPackage`, export-free, no DHIS2 API) into the four sheets. DHIS2 UIDs are deliberately
+omitted (technology-specific); the project's variable **code** is the stable, platform-neutral identifier.

--- a/scripts/New-NeoIPCDataDictionary.ps1
+++ b/scripts/New-NeoIPCDataDictionary.ps1
@@ -1,0 +1,51 @@
+#requires -Version 7.6
+<#
+.SYNOPSIS
+    Render the NeoIPC Core data-dictionary release artifact (CSV + .xlsx) from the canonical metadata.
+.DESCRIPTION
+    Produces a technology-agnostic data dictionary that sits between the DHIS2 metadata JSON and the end-user
+    protocol: it documents everything the NeoIPC Core program collects — patient attributes, per-event data
+    elements, the event dates, and every code list in full (including the pathogen and antimicrobial lists).
+    Four sheets are produced (About, Variables, Code lists, Forms & dates) as one CSV per sheet and, by
+    default, as the tabs of a single .xlsx workbook.
+
+    The data dictionary is a GENERATED release artifact (distributed alongside the protocol and metadata
+    releases), not source — the output is written to the gitignored artifacts/ tree and is not committed.
+
+    The package is assembled from the metadata/ directory alone (New-NeoIPCMetadataPackage, export-free, no
+    DHIS2 API). The CSVs need only PowerShell; the .xlsx needs the DocumentFormat.OpenXml assembly. Provision
+    it once with `Invoke-Workspace.ps1 -InstallDeps` (workspace) or, standalone, with:
+
+        dotnet publish scripts/modules/NeoIPC-Tools/lib -o scripts/modules/NeoIPC-Tools/lib/bin
+
+    See docs/data-dictionary.md.
+.PARAMETER OutputDirectory
+    Where to write the artifacts. Defaults to the repository's (gitignored) artifacts/data-dictionary directory.
+.PARAMETER Format
+    Csv, Xlsx, or Both (default). Xlsx/Both require the provisioned DocumentFormat.OpenXml assembly.
+.EXAMPLE
+    ./scripts/New-NeoIPCDataDictionary.ps1
+    Generate the CSV + .xlsx data dictionary into artifacts/data-dictionary/.
+.EXAMPLE
+    ./scripts/New-NeoIPCDataDictionary.ps1 -Format Csv
+    Generate only the dependency-free CSV sheets.
+#>
+[CmdletBinding()]
+param(
+    [string]$OutputDirectory,
+    [ValidateSet('Csv', 'Xlsx', 'Both')][string]$Format = 'Both'
+)
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$module = Join-Path $repoRoot 'scripts/modules/NeoIPC-Tools/NeoIPC-Tools.psd1'
+$metadataDir = Join-Path $repoRoot 'metadata'
+if (-not $OutputDirectory) { $OutputDirectory = Join-Path $repoRoot 'artifacts/data-dictionary' }
+Import-Module $module -Force
+if (-not (Test-Path -LiteralPath $OutputDirectory)) { New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null }
+
+Write-Host "Rendering the NeoIPC Core data dictionary ($Format) from $metadataDir ..."
+$paths = Export-NeoIPCDataDictionary -MetadataDirectory $metadataDir -OutputDirectory $OutputDirectory -Format $Format
+foreach ($path in $paths) {
+    Write-Host ("  -> {0} ({1:N0} bytes)" -f $path, (Get-Item -LiteralPath $path).Length)
+}

--- a/scripts/modules/NeoIPC-Tools/NeoIPC-Tools.psd1
+++ b/scripts/modules/NeoIPC-Tools/NeoIPC-Tools.psd1
@@ -25,7 +25,7 @@
     Description = 'PowerShell tools for NeoIPC Surveillance: DHIS2 admin, report generation helpers, and pipeline-composable data inspection.'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '7.5'
+    PowerShellVersion = '7.6'
 
     # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
     FunctionsToExport = @(
@@ -91,6 +91,8 @@
         'New-NeoIPCAntibioticOptionGroupSet'
         # Antibiotic translation catalogue (po/antibiotics.pot + .po)
         'Export-NeoIPCAntibioticTranslation'
+        # Data dictionary
+        'Export-NeoIPCDataDictionary'
     )
 
     # Cmdlets to export from this module

--- a/scripts/modules/NeoIPC-Tools/Private/DataDictionary.ps1
+++ b/scripts/modules/NeoIPC-Tools/Private/DataDictionary.ps1
@@ -417,21 +417,36 @@ function Get-NeoIPCDataDictionaryRow {
 
     $programs = Get-NeoIPCDataDictionarySorted -Item @($Package['programs']) -KeyOf { param($p) [string]$p['code'] }
     if ($programs.Count -eq 0) { throw 'The metadata package contains no programs to document.' }
+    # The dictionary documents ONE program (NEOIPC_CORE; the closure is single-program). The cover sheet and the
+    # row sheets must describe the same one — fail loud rather than silently cover only the first of several.
+    if ($programs.Count -gt 1) {
+        throw ("The data dictionary documents a single program, but the package has $($programs.Count): " +
+            ((@($programs | ForEach-Object { [string]$_['code'] })) -join ', ') + '.')
+    }
+    $program = $programs[0]
     $index = ConvertFrom-NeoIPCPackageIndex -Package $Package
 
     $variableRows = [System.Collections.Generic.List[object]]::new()
-    $formRows = [System.Collections.Generic.List[object]]::new()
-    foreach ($program in $programs) {
-        foreach ($r in (Get-NeoIPCPatientAttributeRow -Program $program -Index $index)) { $variableRows.Add($r) }
-        $stages = Get-NeoIPCDataDictionaryProgramStage -Program $program -Index $index
-        foreach ($stage in $stages) {
-            foreach ($r in (Get-NeoIPCEventVariableRow -Stage $stage -Program $program -Index $index)) { $variableRows.Add($r) }
-        }
-        foreach ($r in (Get-NeoIPCFormsAndDatesRow -Stage $stages -Program $program)) { $formRows.Add($r) }
+    foreach ($r in (Get-NeoIPCPatientAttributeRow -Program $program -Index $index)) { $variableRows.Add($r) }
+    $stages = Get-NeoIPCDataDictionaryProgramStage -Program $program -Index $index
+    foreach ($stage in $stages) {
+        foreach ($r in (Get-NeoIPCEventVariableRow -Stage $stage -Program $program -Index $index)) { $variableRows.Add($r) }
     }
+    $formRows = [System.Collections.Generic.List[object]]::new()
+    foreach ($r in (Get-NeoIPCFormsAndDatesRow -Stage $stages -Program $program)) { $formRows.Add($r) }
+
+    # The Code column is the dictionary's stable identifier — fail loud if a synthesized event-date code ever
+    # collides with another variable's code (e.g. two stage names that slugify the same), rather than emit two
+    # rows sharing a supposedly-unique Code.
+    $seenCode = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($r in $variableRows) {
+        $code = [string]$r['Code']
+        if ($code -and -not $seenCode.Add($code)) { throw "Duplicate variable code '$code' in the data dictionary." }
+    }
+
     $codeListRows = Get-NeoIPCCodeListRow -Package $Package -Index $index
     $codeListCount = @($codeListRows | ForEach-Object { $_['Code list code'] } | Select-Object -Unique).Count
-    $aboutRows = Get-NeoIPCDataDictionaryAboutRow -Program $programs[0] `
+    $aboutRows = Get-NeoIPCDataDictionaryAboutRow -Program $program `
         -VariableCount $variableRows.Count -CodeListCount $codeListCount `
         -CodeListValueCount @($codeListRows).Count -FormCount $formRows.Count
 

--- a/scripts/modules/NeoIPC-Tools/Private/DataDictionary.ps1
+++ b/scripts/modules/NeoIPC-Tools/Private/DataDictionary.ps1
@@ -1,0 +1,674 @@
+# NeoIPC data dictionary — flatten the assembled DHIS2 metadata package into a technology-agnostic
+# "data dictionary" readable by epidemiologists AND technical implementers: patient attributes, per-stage
+# data elements, the per-event dates, and the full code lists. Pure transforms over the
+# in-memory package (an [ordered] dictionary `type -> OrderedDictionary[]`, references as `@{ id = '<uid>' }`);
+# no DHIS2 API and no file I/O except the CSV writer. Consumed by Public/DataDictionary.ps1.
+
+# DHIS2 valueType -> a friendly, technology-neutral "data type". An unmapped value type passes through
+# verbatim and warns (fail-loud, never silently mislabel). ASCII-only on purpose so the source stays portable.
+$script:NeoIPCDataTypeMap = [ordered]@{
+    TEXT                     = 'Text'
+    LONG_TEXT                = 'Text (long)'
+    LETTER                   = 'Single letter'
+    EMAIL                    = 'Email address'
+    PHONE_NUMBER             = 'Phone number'
+    URL                      = 'Web address'
+    INTEGER                  = 'Whole number'
+    INTEGER_POSITIVE         = 'Whole number (> 0)'
+    INTEGER_ZERO_OR_POSITIVE = 'Whole number (>= 0)'
+    INTEGER_NEGATIVE         = 'Whole number (< 0)'
+    NUMBER                   = 'Number'
+    UNIT_INTERVAL            = 'Fraction (0 to 1)'
+    PERCENTAGE               = 'Percentage'
+    BOOLEAN                  = 'Yes / No / blank'
+    TRUE_ONLY                = 'Checkbox (yes / blank)'
+    DATE                     = 'Date'
+    DATETIME                 = 'Date and time'
+    TIME                     = 'Time'
+    AGE                      = 'Age'
+    COORDINATE               = 'Coordinate'
+}
+
+# Above this many options a coded field's "Allowed values" cell points to the Code lists sheet instead of
+# inlining every value; the Code lists sheet enumerates every set in full regardless.
+$script:NeoIPCDataDictionaryInlineOptionLimit = 12
+
+# Module / form label for the patient-level (tracked entity) attributes that are captured once per patient.
+$script:NeoIPCDataDictionaryPatientModule = 'Patient master data'
+
+function Get-NeoIPCFriendlyValueType {
+    # Map a DHIS2 valueType to a friendly data-type label; pass unmapped types through verbatim and warn.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter()][AllowNull()][AllowEmptyString()][string]$ValueType)
+    if ([string]::IsNullOrEmpty($ValueType)) { return '' }
+    if ($script:NeoIPCDataTypeMap.Contains($ValueType)) { return $script:NeoIPCDataTypeMap[$ValueType] }
+    Write-Warning "No friendly data-type mapping for valueType '$ValueType'; emitting it verbatim."
+    return $ValueType
+}
+
+function Format-NeoIPCDataDictionaryBoolean {
+    # Render a DHIS2 boolean cell (real [bool] in the package, but tolerate the string form) as Yes/No.
+    [OutputType([string])]
+    param([AllowNull()]$Value)
+    if (($Value -is [bool] -and $Value) -or ("$Value" -ieq 'true')) { return 'Yes' }
+    return 'No'
+}
+
+function Get-NeoIPCMetadataRefId {
+    # Pull the UID out of a DHIS2 reference cell (`@{ id = '<uid>' }`); '' when the reference is absent.
+    [OutputType([string])]
+    param([AllowNull()]$Ref)
+    if ($Ref -is [System.Collections.IDictionary] -and $Ref.Contains('id')) { return [string]$Ref['id'] }
+    return ''
+}
+
+function Get-NeoIPCDataDictionarySorted {
+    # Deterministic, locale-independent ordinal sort. $KeyOf returns a string sort key for an item; the
+    # original index is appended so every key is unique, making the order stable and fully reproducible
+    # regardless of input order. Returns with the `,` (non-enumerating) idiom so a single-element result is
+    # not unrolled to a scalar by the caller.
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Item,
+        [Parameter(Mandatory)][scriptblock]$KeyOf
+    )
+    if ($Item.Count -le 1) { return , ([object[]]$Item) }
+    $sorted = [System.Collections.Generic.SortedDictionary[string, object]]::new([System.StringComparer]::Ordinal)
+    for ($i = 0; $i -lt $Item.Count; $i++) {
+        $sorted[((& $KeyOf $Item[$i]) + '|' + ('{0:D8}' -f $i))] = $Item[$i]
+    }
+    return , ([object[]]$sorted.Values)
+}
+
+function Get-NeoIPCDataDictionaryIntKey {
+    # Zero-padded ordinal-sortable form of an integer-ish cell (absent/blank -> 0).
+    [OutputType([string])]
+    param([AllowNull()]$Value)
+    $n = 0; [void][int]::TryParse([string]$Value, [ref]$n)
+    return '{0:D8}' -f $n
+}
+
+function ConvertFrom-NeoIPCPackageIndex {
+    # Build the id-keyed lookups the row builders need from an assembled package: data elements, option sets,
+    # tracked-entity attributes and program stages by id; options grouped by their option-set id; and program-
+    # stage sections grouped by their stage id (each keeping its ordered data-element id list for section
+    # membership). Returns a hashtable of these indexes.
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Package)
+
+    $byId = { param($type)
+        $h = @{}
+        foreach ($o in @($Package[$type])) {
+            if ($o -is [System.Collections.IDictionary] -and $o.Contains('id')) { $h[[string]$o['id']] = $o }
+        }
+        $h
+    }
+
+    $optionsBySet = @{}
+    foreach ($opt in @($Package['options'])) {
+        if ($opt -isnot [System.Collections.IDictionary]) { continue }
+        $setId = Get-NeoIPCMetadataRefId $opt['optionSet']
+        if (-not $setId) { continue }
+        if (-not $optionsBySet.ContainsKey($setId)) { $optionsBySet[$setId] = [System.Collections.Generic.List[object]]::new() }
+        $optionsBySet[$setId].Add($opt)
+    }
+
+    $sectionsByStage = @{}
+    foreach ($sec in @($Package['programStageSections'])) {
+        if ($sec -isnot [System.Collections.IDictionary]) { continue }
+        $stageId = Get-NeoIPCMetadataRefId $sec['programStage']
+        if (-not $stageId) { continue }
+        if (-not $sectionsByStage.ContainsKey($stageId)) { $sectionsByStage[$stageId] = [System.Collections.Generic.List[object]]::new() }
+        $sectionsByStage[$stageId].Add($sec)
+    }
+
+    return @{
+        DataElementById  = & $byId 'dataElements'
+        OptionSetById    = & $byId 'optionSets'
+        AttributeById    = & $byId 'trackedEntityAttributes'
+        StageById        = & $byId 'programStages'
+        OptionsBySetId   = $optionsBySet
+        SectionsByStageId = $sectionsByStage
+    }
+}
+
+function Resolve-NeoIPCOptionList {
+    # Resolve an option-set reference cell to its set details + ordered member options. $null when the field
+    # has no option set. Options are ordered by sortOrder then code (ordinal), independent of package order.
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([AllowNull()]$OptionSetRef, [Parameter(Mandatory)][hashtable]$Index)
+    $setId = Get-NeoIPCMetadataRefId $OptionSetRef
+    if (-not $setId) { return $null }
+    $set = $Index.OptionSetById[$setId]
+    if (-not $set) { return $null }
+    # @( ... ) array-subexpression, not an if/else returning @(): PowerShell unwraps an if-branch empty array to
+    # $null on assignment, and the downstream [object[]]$Item binder rejects $null (it allows EMPTY, not null).
+    $opts = @(if ($Index.OptionsBySetId.ContainsKey($setId)) { $Index.OptionsBySetId[$setId] })
+    $ordered = Get-NeoIPCDataDictionarySorted -Item $opts -KeyOf {
+        param($o) (Get-NeoIPCDataDictionaryIntKey $o['sortOrder']) + '|' + [string]$o['code']
+    }
+    return @{
+        SetCode   = [string]$set['code']
+        SetName   = [string]$set['name']
+        ValueType = [string]$set['valueType']
+        Options   = $ordered
+    }
+}
+
+function Format-NeoIPCAllowedValues {
+    # The Variables "Allowed values" cell: '' when not coded; an inline "code = label; ..." list for short
+    # sets; otherwise an in-workbook pointer to the named code list (which always carries every value).
+    [OutputType([string])]
+    param([AllowNull()][hashtable]$OptionInfo)
+    if (-not $OptionInfo) { return '' }
+    $opts = @($OptionInfo.Options)
+    if ($opts.Count -eq 0) { return '' }
+    if ($opts.Count -le $script:NeoIPCDataDictionaryInlineOptionLimit) {
+        return (($opts | ForEach-Object { ('{0} = {1}' -f [string]$_['code'], [string]$_['name']).Trim() }) -join '; ')
+    }
+    return "See code list: $($OptionInfo.SetName)"
+}
+
+function Get-NeoIPCDataDictionaryLabel {
+    # Epidemiologist-facing label: prefer formName, then name, then shortName.
+    [OutputType([string])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Object)
+    foreach ($prop in 'formName', 'name', 'shortName') {
+        $v = [string]$Object[$prop]
+        if (-not [string]::IsNullOrWhiteSpace($v)) { return $v }
+    }
+    return ''
+}
+
+function Get-NeoIPCDataDictionaryFieldKind {
+    # Classify a field for the "Field kind" column. Free-text-fallback is a narrow heuristic: an uncoded
+    # TEXT/LONG_TEXT element whose description marks it as the "not in the list above" escape hatch.
+    [OutputType([string])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Element, [AllowNull()][hashtable]$OptionInfo)
+    $vt = [string]$Element['valueType']
+    if (-not $OptionInfo -and ($vt -eq 'TEXT' -or $vt -eq 'LONG_TEXT')) {
+        if ([string]$Element['description'] -match 'not (contained )?in the .*\blist\b') { return 'Free-text fallback' }
+    }
+    return 'Explicit field'
+}
+
+function Get-NeoIPCStageDateLabel {
+    # The human label for a stage's event date. The Admission stage reports on the enrolment date
+    # (reportDateToUse = enrollmentDate; the program's incident date is hidden), so it takes the program's
+    # enrollmentDateLabel; every other stage uses its own executionDateLabel.
+    [OutputType([string])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Stage, [AllowNull()][System.Collections.IDictionary]$Program)
+    if ([string]$Stage['reportDateToUse'] -eq 'enrollmentDate' -and $Program) {
+        $enr = [string]$Program['enrollmentDateLabel']
+        if (-not [string]::IsNullOrWhiteSpace($enr)) { return $enr }
+    }
+    return [string]$Stage['executionDateLabel']
+}
+
+function Get-NeoIPCEventDateCode {
+    # Deterministic synthetic code for a stage's event-date field (stages carry no code column of their own).
+    [OutputType([string])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Stage)
+    $slug = ([string]$Stage['name']).ToUpperInvariant() -replace '[^A-Z0-9]+', '_'
+    return 'NEOIPC_EVENTDATE_' + $slug.Trim('_')
+}
+
+function Get-NeoIPCSectionName {
+    # The form section a data element sits in within a stage ('' when it belongs to none). Sections are
+    # matched by stage; the first whose ordered dataElements list contains the element wins.
+    [OutputType([string])]
+    param([Parameter(Mandatory)][string]$StageId, [Parameter(Mandatory)][string]$DataElementId, [Parameter(Mandatory)][hashtable]$Index)
+    if (-not $Index.SectionsByStageId.ContainsKey($StageId)) { return '' }
+    foreach ($sec in $Index.SectionsByStageId[$StageId]) {
+        foreach ($ref in @($sec['dataElements'])) {
+            if ((Get-NeoIPCMetadataRefId $ref) -eq $DataElementId) { return [string]$sec['name'] }
+        }
+    }
+    return ''
+}
+
+function New-NeoIPCVariableRow {
+    # One Variables-sheet row (ordered to match $script:NeoIPCDataDictionaryVariableColumns).
+    param(
+        [string]$Level, [string]$Module, [string]$DateLabel, [string]$Section, [string]$Code, [string]$Label,
+        [string]$DataType, [string]$Required, [string]$Repeatable, [string]$AllowedValues, [string]$Description,
+        [string]$FieldKind
+    )
+    [ordered]@{
+        'Level'           = $Level
+        'Module / form'   = $Module
+        'Form date label' = $DateLabel
+        'Section'         = $Section
+        'Code'            = $Code
+        'Label'           = $Label
+        'Data type'       = $DataType
+        'Required'        = $Required
+        'Repeatable'      = $Repeatable
+        'Allowed values'  = $AllowedValues
+        'Description'     = $Description
+        'Field kind'      = $FieldKind
+    }
+}
+
+# The DHIS2 UID is deliberately NOT a column — the dictionary is technology-agnostic; the project's variable
+# CODE is the stable, platform-neutral identifier.
+$script:NeoIPCDataDictionaryVariableColumns = @(
+    'Level', 'Module / form', 'Form date label', 'Section', 'Code', 'Label', 'Data type', 'Required',
+    'Repeatable', 'Allowed values', 'Description', 'Field kind')
+$script:NeoIPCDataDictionaryCodeListColumns = @(
+    'Code list', 'Code list code', 'Value code', 'Value label', 'Sort order', 'Data type')
+$script:NeoIPCDataDictionaryFormsColumns = @(
+    'Module / form', 'Date label', 'Repeatable', 'Description', 'Sort order')
+$script:NeoIPCDataDictionaryAboutColumns = @('Field', 'Value')
+
+function Get-NeoIPCPatientAttributeRow {
+    # The patient-level (tracked entity) attribute rows, in program attribute order.
+    [OutputType([object[]])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Program, [Parameter(Mandatory)][hashtable]$Index)
+    $rows = [System.Collections.Generic.List[object]]::new()
+    $pteas = Get-NeoIPCDataDictionarySorted -Item @($Program['programTrackedEntityAttributes']) -KeyOf {
+        param($p) (Get-NeoIPCDataDictionaryIntKey $p['sortOrder']) + '|' + (Get-NeoIPCMetadataRefId $p['trackedEntityAttribute'])
+    }
+    foreach ($ptea in $pteas) {
+        if ($ptea -isnot [System.Collections.IDictionary]) { continue }
+        $tea = $Index.AttributeById[(Get-NeoIPCMetadataRefId $ptea['trackedEntityAttribute'])]
+        if (-not $tea) { continue }
+        $optInfo = Resolve-NeoIPCOptionList -OptionSetRef $tea['optionSet'] -Index $Index
+        $rows.Add((New-NeoIPCVariableRow `
+            -Level 'Patient' -Module $script:NeoIPCDataDictionaryPatientModule -DateLabel '' -Section '' `
+            -Code ([string]$tea['code']) -Label (Get-NeoIPCDataDictionaryLabel $tea) `
+            -DataType (Get-NeoIPCFriendlyValueType ([string]$tea['valueType'])) `
+            -Required (Format-NeoIPCDataDictionaryBoolean $ptea['mandatory']) -Repeatable '' `
+            -AllowedValues (Format-NeoIPCAllowedValues $optInfo) -Description ([string]$tea['description']) `
+            -FieldKind (Get-NeoIPCDataDictionaryFieldKind -Element $tea -OptionInfo $optInfo)))
+    }
+    return $rows.ToArray()
+}
+
+function Get-NeoIPCEventVariableRow {
+    # For one stage: its event-date row first, then its data-element rows in form order (sortOrder).
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$Stage,
+        [AllowNull()][System.Collections.IDictionary]$Program,
+        [Parameter(Mandatory)][hashtable]$Index
+    )
+    $rows = [System.Collections.Generic.List[object]]::new()
+    $stageName = [string]$Stage['name']
+    $stageId = [string]$Stage['id']
+    $dateLabel = Get-NeoIPCStageDateLabel -Stage $Stage -Program $Program
+    $repeatable = Format-NeoIPCDataDictionaryBoolean $Stage['repeatable']
+
+    # The event's own date field — recorded explicitly by the user in the UI; it has no backing data element.
+    $rows.Add((New-NeoIPCVariableRow `
+        -Level 'Event' -Module $stageName -DateLabel $dateLabel -Section '' `
+        -Code (Get-NeoIPCEventDateCode $Stage) -Label $dateLabel -DataType (Get-NeoIPCFriendlyValueType 'DATE') `
+        -Required 'Yes' -Repeatable $repeatable -AllowedValues '' -Description ([string]$Stage['description']) `
+        -FieldKind 'Event date'))
+
+    $psdes = Get-NeoIPCDataDictionarySorted -Item @($Stage['programStageDataElements']) -KeyOf {
+        param($p) (Get-NeoIPCDataDictionaryIntKey $p['sortOrder']) + '|' + (Get-NeoIPCMetadataRefId $p['dataElement'])
+    }
+    foreach ($psde in $psdes) {
+        if ($psde -isnot [System.Collections.IDictionary]) { continue }
+        $de = $Index.DataElementById[(Get-NeoIPCMetadataRefId $psde['dataElement'])]
+        if (-not $de) { continue }
+        $optInfo = Resolve-NeoIPCOptionList -OptionSetRef $de['optionSet'] -Index $Index
+        $rows.Add((New-NeoIPCVariableRow `
+            -Level 'Event' -Module $stageName -DateLabel $dateLabel `
+            -Section (Get-NeoIPCSectionName -StageId $stageId -DataElementId ([string]$de['id']) -Index $Index) `
+            -Code ([string]$de['code']) -Label (Get-NeoIPCDataDictionaryLabel $de) `
+            -DataType (Get-NeoIPCFriendlyValueType ([string]$de['valueType'])) `
+            -Required (Format-NeoIPCDataDictionaryBoolean $psde['compulsory']) -Repeatable $repeatable `
+            -AllowedValues (Format-NeoIPCAllowedValues $optInfo) -Description ([string]$de['description']) `
+            -FieldKind (Get-NeoIPCDataDictionaryFieldKind -Element $de -OptionInfo $optInfo)))
+    }
+    return $rows.ToArray()
+}
+
+function Get-NeoIPCDataDictionaryProgramStage {
+    # The program's stages (resolved from the top-level stage list by program reference), in form order.
+    [OutputType([object[]])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Program, [Parameter(Mandatory)][hashtable]$Index)
+    $programId = [string]$Program['id']
+    $stages = @($Index.StageById.Values | Where-Object { (Get-NeoIPCMetadataRefId $_['program']) -eq $programId })
+    return Get-NeoIPCDataDictionarySorted -Item $stages -KeyOf {
+        param($s) (Get-NeoIPCDataDictionaryIntKey $s['sortOrder']) + '|' + [string]$s['name']
+    }
+}
+
+function Get-NeoIPCFormsAndDatesRow {
+    # One Forms & dates row per stage: the module/form and its event-date label.
+    [OutputType([object[]])]
+    param([Parameter(Mandatory)][AllowEmptyCollection()][object[]]$Stage, [AllowNull()][System.Collections.IDictionary]$Program)
+    $rows = [System.Collections.Generic.List[object]]::new()
+    foreach ($s in $Stage) {
+        $rows.Add([ordered]@{
+            'Module / form'   = [string]$s['name']
+            'Date label'      = Get-NeoIPCStageDateLabel -Stage $s -Program $Program
+            'Repeatable'      = Format-NeoIPCDataDictionaryBoolean $s['repeatable']
+            'Description'     = [string]$s['description']
+            'Sort order'      = [string]$s['sortOrder']
+        })
+    }
+    return $rows.ToArray()
+}
+
+function Get-NeoIPCCodeListRow {
+    # Every option set fully enumerated — one row per (option set, option) — ordered by set code then the
+    # option's sortOrder/code. Includes the large generated sets (pathogens, antimicrobials).
+    [OutputType([object[]])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Package, [Parameter(Mandatory)][hashtable]$Index)
+    $rows = [System.Collections.Generic.List[object]]::new()
+    $sets = Get-NeoIPCDataDictionarySorted -Item @($Package['optionSets']) -KeyOf { param($s) [string]$s['code'] }
+    foreach ($set in $sets) {
+        if ($set -isnot [System.Collections.IDictionary]) { continue }
+        $info = Resolve-NeoIPCOptionList -OptionSetRef @{ id = [string]$set['id'] } -Index $Index
+        if (-not $info) { continue }
+        $dataType = Get-NeoIPCFriendlyValueType $info.ValueType
+        foreach ($opt in $info.Options) {
+            $rows.Add([ordered]@{
+                'Code list'      = $info.SetName
+                'Code list code' = $info.SetCode
+                'Value code'     = [string]$opt['code']
+                'Value label'    = [string]$opt['name']
+                'Sort order'     = [string]$opt['sortOrder']
+                'Data type'      = $dataType
+            })
+        }
+    }
+    return $rows.ToArray()
+}
+
+function Get-NeoIPCDataDictionaryAboutRow {
+    # The About cover sheet: a flat list of Field/Value pairs (program identity, provenance, counts, a
+    # do-not-hand-edit note).
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)][System.Collections.IDictionary]$Program,
+        [int]$VariableCount, [int]$CodeListCount, [int]$CodeListValueCount, [int]$FormCount
+    )
+    $pairs = [ordered]@{
+        'Data dictionary'      = 'NeoIPC Core surveillance — collected variables and code lists'
+        'Program'              = ('{0} ({1})' -f [string]$Program['name'], [string]$Program['code'])
+        'Program version'      = [string]$Program['version']
+        'Generated'            = 'Generated from the canonical NeoIPC metadata directory — do not hand-edit; regenerate with scripts/New-NeoIPCDataDictionary.ps1.'
+        'Variables'            = [string]$VariableCount
+        'Code lists'           = [string]$CodeListCount
+        'Code list values'     = [string]$CodeListValueCount
+        'Modules / forms'      = [string]$FormCount
+        'Pathogen code list'   = 'Generated from the NeoIPC infectious-agents ontology (metadata/common/infectious-agents).'
+        'Antimicrobial list'   = 'Generated from the NeoIPC antibiotics curation (metadata/common/antibiotics).'
+    }
+    $rows = [System.Collections.Generic.List[object]]::new()
+    foreach ($k in $pairs.Keys) { $rows.Add([ordered]@{ 'Field' = $k; 'Value' = $pairs[$k] }) }
+    return $rows.ToArray()
+}
+
+function Get-NeoIPCDataDictionaryRow {
+    # Orchestrator: assemble the four data-dictionary sheets from a parsed package. Returns an ordered list
+    # of sheet descriptors (@{ Name; FileSuffix; Columns; Rows }) for the CSV / XLSX writers.
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param([Parameter(Mandatory)][System.Collections.IDictionary]$Package)
+
+    $programs = Get-NeoIPCDataDictionarySorted -Item @($Package['programs']) -KeyOf { param($p) [string]$p['code'] }
+    if ($programs.Count -eq 0) { throw 'The metadata package contains no programs to document.' }
+    $index = ConvertFrom-NeoIPCPackageIndex -Package $Package
+
+    $variableRows = [System.Collections.Generic.List[object]]::new()
+    $formRows = [System.Collections.Generic.List[object]]::new()
+    foreach ($program in $programs) {
+        foreach ($r in (Get-NeoIPCPatientAttributeRow -Program $program -Index $index)) { $variableRows.Add($r) }
+        $stages = Get-NeoIPCDataDictionaryProgramStage -Program $program -Index $index
+        foreach ($stage in $stages) {
+            foreach ($r in (Get-NeoIPCEventVariableRow -Stage $stage -Program $program -Index $index)) { $variableRows.Add($r) }
+        }
+        foreach ($r in (Get-NeoIPCFormsAndDatesRow -Stage $stages -Program $program)) { $formRows.Add($r) }
+    }
+    $codeListRows = Get-NeoIPCCodeListRow -Package $Package -Index $index
+    $codeListCount = @($codeListRows | ForEach-Object { $_['Code list code'] } | Select-Object -Unique).Count
+    $aboutRows = Get-NeoIPCDataDictionaryAboutRow -Program $programs[0] `
+        -VariableCount $variableRows.Count -CodeListCount $codeListCount `
+        -CodeListValueCount @($codeListRows).Count -FormCount $formRows.Count
+
+    return @(
+        [ordered]@{ Name = 'About';         FileSuffix = 'About';          Columns = $script:NeoIPCDataDictionaryAboutColumns;    Rows = $aboutRows }
+        [ordered]@{ Name = 'Variables';     FileSuffix = 'Variables';      Columns = $script:NeoIPCDataDictionaryVariableColumns; Rows = $variableRows.ToArray() }
+        [ordered]@{ Name = 'Code lists';    FileSuffix = 'Code-lists';     Columns = $script:NeoIPCDataDictionaryCodeListColumns; Rows = $codeListRows }
+        [ordered]@{ Name = 'Forms & dates'; FileSuffix = 'Forms-and-dates'; Columns = $script:NeoIPCDataDictionaryFormsColumns;   Rows = $formRows.ToArray() }
+    )
+}
+
+function Get-NeoIPCDataDictionaryLibDir {
+    # The gitignored output dir the OpenXml assembly is published into (scripts/modules/NeoIPC-Tools/lib/bin).
+    [OutputType([string])]
+    param()
+    Join-Path (Split-Path $PSScriptRoot -Parent) 'lib' 'bin'
+}
+
+function Assert-NeoIPCOpenXmlAvailable {
+    # Ensure the DocumentFormat.OpenXml assembly is loaded, loading it from the provisioned lib dir if needed.
+    # Throws an actionable message when it is not provisioned — the ordinary missing-dependency story.
+    [CmdletBinding()]
+    param()
+    if ('DocumentFormat.OpenXml.Packaging.SpreadsheetDocument' -as [type]) { return }
+    $libDir = Get-NeoIPCDataDictionaryLibDir
+    $main = Join-Path $libDir 'DocumentFormat.OpenXml.dll'
+    if (-not (Test-Path -LiteralPath $main)) {
+        throw ("The DocumentFormat.OpenXml assembly required for .xlsx output is not provisioned (looked in '$libDir'). " +
+            "Run 'Invoke-Workspace.ps1 -InstallDeps' to restore it (or, standalone, " +
+            "'dotnet publish scripts/modules/NeoIPC-Tools/lib -o scripts/modules/NeoIPC-Tools/lib/bin'), " +
+            'or pass -Format Csv to skip the workbook.')
+    }
+    # Load the runtime + framework dependencies first so the main assembly resolves them from this directory
+    # (the default load context probes the host base dir, not lib/bin, so pre-load them explicitly).
+    foreach ($dll in 'System.IO.Packaging.dll', 'DocumentFormat.OpenXml.Framework.dll', 'DocumentFormat.OpenXml.dll') {
+        $path = Join-Path $libDir $dll
+        if (Test-Path -LiteralPath $path) { Add-Type -LiteralPath $path }
+    }
+    if (-not ('DocumentFormat.OpenXml.Packaging.SpreadsheetDocument' -as [type])) {
+        throw "Loaded DocumentFormat.OpenXml from '$libDir' but its SpreadsheetDocument type is still unavailable."
+    }
+}
+
+function Get-NeoIPCXlsxColumnName {
+    # 0-based column index -> spreadsheet column letters (0 -> A, 26 -> AA).
+    [OutputType([string])]
+    param([Parameter(Mandatory)][int]$Index)
+    $n = $Index + 1
+    $name = ''
+    while ($n -gt 0) {
+        $m = ($n - 1) % 26
+        $name = [char](65 + $m) + $name
+        $n = [int](($n - $m - 1) / 26)
+    }
+    return $name
+}
+
+function New-NeoIPCXlsxStylesheet {
+    # Minimal stylesheet: font 0 = normal, font 1 = bold; cell format 0 = default, 1 = bold header.
+    # NOTE: an OpenXmlElement is IEnumerable over its children, so it must be emitted with Write-Output
+    # -NoEnumerate (a bare `return $styles` would unroll it into its child elements). The OpenXml type is
+    # deliberately absent from [OutputType] — it is not loaded when the module is parsed.
+    [OutputType([object])]
+    param()
+    $fonts = [DocumentFormat.OpenXml.Spreadsheet.Fonts]::new()
+    [void]$fonts.Append([DocumentFormat.OpenXml.Spreadsheet.Font]::new())
+    $bold = [DocumentFormat.OpenXml.Spreadsheet.Font]::new(); [void]$bold.Append([DocumentFormat.OpenXml.Spreadsheet.Bold]::new())
+    [void]$fonts.Append($bold); $fonts.Count = [uint32]2
+
+    $fills = [DocumentFormat.OpenXml.Spreadsheet.Fills]::new()
+    foreach ($pt in [DocumentFormat.OpenXml.Spreadsheet.PatternValues]::None, [DocumentFormat.OpenXml.Spreadsheet.PatternValues]::Gray125) {
+        $pf = [DocumentFormat.OpenXml.Spreadsheet.PatternFill]::new(); $pf.PatternType = $pt
+        $fill = [DocumentFormat.OpenXml.Spreadsheet.Fill]::new(); [void]$fill.Append($pf); [void]$fills.Append($fill)
+    }
+    $fills.Count = [uint32]2
+
+    $borders = [DocumentFormat.OpenXml.Spreadsheet.Borders]::new()
+    [void]$borders.Append([DocumentFormat.OpenXml.Spreadsheet.Border]::new()); $borders.Count = [uint32]1
+
+    $csf = [DocumentFormat.OpenXml.Spreadsheet.CellStyleFormats]::new()
+    $base = [DocumentFormat.OpenXml.Spreadsheet.CellFormat]::new()
+    $base.NumberFormatId = [uint32]0; $base.FontId = [uint32]0; $base.FillId = [uint32]0; $base.BorderId = [uint32]0
+    [void]$csf.Append($base); $csf.Count = [uint32]1
+
+    $cfs = [DocumentFormat.OpenXml.Spreadsheet.CellFormats]::new()
+    $def = [DocumentFormat.OpenXml.Spreadsheet.CellFormat]::new()
+    $def.NumberFormatId = [uint32]0; $def.FontId = [uint32]0; $def.FillId = [uint32]0; $def.BorderId = [uint32]0; $def.FormatId = [uint32]0
+    $hdr = [DocumentFormat.OpenXml.Spreadsheet.CellFormat]::new()
+    $hdr.NumberFormatId = [uint32]0; $hdr.FontId = [uint32]1; $hdr.FillId = [uint32]0; $hdr.BorderId = [uint32]0; $hdr.FormatId = [uint32]0; $hdr.ApplyFont = $true
+    [void]$cfs.Append($def); [void]$cfs.Append($hdr); $cfs.Count = [uint32]2
+
+    $styles = [DocumentFormat.OpenXml.Spreadsheet.Stylesheet]::new()
+    [void]$styles.Append($fonts); [void]$styles.Append($fills); [void]$styles.Append($borders); [void]$styles.Append($csf); [void]$styles.Append($cfs)
+    Write-Output -NoEnumerate $styles
+}
+
+function Write-NeoIPCDataDictionaryXlsx {
+    # Write the sheets as one multi-tab .xlsx (bold + frozen header row, column widths, shared strings) via the
+    # DocumentFormat.OpenXml SDK. Requires the provisioned assembly. Returns the written path. The CSVs remain
+    # the diffable source; the workbook is the hand-out artifact (zip timestamps make it only best-effort
+    # byte-stable, so it is not part of the determinism gate).
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory)][object[]]$Sheet, [Parameter(Mandatory)][string]$Path)
+    Assert-NeoIPCOpenXmlAvailable
+
+    $ssDict = [System.Collections.Generic.Dictionary[string, int]]::new([System.StringComparer]::Ordinal)
+    $ssList = [System.Collections.Generic.List[string]]::new()
+    $sharedIndex = {
+        param([string]$value)
+        $i = 0
+        if (-not $ssDict.TryGetValue($value, [ref]$i)) { $i = $ssList.Count; $ssDict[$value] = $i; $ssList.Add($value) }
+        $i
+    }
+    # A Cell is built and appended inline (not returned from a helper): an OpenXmlElement is IEnumerable over
+    # its children, so returning one through the pipeline would unroll it.
+    $addCell = {
+        param($Row, [string]$ColRef, [int]$RowNum, [string]$Value, [uint32]$Style)
+        $cell = [DocumentFormat.OpenXml.Spreadsheet.Cell]::new()
+        $cell.CellReference = $ColRef + $RowNum
+        $cell.DataType = [DocumentFormat.OpenXml.Spreadsheet.CellValues]::SharedString
+        $cell.CellValue = [DocumentFormat.OpenXml.Spreadsheet.CellValue]::new([string](& $sharedIndex $Value))
+        if ($Style -gt 0) { $cell.StyleIndex = $Style }
+        [void]$Row.AppendChild($cell)
+    }
+
+    if (Test-Path -LiteralPath $Path) { Remove-Item -LiteralPath $Path -Force }
+    $doc = [DocumentFormat.OpenXml.Packaging.SpreadsheetDocument]::Create($Path, [DocumentFormat.OpenXml.SpreadsheetDocumentType]::Workbook)
+    try {
+        $wbPart = $doc.AddWorkbookPart()
+        $wbPart.Workbook = [DocumentFormat.OpenXml.Spreadsheet.Workbook]::new()
+        $sheetsEl = $wbPart.Workbook.AppendChild([DocumentFormat.OpenXml.Spreadsheet.Sheets]::new())
+
+        $stylesPart = $wbPart.AddNewPart[DocumentFormat.OpenXml.Packaging.WorkbookStylesPart]()
+        $stylesPart.Stylesheet = New-NeoIPCXlsxStylesheet
+
+        $sheetId = 1
+        foreach ($sheet in $Sheet) {
+            $cols = [string[]]$sheet.Columns
+            $rows = @($sheet.Rows)
+
+            $wsPart = $wbPart.AddNewPart[DocumentFormat.OpenXml.Packaging.WorksheetPart]()
+            $worksheet = [DocumentFormat.OpenXml.Spreadsheet.Worksheet]::new()
+
+            # Freeze the header row.
+            $view = [DocumentFormat.OpenXml.Spreadsheet.SheetView]::new(); $view.WorkbookViewId = [uint32]0
+            $pane = [DocumentFormat.OpenXml.Spreadsheet.Pane]::new()
+            $pane.VerticalSplit = [double]1; $pane.TopLeftCell = 'A2'
+            $pane.ActivePane = [DocumentFormat.OpenXml.Spreadsheet.PaneValues]::BottomLeft
+            $pane.State = [DocumentFormat.OpenXml.Spreadsheet.PaneStateValues]::Frozen
+            $sel = [DocumentFormat.OpenXml.Spreadsheet.Selection]::new(); $sel.Pane = [DocumentFormat.OpenXml.Spreadsheet.PaneValues]::BottomLeft
+            [void]$view.Append($pane); [void]$view.Append($sel)
+            $views = [DocumentFormat.OpenXml.Spreadsheet.SheetViews]::new(); [void]$views.Append($view)
+            [void]$worksheet.Append($views)
+
+            # Column widths from the longest cell (header included), capped.
+            $colsEl = [DocumentFormat.OpenXml.Spreadsheet.Columns]::new()
+            for ($c = 0; $c -lt $cols.Count; $c++) {
+                $max = $cols[$c].Length
+                foreach ($row in $rows) { $len = ([string]$row[$cols[$c]]).Length; if ($len -gt $max) { $max = $len } }
+                if ($max -gt 80) { $max = 80 }
+                $col = [DocumentFormat.OpenXml.Spreadsheet.Column]::new()
+                $col.Min = [uint32]($c + 1); $col.Max = [uint32]($c + 1)
+                $col.Width = [double]([math]::Round([math]::Max(8, $max * 1.1 + 2), 2)); $col.CustomWidth = $true
+                [void]$colsEl.Append($col)
+            }
+            [void]$worksheet.Append($colsEl)
+
+            $sheetData = [DocumentFormat.OpenXml.Spreadsheet.SheetData]::new()
+            $headerRow = [DocumentFormat.OpenXml.Spreadsheet.Row]::new(); $headerRow.RowIndex = [uint32]1
+            for ($c = 0; $c -lt $cols.Count; $c++) {
+                & $addCell $headerRow (Get-NeoIPCXlsxColumnName $c) 1 $cols[$c] ([uint32]1)
+            }
+            [void]$sheetData.Append($headerRow)
+
+            $r = 2
+            foreach ($row in $rows) {
+                $dataRow = [DocumentFormat.OpenXml.Spreadsheet.Row]::new(); $dataRow.RowIndex = [uint32]$r
+                for ($c = 0; $c -lt $cols.Count; $c++) {
+                    & $addCell $dataRow (Get-NeoIPCXlsxColumnName $c) $r ([string]$row[$cols[$c]]) ([uint32]0)
+                }
+                [void]$sheetData.Append($dataRow)
+                $r++
+            }
+            [void]$worksheet.Append($sheetData)
+            $wsPart.Worksheet = $worksheet
+
+            $sheetEl = [DocumentFormat.OpenXml.Spreadsheet.Sheet]::new()
+            $sheetEl.Id = $wbPart.GetIdOfPart($wsPart)
+            $sheetEl.SheetId = [uint32]$sheetId
+            $sheetEl.Name = $sheet.Name
+            [void]$sheetsEl.Append($sheetEl)
+            $sheetId++
+        }
+
+        # Shared string table (built while writing the cells).
+        $sstPart = $wbPart.AddNewPart[DocumentFormat.OpenXml.Packaging.SharedStringTablePart]()
+        $sst = [DocumentFormat.OpenXml.Spreadsheet.SharedStringTable]::new()
+        foreach ($s in $ssList) {
+            $item = [DocumentFormat.OpenXml.Spreadsheet.SharedStringItem]::new()
+            $text = [DocumentFormat.OpenXml.Spreadsheet.Text]::new($s)
+            # Preserve significant leading/trailing whitespace (some source labels carry it).
+            if ($s.Length -ne $s.Trim().Length) { $text.Space = [DocumentFormat.OpenXml.SpaceProcessingModeValues]::Preserve }
+            [void]$item.Append($text)
+            [void]$sst.Append($item)
+        }
+        $sst.Count = [uint32]$ssList.Count; $sst.UniqueCount = [uint32]$ssList.Count
+        $sstPart.SharedStringTable = $sst
+
+        $wbPart.Workbook.Save()
+    }
+    finally { $doc.Dispose() }
+    return $Path
+}
+
+function Write-NeoIPCDataDictionaryCsv {
+    # Write the sheets as one UTF-8 (BOM, for Excel) / LF CSV per sheet, named <BaseName>-<FileSuffix>.csv.
+    # BOM so spreadsheet apps detect UTF-8 (pathogen / antibiotic names carry diacritics); LF for git-stable,
+    # byte-identical re-runs. Embedded CR/CRLF inside a cell (e.g. a CRLF-authored description) is normalized to
+    # LF so the file carries no CR byte and is platform-independent (a multi-line cell stays RFC-4180-quoted).
+    # Returns the written paths.
+    [CmdletBinding()]
+    [OutputType([string[]])]
+    param([Parameter(Mandatory)][object[]]$Sheet, [Parameter(Mandatory)][string]$OutputDirectory, [Parameter(Mandatory)][string]$BaseName)
+    $written = [System.Collections.Generic.List[string]]::new()
+    foreach ($sheet in $Sheet) {
+        $path = Join-Path $OutputDirectory ('{0}-{1}.csv' -f $BaseName, $sheet.FileSuffix)
+        $writer = [System.IO.StreamWriter]::new($path, $false, [System.Text.UTF8Encoding]::new($true))
+        $writer.NewLine = "`n"
+        try {
+            $writer.WriteLine((($sheet.Columns | ForEach-Object { ConvertTo-NeoIPCCsvField $_ }) -join ','))
+            foreach ($row in $sheet.Rows) {
+                $writer.WriteLine((($sheet.Columns | ForEach-Object { ConvertTo-NeoIPCCsvField (([string]$row[$_]).Replace("`r`n", "`n").Replace("`r", "`n")) }) -join ','))
+            }
+        }
+        finally { $writer.Dispose() }
+        $written.Add($path)
+    }
+    return $written.ToArray()
+}

--- a/scripts/modules/NeoIPC-Tools/Public/DataDictionary.ps1
+++ b/scripts/modules/NeoIPC-Tools/Public/DataDictionary.ps1
@@ -1,0 +1,84 @@
+# Public surface for the NeoIPC data-dictionary generator. Flattens the assembled DHIS2 metadata package
+# into a technology-agnostic spreadsheet (CSV + optional multi-tab XLSX). The transforms live in
+# Private/DataDictionary.ps1; this file is the cmdlet wiring only. No DHIS2 API calls.
+
+function Export-NeoIPCDataDictionary {
+    <#
+    .SYNOPSIS
+        Generate the NeoIPC Core data-dictionary spreadsheet (CSV + optional XLSX) from the canonical metadata.
+    .DESCRIPTION
+        Produces a technology-agnostic data dictionary that sits between the DHIS2 metadata JSON and the
+        end-user protocol: it documents everything the NeoIPC Core surveillance program collects — patient
+        attributes, per-event data elements, the event dates (admission / infection /
+        surveillance-end), and every code list (option set) in full, including the large pathogen and
+        antimicrobial lists. The wording avoids DHIS2 jargon (program stage -> module/form, value type -> data
+        type, option set -> code list, compulsory -> required) so it reads for both epidemiologists and
+        technical implementers.
+
+        Four sheets are produced (one CSV per sheet, named <BaseName>-<sheet>.csv, and/or all four as tabs of a
+        single .xlsx): About, Variables, Code lists, and Forms & dates. Output is deterministic and
+        locale-independent so a re-run is byte-identical (the CSVs; the XLSX is best-effort).
+
+        The source is the COMPLETE assembled package (-MetadataDirectory, the default — built export-free from
+        the metadata/ directory by New-NeoIPCMetadataPackage, so the pathogen/antimicrobial option domains are
+        present), or an already-assembled package supplied via -Package.
+
+        XLSX output needs the DocumentFormat.OpenXml assembly (provisioned with `dotnet`; see
+        Invoke-Workspace.ps1 -InstallDeps). When XLSX is requested but the assembly is unavailable the cmdlet
+        fails up front with an actionable message; CSV output needs nothing beyond PowerShell. No DHIS2 API calls.
+    .PARAMETER MetadataDirectory
+        The canonical metadata/ directory; the package is assembled from it (production install base). Default source.
+    .PARAMETER Package
+        An already-assembled package (an [ordered] dictionary: type -> object[]) to document instead of assembling one.
+    .PARAMETER OutputDirectory
+        Directory to write the artifacts into (created if absent).
+    .PARAMETER Format
+        Csv, Xlsx, or Both (default). Xlsx/Both require the DocumentFormat.OpenXml assembly.
+    .PARAMETER BaseName
+        File-name stem for the artifacts (default 'NeoIPC-Core-Data-Dictionary').
+    .OUTPUTS
+        The paths written.
+    .EXAMPLE
+        Export-NeoIPCDataDictionary -MetadataDirectory ./metadata -OutputDirectory ./artifacts/data-dictionary
+        Assemble the package from the directory and write the CSVs + the .xlsx workbook.
+    .EXAMPLE
+        Export-NeoIPCDataDictionary -MetadataDirectory ./metadata -OutputDirectory ./out -Format Csv
+        Write only the dependency-free CSV sheets.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Directory')]
+    [OutputType([string[]])]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'Directory')][string]$MetadataDirectory,
+        [Parameter(Mandatory, ParameterSetName = 'Package')][System.Collections.IDictionary]$Package,
+        [Parameter(Mandatory)][string]$OutputDirectory,
+        [ValidateSet('Csv', 'Xlsx', 'Both')][string]$Format = 'Both',
+        [string]$BaseName = 'NeoIPC-Core-Data-Dictionary'
+    )
+
+    $wantXlsx = $Format -eq 'Xlsx' -or $Format -eq 'Both'
+    $wantCsv = $Format -eq 'Csv' -or $Format -eq 'Both'
+
+    # Fail fast: don't assemble or write anything if XLSX is requested but its dependency is missing.
+    if ($wantXlsx) { Assert-NeoIPCOpenXmlAvailable }
+
+    $pkg = if ($PSCmdlet.ParameterSetName -eq 'Package') {
+        $Package
+    }
+    else {
+        if (-not (Test-Path -LiteralPath $MetadataDirectory)) { throw "Metadata directory not found: '$MetadataDirectory'." }
+        (New-NeoIPCMetadataPackage -MetadataDirectory $MetadataDirectory -PassThru).Package
+    }
+
+    $sheets = Get-NeoIPCDataDictionaryRow -Package $pkg
+
+    if (-not (Test-Path -LiteralPath $OutputDirectory)) { New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null }
+
+    $written = [System.Collections.Generic.List[string]]::new()
+    if ($wantCsv) {
+        foreach ($p in (Write-NeoIPCDataDictionaryCsv -Sheet $sheets -OutputDirectory $OutputDirectory -BaseName $BaseName)) { $written.Add($p) }
+    }
+    if ($wantXlsx) {
+        $written.Add((Write-NeoIPCDataDictionaryXlsx -Sheet $sheets -Path (Join-Path $OutputDirectory ("$BaseName.xlsx"))))
+    }
+    return $written.ToArray()
+}

--- a/scripts/modules/NeoIPC-Tools/README.md
+++ b/scripts/modules/NeoIPC-Tools/README.md
@@ -52,6 +52,7 @@ The module spans two broad areas:
 | `Private/MetadataAssembly.ps1` | Stitch closure config + authored content into the final package (`Join-NeoIPCMetadataPackage`) |
 | `Private/MetadataTranslation.ps1` | The gettext-PO subsystem — translation-unit extraction, PO emit/parse/merge, inject `translations[]` |
 | `Private/MetadataGeneration.ps1` | The generation **plans** — pathogen/substance/field-gating DE+PRV+rule plans, resistance + common-commensal effective-flag/code-set computation, the per-slot capability matrix |
+| `Public/DataDictionary.ps1` + `Private/DataDictionary.ps1` | The **data-dictionary** generator (`Export-NeoIPCDataDictionary`) — flattens the assembled package into a technology-agnostic spreadsheet (patient attributes, per-stage data elements, the event dates, and every code list in full) as CSV + a multi-tab `.xlsx` (via `DocumentFormat.OpenXml`, provisioned under `lib/`) |
 
 ### Metadata pipeline — data flow
 
@@ -410,3 +411,4 @@ runs `msgfmt -c` (via WSL on Windows) when gettext is available.
 | InfectiousAgents | `Find-NextFreeInfectiousAgentId` |
 | Metadata pipeline | `ConvertFrom-NeoIPCMetadataJson`, `ConvertTo-NeoIPCMetadataJson`, `Compare-NeoIPCMetadata`, `Test-NeoIPCMetadataRoundTrip`, `Merge-NeoIPCMetadataJson`, `Select-NeoIPCMetadataClosure`, `Test-NeoIPCMetadataExpression`, `Update-NeoIPCMetadata`, `New-NeoIPCMetadataPackage`, `Export-NeoIPCMetadataTranslation`, `Import-NeoIPCMetadataTranslation`, `Update-NeoIPCMetadataDirectory` |
 | Metadata generation | `New-NeoIPCPathogenOptionSet`, `New-NeoIPCPathogenDataElement`, `New-NeoIPCPathogenVariable`, `New-NeoIPCPathogenRule`, `New-NeoIPCPathogenFieldGatingVariable`, `New-NeoIPCPathogenFieldGatingRule`, `New-NeoIPCSubstanceDataElement`, `New-NeoIPCSubstanceVariable`, `New-NeoIPCSubstanceRule` |
+| Data dictionary | `Export-NeoIPCDataDictionary` |

--- a/scripts/modules/NeoIPC-Tools/Tests/DataDictionary.Tests.ps1
+++ b/scripts/modules/NeoIPC-Tools/Tests/DataDictionary.Tests.ps1
@@ -201,6 +201,27 @@ InModuleScope 'NeoIPC-Tools' {
         }
     }
 
+    Describe 'Guards' {
+        It 'throws on a multi-program package' {
+            $mkProg = { param($c) [ordered]@{ id = $c; code = $c; name = $c; version = 1; programStages = @(); programTrackedEntityAttributes = @() } }
+            $pkg = [ordered]@{
+                programs = @((& $mkProg 'P1'), (& $mkProg 'P2'))
+                programStages = @(); trackedEntityAttributes = @(); dataElements = @(); optionSets = @(); options = @(); programStageSections = @()
+            }
+            { Get-NeoIPCDataDictionaryRow -Package $pkg } | Should -Throw -ExpectedMessage '*single program*'
+        }
+
+        It 'throws on a duplicate variable code (e.g. stage names that slugify the same)' {
+            $mkStage = { param($id, $name, $order) [ordered]@{ id = $id; name = $name; executionDateLabel = 'D'; reportDateToUse = ''; sortOrder = $order; repeatable = $false; program = (Ref 'p'); programStageSections = @(); programStageDataElements = @() } }
+            $pkg = [ordered]@{
+                programs = @([ordered]@{ id = 'p'; code = 'P'; name = 'P'; version = 1; programStages = @((Ref 's1'), (Ref 's2')); programTrackedEntityAttributes = @() })
+                programStages = @((& $mkStage 's1' 'Visit A' 1), (& $mkStage 's2' 'Visit/A' 2))
+                trackedEntityAttributes = @(); dataElements = @(); optionSets = @(); options = @(); programStageSections = @()
+            }
+            { Get-NeoIPCDataDictionaryRow -Package $pkg } | Should -Throw -ExpectedMessage '*Duplicate variable code*'
+        }
+    }
+
     Describe 'value-type mapping' {
         It 'maps known value types' {
             Get-NeoIPCFriendlyValueType 'TRUE_ONLY' | Should -BeExactly 'Checkbox (yes / blank)'

--- a/scripts/modules/NeoIPC-Tools/Tests/DataDictionary.Tests.ps1
+++ b/scripts/modules/NeoIPC-Tools/Tests/DataDictionary.Tests.ps1
@@ -1,0 +1,316 @@
+# Pester 5 tests for the NeoIPC data-dictionary generator (Private/DataDictionary.ps1 + Public/DataDictionary.ps1).
+# Self-contained: every fixture is a synthetic in-memory package, so the suite runs against a standalone
+# Surveillance-Toolkit checkout with no DHIS2 metadata.json and no package assembly. The XLSX case is skipped
+# unless the DocumentFormat.OpenXml assembly has been provisioned.
+#
+# Run:  Invoke-Pester -Path scripts/modules/NeoIPC-Tools/Tests/DataDictionary.Tests.ps1
+#
+# Private helpers are exercised via InModuleScope. The Import-Module at file top runs during Pester's
+# discovery phase, which InModuleScope requires.
+
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot '..') -Force
+
+InModuleScope 'NeoIPC-Tools' {
+
+    # Whether the optional DocumentFormat.OpenXml assembly is provisioned (decides the XLSX case). Evaluated
+    # during Pester discovery so it can gate -Skip.
+    $script:XlsxAvailable = Test-Path -LiteralPath (Join-Path (Get-NeoIPCDataDictionaryLibDir) 'DocumentFormat.OpenXml.dll')
+
+    BeforeAll {
+        function Ref([string]$Id) { @{ id = $Id } }
+
+        # A synthetic package mirroring the assembled-package shape (type -> OrderedDictionary[], refs as
+        # @{ id = '<uid>' }, nested-only children inlined). Deliberately out-of-order in places to prove the
+        # ordinal sort. One small coded set, one free-text fallback element, one TRUE_ONLY, and a >limit set.
+        function New-TestPackage {
+            $pathOptions = @(for ($i = 1; $i -le 15; $i++) {
+                    [ordered]@{ id = "p$i"; code = "$i"; name = "Organism $i"; sortOrder = $i; optionSet = (Ref 'osPath') }
+                })
+            [ordered]@{
+                programs                  = @(
+                    [ordered]@{
+                        id = 'prog1'; code = 'TEST_PROG'; name = 'Test program'; version = 3
+                        enrollmentDateLabel = 'Admission date'; incidentDateLabel = 'Enrolment date'; displayIncidentDate = $false
+                        programStages = @((Ref 'stgAdm'), (Ref 'stgInf'))
+                        programTrackedEntityAttributes = @(
+                            [ordered]@{ id = 'pt2'; mandatory = $false; sortOrder = 2; trackedEntityAttribute = (Ref 'teaSex') },
+                            [ordered]@{ id = 'pt1'; mandatory = $true; sortOrder = 1; trackedEntityAttribute = (Ref 'teaId') }
+                        )
+                    }
+                )
+                programStages             = @(
+                    [ordered]@{
+                        id = 'stgInf'; name = 'Infection'; description = 'Infection event.'; executionDateLabel = 'Infection date'
+                        reportDateToUse = ''; sortOrder = 2; repeatable = $true; program = (Ref 'prog1')
+                        programStageSections = @(Ref 'sec1')
+                        programStageDataElements = @(
+                            [ordered]@{ id = 'psde2'; compulsory = $false; sortOrder = 2; dataElement = (Ref 'deNote'); programStage = (Ref 'stgInf') },
+                            [ordered]@{ id = 'psde3'; compulsory = $false; sortOrder = 1; dataElement = (Ref 'dePath'); programStage = (Ref 'stgInf') }
+                        )
+                    },
+                    [ordered]@{
+                        id = 'stgAdm'; name = 'Admission'; description = 'Admission event.'; executionDateLabel = 'Admission date'
+                        reportDateToUse = 'enrollmentDate'; sortOrder = 1; repeatable = $false; program = (Ref 'prog1')
+                        programStageSections = @()
+                        programStageDataElements = @(
+                            [ordered]@{ id = 'psde1'; compulsory = $true; sortOrder = 1; dataElement = (Ref 'deType'); programStage = (Ref 'stgAdm') }
+                        )
+                    }
+                )
+                trackedEntityAttributes   = @(
+                    [ordered]@{ id = 'teaId'; code = 'TEST_PATIENT_ID'; name = 'Patient identifier'; formName = 'Patient ID'; shortName = 'Pat ID'; description = 'Unique, random id.'; valueType = 'TEXT' },
+                    [ordered]@{ id = 'teaSex'; code = 'TEST_SEX'; name = 'Sex name'; formName = 'Sex'; shortName = 'Sx'; description = 'Phenotypic sex.'; valueType = 'LETTER'; optionSet = (Ref 'osSex') }
+                )
+                dataElements              = @(
+                    [ordered]@{ id = 'deType'; code = 'TEST_ADM_TYPE'; name = 'Admission type name'; formName = 'Admission type'; shortName = 'Adm type'; description = 'Type.'; valueType = 'INTEGER_POSITIVE'; optionSet = (Ref 'osType') },
+                    [ordered]@{ id = 'deNote'; code = 'TEST_ORG_NAME'; name = 'Organism name'; formName = 'Organism name'; shortName = 'Org name'; description = 'Use this option if the organism is not contained in the organism-list above.'; valueType = 'TEXT' },
+                    [ordered]@{ id = 'dePath'; code = 'TEST_PATHOGEN_1'; name = 'Organism 1 name'; formName = 'Organism 1'; shortName = 'Org 1'; description = 'Detected organism.'; valueType = 'INTEGER_ZERO_OR_POSITIVE'; optionSet = (Ref 'osPath') }
+                )
+                optionSets                = @(
+                    [ordered]@{ id = 'osPath'; code = 'NEOIPC_PATHOGENS'; name = 'Test pathogens'; valueType = 'INTEGER_ZERO_OR_POSITIVE'; options = @($pathOptions | ForEach-Object { Ref $_.id }) },
+                    [ordered]@{ id = 'osSex'; code = 'TEST_SEX_VALUES'; name = 'Test sex values'; valueType = 'LETTER'; options = @((Ref 'oF'), (Ref 'oM'), (Ref 'oU')) },
+                    [ordered]@{ id = 'osType'; code = 'TEST_ADM_TYPES'; name = 'Test admission types'; valueType = 'INTEGER_POSITIVE'; options = @((Ref 't1'), (Ref 't2')) }
+                )
+                options                   = @(
+                    # Deliberately out of sortOrder to prove the resolver reorders.
+                    [ordered]@{ id = 'oU'; code = 'u'; name = 'Undetermined'; sortOrder = 3; optionSet = (Ref 'osSex') },
+                    [ordered]@{ id = 'oF'; code = 'f'; name = 'Female'; sortOrder = 1; optionSet = (Ref 'osSex') },
+                    [ordered]@{ id = 'oM'; code = 'm'; name = 'Male'; sortOrder = 2; optionSet = (Ref 'osSex') },
+                    [ordered]@{ id = 't1'; code = '1'; name = 'Born here'; sortOrder = 1; optionSet = (Ref 'osType') },
+                    [ordered]@{ id = 't2'; code = '2'; name = 'Transferred'; sortOrder = 2; optionSet = (Ref 'osType') }
+                ) + $pathOptions
+                programStageSections      = @(
+                    [ordered]@{ id = 'sec1'; name = 'Organisms'; sortOrder = 0; programStage = (Ref 'stgInf'); dataElements = @((Ref 'dePath'), (Ref 'deNote')) }
+                )
+            }
+        }
+
+        function Get-Sheet($Sheets, [string]$Name) { $Sheets | Where-Object { $_.Name -eq $Name } | Select-Object -First 1 }
+
+        $script:Pkg = New-TestPackage
+        $script:Sheets = Get-NeoIPCDataDictionaryRow -Package $script:Pkg
+        $script:Variables = (Get-Sheet $script:Sheets 'Variables').Rows
+        $script:CodeLists = (Get-Sheet $script:Sheets 'Code lists').Rows
+        $script:Forms = (Get-Sheet $script:Sheets 'Forms & dates').Rows
+        $script:About = (Get-Sheet $script:Sheets 'About').Rows
+    }
+
+    Describe 'Sheet assembly' {
+        It 'produces the four named sheets in order' {
+            @($script:Sheets | ForEach-Object { $_.Name }) | Should -Be @('About', 'Variables', 'Code lists', 'Forms & dates')
+        }
+    }
+
+    Describe 'Variable rows' {
+        It 'orders patient attributes first, then stages by sortOrder, date row before its elements' {
+            # Codes in document order: patient attrs (sortOrder 1,2), then Admission (date + 1 DE), then Infection (date + 2 DEs).
+            $codes = @($script:Variables | ForEach-Object { $_['Code'] })
+            $codes | Should -Be @(
+                'TEST_PATIENT_ID', 'TEST_SEX',
+                'NEOIPC_EVENTDATE_ADMISSION', 'TEST_ADM_TYPE',
+                'NEOIPC_EVENTDATE_INFECTION', 'TEST_PATHOGEN_1', 'TEST_ORG_NAME')
+        }
+
+        It 'labels a known data element from formName, maps the data type, derives Required and Section, inlines a short code list' {
+            $row = $script:Variables | Where-Object { $_['Code'] -eq 'TEST_PATHOGEN_1' } | Select-Object -First 1
+            $row['Label'] | Should -BeExactly 'Organism 1'                 # formName
+            $row['Data type'] | Should -BeExactly 'Whole number (>= 0)'    # INTEGER_ZERO_OR_POSITIVE
+            $row['Required'] | Should -BeExactly 'No'                       # compulsory = false
+            $row['Section'] | Should -BeExactly 'Organisms'
+            $row['Repeatable'] | Should -BeExactly 'Yes'                    # stage repeatable
+            $row['Level'] | Should -BeExactly 'Event'
+        }
+
+        It 'marks patient attributes Patient with blank Repeatable, and a coded attribute inlines its values' {
+            $sex = $script:Variables | Where-Object { $_['Code'] -eq 'TEST_SEX' } | Select-Object -First 1
+            $sex['Level'] | Should -BeExactly 'Patient'
+            $sex['Module / form'] | Should -BeExactly 'Patient master data'
+            $sex['Repeatable'] | Should -BeExactly ''
+            $sex['Required'] | Should -BeExactly 'No'                       # mandatory = false
+            $sex['Allowed values'] | Should -BeExactly 'f = Female; m = Male; u = Undetermined'
+        }
+    }
+
+    Describe 'Event dates' {
+        It 'emits exactly one event-date row per stage (user-entered Date, required) with unique codes' {
+            $dateRows = @($script:Variables | Where-Object { $_['Field kind'] -eq 'Event date' })
+            $dateRows.Count | Should -Be 2
+            $codes = @($dateRows | ForEach-Object { $_['Code'] })
+            ($codes | Select-Object -Unique).Count | Should -Be $codes.Count
+            $dateRows | ForEach-Object { $_['Data type'] | Should -BeExactly 'Date'; $_['Required'] | Should -BeExactly 'Yes' }
+        }
+
+        It 'uses the program enrollmentDateLabel for the Admission stage date (reportDateToUse=enrollmentDate)' {
+            $adm = $script:Variables | Where-Object { $_['Code'] -eq 'NEOIPC_EVENTDATE_ADMISSION' } | Select-Object -First 1
+            $adm['Form date label'] | Should -BeExactly 'Admission date'
+            $adm['Label'] | Should -BeExactly 'Admission date'
+            $adm['Repeatable'] | Should -BeExactly 'No'
+        }
+
+        It 'uses the stage executionDateLabel for a non-Admission (Infection) event date' {
+            $inf = $script:Variables | Where-Object { $_['Code'] -eq 'NEOIPC_EVENTDATE_INFECTION' } | Select-Object -First 1
+            $inf['Form date label'] | Should -BeExactly 'Infection date'
+            $inf['Label'] | Should -BeExactly 'Infection date'
+            $inf['Repeatable'] | Should -BeExactly 'Yes'
+        }
+    }
+
+    Describe 'Code lists' {
+        It 'fully enumerates every option set, including the large one' {
+            $setCodes = @($script:CodeLists | ForEach-Object { $_['Code list code'] } | Select-Object -Unique)
+            $setCodes | Should -Contain 'NEOIPC_PATHOGENS'
+            @($script:CodeLists | Where-Object { $_['Code list code'] -eq 'NEOIPC_PATHOGENS' }).Count | Should -Be 15
+            @($script:CodeLists).Count | Should -Be (15 + 3 + 2)
+        }
+
+        It 'orders options by sortOrder and carries the value label' {
+            $sex = @($script:CodeLists | Where-Object { $_['Code list code'] -eq 'TEST_SEX_VALUES' })
+            @($sex | ForEach-Object { $_['Value code'] }) | Should -Be @('f', 'm', 'u')
+            $sex[0]['Value label'] | Should -BeExactly 'Female'
+        }
+    }
+
+    Describe 'Allowed values cell' {
+        It 'inlines a short set but points to the Code lists sheet for a long one' {
+            $type = $script:Variables | Where-Object { $_['Code'] -eq 'TEST_ADM_TYPE' } | Select-Object -First 1
+            $type['Allowed values'] | Should -BeExactly '1 = Born here; 2 = Transferred'
+            $path = $script:Variables | Where-Object { $_['Code'] -eq 'TEST_PATHOGEN_1' } | Select-Object -First 1
+            $path['Allowed values'] | Should -BeExactly 'See code list: Test pathogens'
+        }
+
+        It 'inlines at the option limit and points just past it (pins the boundary)' {
+            $mk = { param($n) @{ SetName = 'S'; Options = @(1..$n | ForEach-Object { [ordered]@{ code = "$_"; name = "v$_" } }) } }
+            (Format-NeoIPCAllowedValues (& $mk 12)) | Should -Not -Match 'See code list'
+            (Format-NeoIPCAllowedValues (& $mk 13)) | Should -BeExactly 'See code list: S'
+        }
+    }
+
+    Describe 'Empty option set' {
+        It 'does not crash and emits no code-list rows for an option set with zero options' {
+            $pkg = [ordered]@{
+                programs                = @([ordered]@{ id = 'p'; code = 'P'; name = 'P'; version = 1; programStages = @()
+                        programTrackedEntityAttributes = @([ordered]@{ id = 'pt'; mandatory = $false; sortOrder = 1; trackedEntityAttribute = (Ref 'tea') }) })
+                programStages           = @(); dataElements = @(); options = @(); programStageSections = @()
+                trackedEntityAttributes = @([ordered]@{ id = 'tea'; code = 'C'; name = 'N'; valueType = 'TEXT'; optionSet = (Ref 'osE') })
+                optionSets              = @([ordered]@{ id = 'osE'; code = 'EMPTY_SET'; name = 'Empty set'; valueType = 'TEXT'; options = @() })
+            }
+            { Get-NeoIPCDataDictionaryRow -Package $pkg } | Should -Not -Throw
+            $cl = (Get-Sheet (Get-NeoIPCDataDictionaryRow -Package $pkg) 'Code lists').Rows
+            @($cl | Where-Object { $_['Code list code'] -eq 'EMPTY_SET' }).Count | Should -Be 0
+        }
+    }
+
+    Describe 'value-type mapping' {
+        It 'maps known value types' {
+            Get-NeoIPCFriendlyValueType 'TRUE_ONLY' | Should -BeExactly 'Checkbox (yes / blank)'
+            Get-NeoIPCFriendlyValueType 'DATE' | Should -BeExactly 'Date'
+        }
+        It 'passes an unknown value type through verbatim and warns' {
+            $w = $null
+            $result = Get-NeoIPCFriendlyValueType -ValueType 'NO_SUCH_TYPE' -WarningVariable w -WarningAction SilentlyContinue
+            $result | Should -BeExactly 'NO_SUCH_TYPE'
+            $w | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Describe 'Field kind' {
+        It 'flags an uncoded free-text "not in the list" element as a free-text fallback' {
+            $note = $script:Variables | Where-Object { $_['Code'] -eq 'TEST_ORG_NAME' } | Select-Object -First 1
+            $note['Field kind'] | Should -BeExactly 'Free-text fallback'
+        }
+        It 'treats an ordinary element as an explicit field' {
+            ($script:Variables | Where-Object { $_['Code'] -eq 'TEST_ADM_TYPE' } | Select-Object -First 1)['Field kind'] | Should -BeExactly 'Explicit field'
+        }
+    }
+
+    Describe 'Label fallback' {
+        It 'prefers formName, then name, then shortName' {
+            (Get-NeoIPCDataDictionaryLabel ([ordered]@{ formName = 'F'; name = 'N'; shortName = 'S' })) | Should -BeExactly 'F'
+            (Get-NeoIPCDataDictionaryLabel ([ordered]@{ formName = ''; name = 'N'; shortName = 'S' })) | Should -BeExactly 'N'
+            (Get-NeoIPCDataDictionaryLabel ([ordered]@{ formName = ''; name = ''; shortName = 'S' })) | Should -BeExactly 'S'
+        }
+    }
+
+    Describe 'About sheet' {
+        It 'reports the program identity and counts' {
+            $map = @{}; foreach ($r in $script:About) { $map[$r['Field']] = $r['Value'] }
+            $map['Program'] | Should -BeExactly 'Test program (TEST_PROG)'
+            $map['Variables'] | Should -BeExactly ([string]@($script:Variables).Count)
+            $map['Code list values'] | Should -BeExactly ([string]@($script:CodeLists).Count)
+            $map['Modules / forms'] | Should -BeExactly '2'
+        }
+    }
+
+    Describe 'Determinism' {
+        It 'produces a row order independent of the current culture' {
+            $orig = [System.Threading.Thread]::CurrentThread.CurrentCulture
+            try {
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::new('tr-TR')
+                $a = @((Get-Sheet (Get-NeoIPCDataDictionaryRow -Package (New-TestPackage)) 'Variables').Rows | ForEach-Object { $_['Code'] })
+                [System.Threading.Thread]::CurrentThread.CurrentCulture = [System.Globalization.CultureInfo]::new('en-US')
+                $b = @((Get-Sheet (Get-NeoIPCDataDictionaryRow -Package (New-TestPackage)) 'Variables').Rows | ForEach-Object { $_['Code'] })
+                $a | Should -Be $b
+            }
+            finally { [System.Threading.Thread]::CurrentThread.CurrentCulture = $orig }
+        }
+    }
+
+    Describe 'CSV writer' {
+        It 'writes a UTF-8 BOM, LF line endings, the fixed header, and RFC-4180 quoting' {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) ('neoipc-dd-' + [guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $dir | Out-Null
+            try {
+                $paths = Write-NeoIPCDataDictionaryCsv -Sheet $script:Sheets -OutputDirectory $dir -BaseName 'DD'
+                @($paths).Count | Should -Be 4
+                $varPath = $paths | Where-Object { $_ -like '*-Variables.csv' }
+                $bytes = [System.IO.File]::ReadAllBytes($varPath)
+                $bytes[0..2] | Should -Be @(0xEF, 0xBB, 0xBF)                      # UTF-8 BOM
+                $text = [System.IO.File]::ReadAllText($varPath, [System.Text.UTF8Encoding]::new($true))
+                $text | Should -Not -Match "`r`n"                                   # LF only
+                $lines = $text -split "`n"
+                $lines[0] | Should -BeExactly 'Level,Module / form,Form date label,Section,Code,Label,Data type,Required,Repeatable,Allowed values,Description,Field kind'
+                # A field containing a comma is RFC-4180 quoted; one without is not.
+                @($lines | Where-Object { $_ -match 'TEST_PATIENT_ID' })[0] | Should -Match '"Unique, random id\."'
+            }
+            finally { Remove-Item $dir -Recurse -Force }
+        }
+
+        It 'normalizes embedded CR/CRLF in cell text to LF (no CR byte in the output)' {
+            $pkg = [ordered]@{
+                programs                = @([ordered]@{ id = 'p'; code = 'P'; name = 'P'; version = 1; programStages = @()
+                        programTrackedEntityAttributes = @([ordered]@{ id = 'pt'; mandatory = $false; sortOrder = 1; trackedEntityAttribute = (Ref 'tea') }) })
+                programStages           = @(); dataElements = @(); optionSets = @(); options = @(); programStageSections = @()
+                trackedEntityAttributes = @([ordered]@{ id = 'tea'; code = 'C'; name = 'N'; formName = 'N'; description = "line1`r`nline2`rline3"; valueType = 'TEXT' })
+            }
+            $sheets = Get-NeoIPCDataDictionaryRow -Package $pkg
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) ('neoipc-dd-cr-' + [guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $dir | Out-Null
+            try {
+                $paths = Write-NeoIPCDataDictionaryCsv -Sheet $sheets -OutputDirectory $dir -BaseName 'DD'
+                foreach ($p in $paths) { ([System.IO.File]::ReadAllBytes($p) -contains [byte]13) | Should -BeFalse }
+            }
+            finally { Remove-Item $dir -Recurse -Force }
+        }
+    }
+
+    Describe 'XLSX writer' {
+        It 'produces a schema-valid workbook with the expected sheet names' -Skip:(-not $script:XlsxAvailable) {
+            $dir = Join-Path ([System.IO.Path]::GetTempPath()) ('neoipc-dd-xlsx-' + [guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $dir | Out-Null
+            try {
+                $paths = Export-NeoIPCDataDictionary -Package $script:Pkg -OutputDirectory $dir -Format Xlsx -BaseName 'DD'
+                $xlsx = @($paths | Where-Object { $_ -like '*.xlsx' })[0]
+                Test-Path -LiteralPath $xlsx | Should -BeTrue
+                $doc = [DocumentFormat.OpenXml.Packaging.SpreadsheetDocument]::Open($xlsx, $false)
+                try {
+                    @([DocumentFormat.OpenXml.Validation.OpenXmlValidator]::new().Validate($doc)).Count | Should -Be 0
+                    @($doc.WorkbookPart.Workbook.Sheets.ChildElements | ForEach-Object { $_.Name.Value }) |
+                        Should -Be @('About', 'Variables', 'Code lists', 'Forms & dates')
+                }
+                finally { $doc.Dispose() }
+            }
+            finally { Remove-Item $dir -Recurse -Force }
+        }
+    }
+}

--- a/scripts/modules/NeoIPC-Tools/lib/NeoIPC-Tools.Dependencies.csproj
+++ b/scripts/modules/NeoIPC-Tools/lib/NeoIPC-Tools.Dependencies.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Provisioning-only project. It carries NO source of its own; its sole purpose is to pin and restore the
+    DocumentFormat.OpenXml assemblies (MIT-licensed; https://github.com/dotnet/Open-XML-SDK) that the
+    NeoIPC-Tools module loads to write the data-dictionary .xlsx workbook (Public/DataDictionary.ps1).
+
+    Restore the assemblies into the gitignored ./bin output dir the module loads from:
+        dotnet publish scripts/modules/NeoIPC-Tools/lib -o scripts/modules/NeoIPC-Tools/lib/bin
+
+    Invoke-Workspace.ps1 -InstallDeps runs this; the data-dictionary README documents the same one-liner for
+    standalone Surveillance-Toolkit clones. net10.0 matches the .NET 10 / PowerShell 7.6 baseline.
+  -->
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## NeoIPC Core data dictionary

A technology-agnostic data dictionary (codebook) for the NeoIPC Core surveillance program, auto-generated from the canonical metadata so it stays in step with future changes. It sits between the machine-readable DHIS2 metadata and the end-user protocol — readable by both epidemiologists and technical implementers.

`Export-NeoIPCDataDictionary` (NeoIPC-Tools) flattens the assembled metadata package into four sheets:

- **About** — program identity, counts, provenance
- **Variables** — patient attributes, per-event data elements, and the per-event dates
- **Code lists** — every option set in full (including the pathogen and antimicrobial lists)
- **Forms & dates** — each module/form and its event date

emitted as CSV plus a multi-tab `.xlsx`. DHIS2 UIDs are omitted (technology-specific); the project variable code is the stable identifier.

- **Release artifact, not source:** output goes to the gitignored `artifacts/` tree and is generated in CI (uploaded with the build). See `docs/data-dictionary.md`.
- **`.xlsx`** via the MIT DocumentFormat.OpenXml SDK, restored with `dotnet` (`dotnet publish` of `scripts/modules/NeoIPC-Tools/lib`); the CSV path needs no extra dependency.
- Module baseline raised to PowerShell 7.6 / .NET 10.

Generate locally: `./scripts/New-NeoIPCDataDictionary.ps1` (CSV + `.xlsx`) or `-Format Csv`.
