### PR TITLE
Report logging via the shared logger, plus metadata-import round-trip verification

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -67,7 +67,7 @@ Reports live under `reports/`:
 
 ### Shared Infrastructure
 
-- **Shared R code**: `reports/common/` — `helpers.R` (locale parsing, string resource loading, DHIS2 connection helpers), `load-neoipcr.R`, `parse-args.R` (CLI arg parsing), `getDataset.R` (dataset export), `reference.docx` (Word template)
+- **Shared R code**: `reports/common/` — `helpers.R` (locale parsing, string resource loading, DHIS2 connection helpers), `load-neoipcr.R`, `parse-args.R` (CLI arg parsing), `getDataset.R` (dataset export), `logging.R` (unified `logger`-based logging: `configure_logging()` + `logInfo`/`logVerbose`/`logDebug`/`logWarn`/`logError`), `reference.docx` (Word template)
 - **Base string resources**: `reports/common.yaml` (English domain terms, table headers, footnotes)
 - **Pandoc filters**: `reports/filters/pandoc-quotes.lua` (language-aware typographic quotes), `remove-empty-sections.lua`
 
@@ -264,6 +264,18 @@ No `sprintf` `%s`, markdown, or LaTeX syntax in translatable strings. Use `glue`
 ### PowerShell Scripts
 
 Approved PS verbs + PascalCase noun (e.g., `New-PartnerReports.ps1`). All wrappers in `scripts/`. Shared helpers in `scripts/NeoIPCReportHelpers.ps1` (dot-sourced).
+
+### Logging
+
+All report R code and neoipcr log through the `logger` package (`reports/common/logging.R`). Three R namespaces —
+the report's slug (e.g. `partner-report`), `report-common` (the shared `common/` layer), and `neoipcr` — let every
+line self-identify its source. Verbosity is **one** setting (`quiet`/`normal`/`verbose`/`debug`), propagated to the
+R / Quarto child processes via the **`NEOIPC_LOG_LEVEL`** environment variable: the default `normal` shows lifecycle
+progress; `verbose`/`debug` reveal the DHIS2 query trace (URL + HTTP status + row count — **never** response bodies,
+a data-protection boundary). The `New-*.ps1` wrappers map the standard `-Quiet`/`-Verbose`/`-Debug` switches to it
+(via `Invoke-WithNeoIPCAuth -ExtraEnvVars`); the `Generate-*Data.R` wrappers' `--quiet`/`--verbose`/`--debug` flags
+and Partner-Report's `-P debug:true` override it. When `NEOIPC_LOG_FILE` is set (by the NeoIPC-Reporting .NET
+service), the R side writes structured JSON to that file instead of the console.
 
 ### Argument Handling
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -269,13 +269,16 @@ Approved PS verbs + PascalCase noun (e.g., `New-PartnerReports.ps1`). All wrappe
 
 All report R code and neoipcr log through the `logger` package (`reports/common/logging.R`). Three R namespaces —
 the report's slug (e.g. `partner-report`), `report-common` (the shared `common/` layer), and `neoipcr` — let every
-line self-identify its source. Verbosity is **one** setting (`quiet`/`normal`/`verbose`/`debug`), propagated to the
-R / Quarto child processes via the **`NEOIPC_LOG_LEVEL`** environment variable: the default `normal` shows lifecycle
-progress; `verbose`/`debug` reveal the DHIS2 query trace (URL + HTTP status + row count — **never** response bodies,
-a data-protection boundary). The `New-*.ps1` wrappers map the standard `-Quiet`/`-Verbose`/`-Debug` switches to it
-(via `Invoke-WithNeoIPCAuth -ExtraEnvVars`); the `Generate-*Data.R` wrappers' `--quiet`/`--verbose`/`--debug` flags
-and Partner-Report's `-P debug:true` override it. When `NEOIPC_LOG_FILE` is set (by the NeoIPC-Reporting .NET
-service), the R side writes structured JSON to that file instead of the console.
+line self-identify its source. Verbosity is **one** setting (`quiet`/`normal`/`verbose`/`debug`): the default
+`normal` shows lifecycle progress; `verbose`/`debug` reveal the DHIS2 query trace (URL + HTTP status + row count —
+**never** response bodies, a data-protection boundary). The `New-*.ps1` wrappers map the standard
+`-Quiet`/`-Verbose`/`-Debug` switches to it and pass it to the children **two** ways: the **`NEOIPC_LOG_LEVEL`**
+environment variable (read by the QMDs and neoipcr) and the native `--quiet`/`--verbose`/`--debug` CLI flags on the
+`Generate-*Data.R` / `quarto render` calls; `-Quiet` additionally silences the wrapper's own progress/verbose
+streams. Each `Generate-*Data.R` resolves a native CLI flag first, falls back to `NEOIPC_LOG_LEVEL` (so the .NET
+service can drive it environment-only), and republishes the resolved level for neoipcr and any child processes. When
+`NEOIPC_LOG_FILE` is set (by the NeoIPC-Reporting .NET service), the R side writes structured JSON to that file
+instead of the console.
 
 ### Argument Handling
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -273,8 +273,8 @@ line self-identify its source. Verbosity is **one** setting (`quiet`/`normal`/`v
 `normal` shows lifecycle progress; `verbose`/`debug` reveal the DHIS2 query trace (URL + HTTP status + row count —
 **never** response bodies, a data-protection boundary). The `New-*.ps1` wrappers map the standard
 `-Quiet`/`-Verbose`/`-Debug` switches to it and pass it to the children **two** ways: the **`NEOIPC_LOG_LEVEL`**
-environment variable (read by the QMDs and neoipcr) and the native `--quiet`/`--verbose`/`--debug` CLI flags on the
-`Generate-*Data.R` / `quarto render` calls; `-Quiet` additionally silences the wrapper's own progress/verbose
+environment variable (read by the QMDs and neoipcr) and native CLI flags — `--quiet`/`--verbose`/`--debug` on the
+`Generate-*Data.R` calls and `--quiet`/`--log-level` on `quarto render`; `-Quiet` additionally silences the wrapper's own progress/verbose
 streams. Each `Generate-*Data.R` resolves a native CLI flag first, falls back to `NEOIPC_LOG_LEVEL` (so the .NET
 service can drive it environment-only), and republishes the resolved level for neoipcr and any child processes. When
 `NEOIPC_LOG_FILE` is set (by the NeoIPC-Reporting .NET service), the R side writes structured JSON to that file

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Reports live under `reports/`:
 
 ### Shared Infrastructure
 
-- **Shared R code**: `reports/common/` — `helpers.R` (locale parsing, string resource loading, DHIS2 connection helpers), `load-neoipcr.R`, `parse-args.R` (CLI arg parsing), `getDataset.R` (dataset export), `reference.docx` (Word template)
+- **Shared R code**: `reports/common/` — `helpers.R` (locale parsing, string resource loading, DHIS2 connection helpers), `load-neoipcr.R`, `parse-args.R` (CLI arg parsing), `getDataset.R` (dataset export), `logging.R` (unified `logger`-based logging: `configure_logging()` + `logInfo`/`logVerbose`/`logDebug`/`logWarn`/`logError`), `reference.docx` (Word template)
 - **Base string resources**: `reports/common.yaml` (English domain terms, table headers, footnotes)
 - **Pandoc filters**: `reports/filters/pandoc-quotes.lua` (language-aware typographic quotes), `remove-empty-sections.lua`
 
@@ -264,6 +264,18 @@ No `sprintf` `%s`, markdown, or LaTeX syntax in translatable strings. Use `glue`
 ### PowerShell Scripts
 
 Approved PS verbs + PascalCase noun (e.g., `New-PartnerReports.ps1`). All wrappers in `scripts/`. Shared helpers in `scripts/NeoIPCReportHelpers.ps1` (dot-sourced).
+
+### Logging
+
+All report R code and neoipcr log through the `logger` package (`reports/common/logging.R`). Three R namespaces —
+the report's slug (e.g. `partner-report`), `report-common` (the shared `common/` layer), and `neoipcr` — let every
+line self-identify its source. Verbosity is **one** setting (`quiet`/`normal`/`verbose`/`debug`), propagated to the
+R / Quarto child processes via the **`NEOIPC_LOG_LEVEL`** environment variable: the default `normal` shows lifecycle
+progress; `verbose`/`debug` reveal the DHIS2 query trace (URL + HTTP status + row count — **never** response bodies,
+a data-protection boundary). The `New-*.ps1` wrappers map the standard `-Quiet`/`-Verbose`/`-Debug` switches to it
+(via `Invoke-WithNeoIPCAuth -ExtraEnvVars`); the `Generate-*Data.R` wrappers' `--quiet`/`--verbose`/`--debug` flags
+and Partner-Report's `-P debug:true` override it. When `NEOIPC_LOG_FILE` is set (by the NeoIPC-Reporting .NET
+service), the R side writes structured JSON to that file instead of the console.
 
 ### Argument Handling
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,8 +273,8 @@ line self-identify its source. Verbosity is **one** setting (`quiet`/`normal`/`v
 `verbose`/`debug` reveal the DHIS2 query trace (URL + HTTP status + row count — **never** response bodies, a
 data-protection boundary). The `New-*.ps1` wrappers map the standard `-Quiet`/`-Verbose`/`-Debug` switches to it and
 pass it to the children **two** ways: the **`NEOIPC_LOG_LEVEL`** environment variable (read by the QMDs and neoipcr)
-and the native `--quiet`/`--verbose`/`--debug` CLI flags on the `Generate-*Data.R` / `quarto render` calls; `-Quiet`
-additionally silences the wrapper's own progress/verbose streams. Each `Generate-*Data.R` resolves a native CLI flag
+and native CLI flags — `--quiet`/`--verbose`/`--debug` on the `Generate-*Data.R` calls and `--quiet`/`--log-level`
+on `quarto render`; `-Quiet` additionally silences the wrapper's own progress/verbose streams. Each `Generate-*Data.R` resolves a native CLI flag
 first, falls back to `NEOIPC_LOG_LEVEL` (so the .NET service can drive it environment-only), and republishes the
 resolved level for neoipcr and any child processes. When `NEOIPC_LOG_FILE` is set (by the NeoIPC-Reporting .NET
 service), the R side writes structured JSON to that file instead of the console.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -269,12 +269,14 @@ Approved PS verbs + PascalCase noun (e.g., `New-PartnerReports.ps1`). All wrappe
 
 All report R code and neoipcr log through the `logger` package (`reports/common/logging.R`). Three R namespaces —
 the report's slug (e.g. `partner-report`), `report-common` (the shared `common/` layer), and `neoipcr` — let every
-line self-identify its source. Verbosity is **one** setting (`quiet`/`normal`/`verbose`/`debug`), propagated to the
-R / Quarto child processes via the **`NEOIPC_LOG_LEVEL`** environment variable: the default `normal` shows lifecycle
-progress; `verbose`/`debug` reveal the DHIS2 query trace (URL + HTTP status + row count — **never** response bodies,
-a data-protection boundary). The `New-*.ps1` wrappers map the standard `-Quiet`/`-Verbose`/`-Debug` switches to it
-(via `Invoke-WithNeoIPCAuth -ExtraEnvVars`); the `Generate-*Data.R` wrappers' `--quiet`/`--verbose`/`--debug` flags
-and Partner-Report's `-P debug:true` override it. When `NEOIPC_LOG_FILE` is set (by the NeoIPC-Reporting .NET
+line self-identify its source. Verbosity is **one** setting (`quiet`/`normal`/`verbose`/`debug`): the default `normal` shows lifecycle progress;
+`verbose`/`debug` reveal the DHIS2 query trace (URL + HTTP status + row count — **never** response bodies, a
+data-protection boundary). The `New-*.ps1` wrappers map the standard `-Quiet`/`-Verbose`/`-Debug` switches to it and
+pass it to the children **two** ways: the **`NEOIPC_LOG_LEVEL`** environment variable (read by the QMDs and neoipcr)
+and the native `--quiet`/`--verbose`/`--debug` CLI flags on the `Generate-*Data.R` / `quarto render` calls; `-Quiet`
+additionally silences the wrapper's own progress/verbose streams. Each `Generate-*Data.R` resolves a native CLI flag
+first, falls back to `NEOIPC_LOG_LEVEL` (so the .NET service can drive it environment-only), and republishes the
+resolved level for neoipcr and any child processes. When `NEOIPC_LOG_FILE` is set (by the NeoIPC-Reporting .NET
 service), the R side writes structured JSON to that file instead of the console.
 
 ### Argument Handling

--- a/reports/Partner-Certificate/_setup.qmd
+++ b/reports/Partner-Certificate/_setup.qmd
@@ -1,8 +1,14 @@
 ```{r}
 #| label: Setup
+#| warning: false
 source("../common/helpers.R")
 source("../common/logging.R")
 configure_logging(report = "partner-certificate")
+# R warnings (e.g. from the import_dhis2 fallback below) are captured into the
+# unified log channel by configure_logging()'s warning hook; the chunk's
+# `warning: false` keeps them out of the rendered certificate body. (The import
+# runs inside this chunk, so a chunk option is needed rather than
+# opts_chunk$set, which only affects subsequent chunks.)
 
 locale <- Sys.getenv("LC_ALL")
 localeObj <- parse_locales(locale)[[1]]

--- a/reports/Partner-Certificate/_setup.qmd
+++ b/reports/Partner-Certificate/_setup.qmd
@@ -1,6 +1,8 @@
 ```{r}
 #| label: Setup
 source("../common/helpers.R")
+source("../common/logging.R")
+configure_logging(report = "partner-certificate")
 
 locale <- Sys.getenv("LC_ALL")
 localeObj <- parse_locales(locale)[[1]]
@@ -50,7 +52,7 @@ if (is.null(data$startYear) || is.null(data$endYear) || is.null(data$hospitalNam
     port = params$dhis2Port, path = params$dhis2Path)
 
   # Import date from our DHIS2 server
-  ds <- suppressWarnings(neoipcr::import_dhis2(
+  ds <- neoipcr::import_dhis2(
     connection_options = connection_options,
     dataset_options = neoipcr::dhis2_dataset_options(
       surveillance_end_from = startFrom,
@@ -62,7 +64,7 @@ if (is.null(data$startYear) || is.null(data$endYear) || is.null(data$hospitalNam
                            "delivery_mode", "siblings"),
       include_enrollment = "full",
       include_event = "full"
-      )))
+      ))
 
   department <- ds$metadata$departments |>
     dplyr::filter(code == data$departmentCode) |>

--- a/reports/Partner-Report/Generate-PartnerData.R
+++ b/reports/Partner-Report/Generate-PartnerData.R
@@ -11,26 +11,11 @@ suppressPackageStartupMessages({
   source(file.path(script_dir, "../common/load-neoipcr.R"))
   load_neoipcr(dev_pkg_path = file.path(script_dir, "../../../neoipcr"))
   source(file.path(script_dir, "../common/parse-args.R"))
+  source(file.path(script_dir, "../common/logging.R"))
   library(jsonlite)
 })
 
 verbosity <- "normal"
-
-logInfo <- function(...) {
-  if (verbosity != "quiet") message(...)
-}
-
-logVerbose <- function(...) {
-  if (verbosity %in% c("verbose", "debug")) message(...)
-}
-
-logDebug <- function(...) {
-  if (verbosity == "debug") message(...)
-}
-
-logWarn <- function(...) {
-  if (verbosity != "quiet") warning(..., call. = FALSE)
-}
 
 printUsage <- function() {
   cat(
@@ -110,7 +95,7 @@ getValidationExceptions <- function(x) {
     }
     return(utils::read.csv(x, stringsAsFactors = FALSE, colClasses = colClasses))
   }
-  logWarn(sprintf("Validation exception file not found: '%s'", x))
+  logWarn("Validation exception file not found: '{x}'")
   FALSE
 }
 
@@ -130,6 +115,8 @@ if (isTRUE(args$quiet)) {
   verbosity <- "verbose"
 }
 
+configure_logging(report = "partner-report", verbosity = verbosity)
+
 outputFile <- as_null(args$file)
 unitCodes <- as_vector_or_null(args$unitCodes)
 referenceDataFile <- as_null(args$referenceDataFile)
@@ -144,7 +131,7 @@ includeTestData <- as_bool(args$includeTestData, default = FALSE)
 validationExceptionFile <- as_null(args$validationExceptionFile)
 
 if (is.null(unitCodes)) {
-  cat("Error: --unitCodes is required.\n", file = stderr())
+  logError("--unitCodes is required.")
   quit(status = 1)
 }
 
@@ -180,11 +167,9 @@ datasetOptions <- neoipcr::dhis2_dataset_options(
 )
 
 logVerbose("Importing DHIS2 data...")
-unit_data <- suppressWarnings(
-  neoipcr::import_dhis2(
-    connection_options = connectionOptions,
-    dataset_options = datasetOptions
-  )
+unit_data <- neoipcr::import_dhis2(
+  connection_options = connectionOptions,
+  dataset_options = datasetOptions
 ) |> neoipcr::calculate_department_data()
 
 # Load reference data if provided
@@ -193,7 +178,7 @@ if (!is.null(referenceDataFile)) {
   if (!file.exists(referenceDataFile)) {
     stop(sprintf("Reference data file not found: '%s'", referenceDataFile))
   }
-  logVerbose("Loading reference data: ", referenceDataFile)
+  logVerbose("Loading reference data: {referenceDataFile}")
   reference_data <- jsonlite::unserializeJSON(
     readChar(referenceDataFile, file.info(referenceDataFile)$size))
 }
@@ -218,5 +203,5 @@ if (is.null(outputFile)) {
     dir.create(outputDir, recursive = TRUE, showWarnings = FALSE)
   }
   writeLines(json, outputFile, useBytes = TRUE)
-  logInfo("Partner data written to: ", outputFile)
+  logInfo("Partner data written to: {outputFile}")
 }

--- a/reports/Partner-Report/Generate-PartnerData.R
+++ b/reports/Partner-Report/Generate-PartnerData.R
@@ -15,8 +15,6 @@ suppressPackageStartupMessages({
   library(jsonlite)
 })
 
-verbosity <- "normal"
-
 printUsage <- function() {
   cat(
     "Usage: Rscript --vanilla ",
@@ -107,13 +105,20 @@ if (isTRUE(args$help)) {
   quit(status = 0)
 }
 
-if (isTRUE(args$quiet)) {
-  verbosity <- "quiet"
+# Verbosity precedence: an explicit CLI flag wins; otherwise inherit
+# NEOIPC_LOG_LEVEL (set by the PowerShell wrapper or the .NET service);
+# otherwise default to normal. Republish the resolved level so neoipcr and any
+# child processes share it.
+verbosity <- if (isTRUE(args$quiet)) {
+  "quiet"
 } else if (isTRUE(args$debug)) {
-  verbosity <- "debug"
+  "debug"
 } else if (isTRUE(args$verbose)) {
-  verbosity <- "verbose"
+  "verbose"
+} else {
+  Sys.getenv("NEOIPC_LOG_LEVEL", unset = "normal")
 }
+Sys.setenv(NEOIPC_LOG_LEVEL = verbosity)
 
 configure_logging(report = "partner-report", verbosity = verbosity)
 

--- a/reports/Partner-Report/Partner-Report.de.qmd
+++ b/reports/Partner-Report/Partner-Report.de.qmd
@@ -35,7 +35,6 @@ params:
   includeAntibioticResistanceTestRateTable: false
   includeSecondaryBsiRateTable: false
   sparseDataThreshold: 16
-  debug: false
 subtitle: '`r paste0(params$unitCodes, collapse = ", ")`'
 ---
 

--- a/reports/Partner-Report/Partner-Report.qmd
+++ b/reports/Partner-Report/Partner-Report.qmd
@@ -156,10 +156,6 @@ params:
   # @type integer
   # @range 1..
   sparseDataThreshold: 16
-
-  # Render in debug mode (extra diagnostics).
-  # @type logical
-  debug: false
 subtitle: '`r paste0(params$unitCodes, collapse = ", ")`'
 ---
 

--- a/reports/Partner-Report/_setup.qmd
+++ b/reports/Partner-Report/_setup.qmd
@@ -15,16 +15,13 @@ library(gt, warn.conflicts = FALSE, quietly = TRUE)
 ```{r Set up functions}
 #| include: false
 
-# Debug mode: when false (default), suppress warnings from rendered output.
-# Warnings still appear in the build log. Pass -P debug:true to enable.
-debug_mode <- isTRUE(as.logical(params$debug))
-knitr::opts_chunk$set(warning = debug_mode)
+# R warnings are captured into the unified log channel by configure_logging()'s
+# warning hook; keep them out of the rendered report body.
+knitr::opts_chunk$set(warning = FALSE)
 
 source("../common/helpers.R")
 source("../common/logging.R")
-configure_logging(
-  report = "partner-report",
-  verbosity = if (debug_mode) "debug" else NULL)
+configure_logging(report = "partner-report")
 
 # Cross-reference table IDs for metric pairings. These are Quarto
 # cross-references (invariant across languages), not translatable strings,
@@ -1169,14 +1166,11 @@ localize_metric_name <- function(metric_id, sR, table_name = NULL) {
     }
   }
 
-  # Fall back to the raw identifier. Warn in debug mode so it renders into
-  # the document for diagnosis; silently fall back otherwise.
-  if (isTRUE(debug_mode)) {
-    rlang::warn(paste0(
-      "localize_metric_name: no display label found for metric identifier '",
-      metric_id, "'. Using raw identifier as fallback."
-    ))
-  }
+  # Fall back to the raw identifier; record the gap in the log channel only (it
+  # never surfaces in the rendered report body).
+  logDebug(paste0(
+    "localize_metric_name: no display label found for metric ",
+    "identifier '{metric_id}'. Using raw identifier as fallback."))
   return(metric_id)
 }
 

--- a/reports/Partner-Report/_setup.qmd
+++ b/reports/Partner-Report/_setup.qmd
@@ -21,6 +21,10 @@ debug_mode <- isTRUE(as.logical(params$debug))
 knitr::opts_chunk$set(warning = debug_mode)
 
 source("../common/helpers.R")
+source("../common/logging.R")
+configure_logging(
+  report = "partner-report",
+  verbosity = if (debug_mode) "debug" else NULL)
 
 # Cross-reference table IDs for metric pairings. These are Quarto
 # cross-references (invariant across languages), not translatable strings,
@@ -1638,8 +1642,7 @@ if (!is.null(params$partnerDataFile)) {
     typedParams$unitCodes <- data_unit_codes
   }
 } else {
-  get_unit_data <- function() suppressWarnings(
-    import_dhis2(
+  get_unit_data <- function() import_dhis2(
       connection_options = get_connection_options(
         scheme = params$dhis2Scheme, hostname = params$dhis2Hostname,
         port = params$dhis2Port, path = params$dhis2Path),
@@ -1663,7 +1666,7 @@ if (!is.null(params$partnerDataFile)) {
         include_enrollment = "full",
         include_event = "full",
         include_test_data = isTRUE(params$includeTestData)
-        ))) |>
+        )) |>
     neoipcr::calculate_department_data()
 
   benchmark_data <- if (is.null(reference_data)) {

--- a/reports/Patient-Data-Report/Generate-PatientData.R
+++ b/reports/Patient-Data-Report/Generate-PatientData.R
@@ -22,7 +22,10 @@ print_usage <- function() {
     "  --patient-id, -p <id>           NeoIPC patient ID\n",
     "  --department, -d <code>         Department code\n\n",
     "Options:\n",
-    "  --output, -o <path>             Output file path (stdout if omitted)\n\n",
+    "  --output, -o <path>             Output file path (stdout if omitted)\n",
+    "  --quiet, -q                     Suppress non-critical output\n",
+    "  --verbose, -V                   Verbose output\n",
+    "  --debug, -D                     Debug output\n\n",
     "Connection settings:\n",
     "  --scheme <scheme>               URL scheme (default: https)\n",
     "  --host <hostname>               DHIS2 hostname\n",
@@ -42,6 +45,9 @@ short_map <- list(
   p = "patientId",
   d = "department",
   o = "output",
+  q = "quiet",
+  V = "verbose",
+  D = "debug",
   h = "help"
 )
 
@@ -53,7 +59,22 @@ if (isTRUE(args$help)) {
   quit(status = 0)
 }
 
-configure_logging(report = "patient-data-report")
+# Verbosity precedence: an explicit CLI flag wins; otherwise inherit
+# NEOIPC_LOG_LEVEL (set by the PowerShell wrapper or the .NET service);
+# otherwise default to normal. Republish the resolved level so neoipcr and any
+# child processes share it.
+verbosity <- if (isTRUE(args$quiet)) {
+  "quiet"
+} else if (isTRUE(args$debug)) {
+  "debug"
+} else if (isTRUE(args$verbose)) {
+  "verbose"
+} else {
+  Sys.getenv("NEOIPC_LOG_LEVEL", unset = "normal")
+}
+Sys.setenv(NEOIPC_LOG_LEVEL = verbosity)
+
+configure_logging(report = "patient-data-report", verbosity = verbosity)
 
 patient_id <- as_null(args$patientId)
 department_code <- as_null(args$department)

--- a/reports/Patient-Data-Report/Generate-PatientData.R
+++ b/reports/Patient-Data-Report/Generate-PatientData.R
@@ -6,6 +6,7 @@ suppressPackageStartupMessages({
   source(file.path(script_dir, "../common/load-neoipcr.R"))
   load_neoipcr(dev_pkg_path = file.path(script_dir, "../../neoipcr"))
   source(file.path(script_dir, "../common/parse-args.R"))
+  source(file.path(script_dir, "../common/logging.R"))
   library(jsonlite)
   library(dplyr, warn.conflicts = FALSE)
 })
@@ -52,15 +53,17 @@ if (isTRUE(args$help)) {
   quit(status = 0)
 }
 
+configure_logging(report = "patient-data-report")
+
 patient_id <- as_null(args$patientId)
 department_code <- as_null(args$department)
 
 if (is.null(patient_id)) {
-  cat("Error: --patient-id is required.\n", file = stderr())
+  logError("--patient-id is required.")
   quit(status = 1)
 }
 if (is.null(department_code)) {
-  cat("Error: --department is required.\n", file = stderr())
+  logError("--department is required.")
   quit(status = 1)
 }
 
@@ -98,8 +101,7 @@ ds <- neoipcr::import_dhis2(connection_options = conn_opt, dataset_options = ds_
 patient <- ds$patients |> dplyr::filter(patient_id == !!patient_id)
 
 if (nrow(patient) == 0) {
-  cat(sprintf("Error: No patient with ID '%s' found in department '%s'.\n",
-    patient_id, department_code), file = stderr())
+  logError("No patient with ID '{patient_id}' found in department '{department_code}'.")
   quit(status = 1)
 }
 
@@ -150,5 +152,5 @@ if (is.null(output_path)) {
   cat(out)
 } else {
   writeLines(out, output_path, useBytes = TRUE)
-  cat(sprintf("Patient data written to '%s'.\n", output_path), file = stderr())
+  logInfo("Patient data written to '{output_path}'.")
 }

--- a/reports/Patient-Data-Report/_setup.qmd
+++ b/reports/Patient-Data-Report/_setup.qmd
@@ -7,6 +7,12 @@ source("../common/logging.R")
 suppressMessages(library(tidyverse, warn.conflicts = FALSE, quietly = TRUE))
 configure_logging(report = "patient-data-report")
 
+# R warnings (e.g. from import_dhis2) are captured into the unified log channel
+# by configure_logging()'s warning hook; keep them out of the rendered report
+# body. Set here in the setup chunk so it applies to the later import/filter
+# chunks (mirrors Partner-Report).
+knitr::opts_chunk$set(warning = FALSE)
+
 locale <- Sys.getenv("LC_ALL")
 invisible(Sys.setlocale(category = "LC_ALL", locale = locale))
 localeObj <- parse_locales(locale)[[1]]

--- a/reports/Patient-Data-Report/_setup.qmd
+++ b/reports/Patient-Data-Report/_setup.qmd
@@ -3,7 +3,9 @@
 source("../common/load-neoipcr.R")
 suppressMessages(load_neoipcr(dev_pkg_path = "../../../neoipcr"))
 source("../common/helpers.R")
+source("../common/logging.R")
 suppressMessages(library(tidyverse, warn.conflicts = FALSE, quietly = TRUE))
+configure_logging(report = "patient-data-report")
 
 locale <- Sys.getenv("LC_ALL")
 invisible(Sys.setlocale(category = "LC_ALL", locale = locale))
@@ -21,7 +23,7 @@ connection_options <- get_connection_options(
   scheme = params$dhis2Scheme, hostname = params$dhis2Hostname,
   port = params$dhis2Port, path = params$dhis2Path)
 
-ds <- suppressWarnings(neoipcr::import_dhis2(
+ds <- neoipcr::import_dhis2(
   connection_options = connection_options,
   dataset_options = neoipcr::dhis2_dataset_options(
     department_filter = department_code,
@@ -42,7 +44,7 @@ ds <- suppressWarnings(neoipcr::import_dhis2(
     include_incomplete = c("enrollments", "events"),
     translate = TRUE,
     locale = locale
-  )))
+  ))
 ```
 
 ```{r}

--- a/reports/Reference-Report/Generate-ReferenceData.R
+++ b/reports/Reference-Report/Generate-ReferenceData.R
@@ -15,8 +15,6 @@ suppressPackageStartupMessages({
   library(jsonlite)
 })
 
-verbosity <- "normal"
-
 printUsage <- function() {
   cat(
     "Usage: Rscript --vanilla ",
@@ -264,13 +262,20 @@ if (isTRUE(args$help)) {
   quit(status = 0)
 }
 
-if (isTRUE(args$quiet)) {
-  verbosity <- "quiet"
+# Verbosity precedence: an explicit CLI flag wins; otherwise inherit
+# NEOIPC_LOG_LEVEL (set by the PowerShell wrapper or the .NET service);
+# otherwise default to normal. Republish the resolved level so neoipcr and any
+# child processes share it.
+verbosity <- if (isTRUE(args$quiet)) {
+  "quiet"
 } else if (isTRUE(args$debug)) {
-  verbosity <- "debug"
+  "debug"
 } else if (isTRUE(args$verbose)) {
-  verbosity <- "verbose"
+  "verbose"
+} else {
+  Sys.getenv("NEOIPC_LOG_LEVEL", unset = "normal")
 }
+Sys.setenv(NEOIPC_LOG_LEVEL = verbosity)
 
 configure_logging(report = "reference-report", verbosity = verbosity)
 

--- a/reports/Reference-Report/Generate-ReferenceData.R
+++ b/reports/Reference-Report/Generate-ReferenceData.R
@@ -11,26 +11,11 @@ suppressPackageStartupMessages({
   source(file.path(script_dir, "../common/load-neoipcr.R"))
   load_neoipcr(dev_pkg_path = file.path(script_dir, "../../../neoipcr"))
   source(file.path(script_dir, "../common/parse-args.R"))
+  source(file.path(script_dir, "../common/logging.R"))
   library(jsonlite)
 })
 
 verbosity <- "normal"
-
-logInfo <- function(...) {
-  if (verbosity != "quiet") message(...)
-}
-
-logVerbose <- function(...) {
-  if (verbosity %in% c("verbose", "debug")) message(...)
-}
-
-logDebug <- function(...) {
-  if (verbosity == "debug") message(...)
-}
-
-logWarn <- function(...) {
-  if (verbosity != "quiet") warning(..., call. = FALSE)
-}
 
 printUsage <- function() {
   cat(
@@ -115,12 +100,7 @@ getValidationExceptions <- function(x) {
       colClasses = colClasses
     ))
   }
-  logWarn(
-    sprintf(
-      "Validation exception file not found: '%s'",
-      validationExceptionFile
-    )
-  )
+  logWarn("Validation exception file not found: '{validationExceptionFile}'")
   NULL
 }
 
@@ -292,6 +272,8 @@ if (isTRUE(args$quiet)) {
   verbosity <- "verbose"
 }
 
+configure_logging(report = "reference-report", verbosity = verbosity)
+
 referenceDataFile <- as_null(args$file)
 reportingPeriodFrom <- as_date_or_null(args$reportingPeriodFrom)
 reportingPeriodTo <- as_date_or_null(args$reportingPeriodTo)
@@ -328,18 +310,16 @@ datasetOptions <- getDatasetOptions(
 )
 
 logVerbose("Importing DHIS2 data...")
-rawData <- suppressWarnings(
-  neoipcr::import_dhis2(
-    connection_options = connectionOptions,
-    dataset_options = datasetOptions
-  )
+rawData <- neoipcr::import_dhis2(
+  connection_options = connectionOptions,
+  dataset_options = datasetOptions
 )
 if (!is.null(backupDataset)) {
   backupPath <- backupDataset
   if (is.na(backupPath) || backupPath == "") {
     stop("--backup-dataset requires a file path.")
   }
-  logVerbose("Creating encrypted backup: ", backupPath)
+  logVerbose("Creating encrypted backup: {backupPath}")
   backupReferenceDataset(rawData, backupPath)
 }
 referenceData <- neoipcr::calculate_reference_data(rawData)
@@ -358,5 +338,5 @@ if (is.null(referenceDataFile)) {
     dir.create(outputDir, recursive = TRUE, showWarnings = FALSE)
   }
   writeLines(json, referenceDataFile, useBytes = TRUE)
-  logInfo("Reference data written to: ", referenceDataFile)
+  logInfo("Reference data written to: {referenceDataFile}")
 }

--- a/reports/Reference-Report/_setup.qmd
+++ b/reports/Reference-Report/_setup.qmd
@@ -15,6 +15,8 @@ library(gt, warn.conflicts = FALSE, quietly = TRUE)
 #| include: false
 
 source("../common/helpers.R")
+source("../common/logging.R")
+configure_logging(report = "reference-report")
 
 labels_bw <- function(x) {
   paste(
@@ -199,7 +201,7 @@ if (!is.null(params$referenceDataFile)) {
         params$referenceDataFile,
         file.info(params$referenceDataFile)$size))
 } else {
-  reference_data <- suppressWarnings(import_dhis2(
+  reference_data <- import_dhis2(
     connection_options = get_connection_options(
       scheme = params$dhis2Scheme, hostname = params$dhis2Hostname,
       port = params$dhis2Port, path = params$dhis2Path),
@@ -213,7 +215,7 @@ if (!is.null(params$referenceDataFile)) {
       reportingCountries = params$reportingCountries,
       testUnitFilter = params$testUnitFilter,
       defaultPatientFilter = params$defaultPatientFilter,
-      validationExceptionFile = params$validationExceptionFile))) |>
+      validationExceptionFile = params$validationExceptionFile)) |>
     neoipcr::calculate_reference_data()
 }
 

--- a/reports/Validation-Report/_setup.qmd
+++ b/reports/Validation-Report/_setup.qmd
@@ -2,7 +2,9 @@
 source("../common/load-neoipcr.R")
 load_neoipcr(dev_pkg_path = "../../../neoipcr")
 source("../common/helpers.R")
+source("../common/logging.R")
 suppressMessages(library(tidyverse, warn.conflicts = FALSE, quietly = TRUE))
+configure_logging(report = "validation-report")
 ```
 
 ```{r Initialise locale dependent information}

--- a/reports/common/helpers.R
+++ b/reports/common/helpers.R
@@ -153,7 +153,8 @@ get_validation_exceptions <- function(x) {
   if (file.exists(validationExceptionFile)) {
     return(read_csv(validationExceptionFile, show_col_types = FALSE))
   } else {
-    warning(sprintf("Validation ecxeption file not found: '%s'", validationExceptionFile))
+    logWarn("Validation exception file not found: '{validationExceptionFile}'",
+            namespace = "report-common")
     return(FALSE)
   }
 }

--- a/reports/common/logging.R
+++ b/reports/common/logging.R
@@ -1,0 +1,109 @@
+# Shared logging configuration for the NeoIPC Surveillance-Toolkit reports.
+#
+# All report R code logs through the `logger` package so the reports, the shared
+# `common/` layer, and neoipcr emit through one consistent, level-aware,
+# namespaced channel. Three R namespaces are used so every line self-identifies
+# its source regardless of which report invoked it:
+#   * the active report's slug   (e.g. "partner-report") — report-specific code
+#   * "report-common"            — this shared `common/` layer
+#   * "neoipcr"                  — the neoipcr package (level set via its own
+#                                  configurator; destination set here)
+#
+# Verbosity and destination are driven by environment variables so the whole
+# pipeline (PowerShell wrapper / .NET service -> Rscript / Quarto -> R) shares
+# one setting:
+#   * NEOIPC_LOG_LEVEL  quiet|normal|verbose|debug  (default "normal")
+#   * NEOIPC_LOG_FILE   when set, structured JSON is written to this file (the
+#                       NeoIPC-Reporting .NET service drains it); otherwise the
+#                       console (stderr) is used.
+
+# Active report namespace for the level helpers; updated by configure_logging().
+.report_log <- new.env(parent = emptyenv())
+.report_log$namespace <- "report-common"
+
+# Map a verbosity level to a logger threshold (unknown -> INFO).
+.report_log_threshold <- function(verbosity) {
+  switch(
+    tolower(verbosity),
+    quiet   = logger::WARN,
+    normal  = logger::INFO,
+    verbose = logger::DEBUG,
+    debug   = logger::TRACE,
+    logger::INFO)
+}
+
+# Configure logging for a report run.
+#
+# `report` is the report slug used as this report's logger namespace (e.g.
+# "partner-report"); NULL (the default) uses "report-common", for standalone
+# common entry points such as getDataset.R. `verbosity` is one of
+# quiet|normal|verbose|debug; NULL reads NEOIPC_LOG_LEVEL (default "normal").
+configure_logging <- function(report = NULL, verbosity = NULL) {
+  namespace <- if (is.null(report) || !nzchar(report)) "report-common" else report
+  .report_log$namespace <- namespace
+
+  if (is.null(verbosity)) {
+    verbosity <- Sys.getenv("NEOIPC_LOG_LEVEL", unset = "normal")
+  }
+  threshold <- .report_log_threshold(verbosity)
+
+  # Destination: structured JSON to NEOIPC_LOG_FILE when the .NET service sets
+  # it (it drains the file into ILogger), else the console (stderr).
+  log_file <- Sys.getenv("NEOIPC_LOG_FILE", unset = "")
+  if (nzchar(log_file)) {
+    appender <- logger::appender_file(log_file)
+    layout   <- logger::layout_json()
+  } else {
+    appender <- logger::appender_console
+    layout   <- logger::layout_glue_generator(format = "{level} [{namespace}] {msg}")
+  }
+
+  # The report namespaces (this report + the shared common layer) get the glue
+  # formatter for their log messages; neoipcr owns its own formatter (set in
+  # its .onLoad), so the application does not touch it.
+  for (ns in unique(c(namespace, "report-common"))) {
+    logger::log_formatter(logger::formatter_glue, namespace = ns)
+  }
+
+  # Threshold and destination (appender + layout) are application concerns:
+  # apply them to all three namespaces — this report, the common layer, and
+  # neoipcr — so their output shares one level and one channel. Setting
+  # neoipcr's threshold directly (rather than via neoipcr::neoipcr_log_config)
+  # keeps this independent of which neoipcr build is loaded.
+  for (ns in unique(c(namespace, "report-common", "neoipcr"))) {
+    logger::log_threshold(threshold, namespace = ns)
+    logger::log_appender(appender, namespace = ns)
+    logger::log_layout(layout, namespace = ns)
+  }
+
+  # Capture stray base-R conditions (warnings, messages) into the unified log
+  # while leaving them catchable (log_warnings() defaults to muffle = FALSE).
+  logger::log_warnings()
+  logger::log_messages()
+
+  invisible(threshold)
+}
+
+# Leveled log helpers (replacing the old message()/warning() wrappers). They
+# emit under the active report namespace by default; the shared `common/` code
+# passes `namespace = "report-common"` so its lines are attributed to the
+# shared layer rather than to whichever report invoked it.
+logInfo <- function(..., namespace = .report_log$namespace) {
+  logger::log_info(..., namespace = namespace)
+}
+
+logVerbose <- function(..., namespace = .report_log$namespace) {
+  logger::log_debug(..., namespace = namespace)
+}
+
+logDebug <- function(..., namespace = .report_log$namespace) {
+  logger::log_trace(..., namespace = namespace)
+}
+
+logWarn <- function(..., namespace = .report_log$namespace) {
+  logger::log_warn(..., namespace = namespace)
+}
+
+logError <- function(..., namespace = .report_log$namespace) {
+  logger::log_error(..., namespace = namespace)
+}

--- a/reports/common/logging.R
+++ b/reports/common/logging.R
@@ -77,8 +77,11 @@ configure_logging <- function(report = NULL, verbosity = NULL) {
   }
 
   # Capture stray base-R conditions (warnings, messages) into the unified log
-  # while leaving them catchable (log_warnings() defaults to muffle = FALSE).
-  logger::log_warnings()
+  # while leaving them catchable. muffle = FALSE keeps each warning propagating
+  # (logged AND still reachable by a surrounding handler), independent of the
+  # global logger_muffle_warnings option. log_messages() takes no muffle
+  # argument and never muffles.
+  logger::log_warnings(muffle = FALSE)
   logger::log_messages()
 
   invisible(threshold)
@@ -88,22 +91,28 @@ configure_logging <- function(report = NULL, verbosity = NULL) {
 # emit under the active report namespace by default; the shared `common/` code
 # passes `namespace = "report-common"` so its lines are attributed to the
 # shared layer rather than to whichever report invoked it.
+#
+# Each helper forwards `.topenv = parent.frame()` so logger's glue formatter
+# resolves `{placeholder}` tokens in the *caller's* frame. Without it the
+# formatter evaluates in this wrapper's frame (whose enclosing environment is
+# globalenv, since this file is sourced at top level), and a message that
+# references a caller-local variable would error at runtime.
 logInfo <- function(..., namespace = .report_log$namespace) {
-  logger::log_info(..., namespace = namespace)
+  logger::log_info(..., namespace = namespace, .topenv = parent.frame())
 }
 
 logVerbose <- function(..., namespace = .report_log$namespace) {
-  logger::log_debug(..., namespace = namespace)
+  logger::log_debug(..., namespace = namespace, .topenv = parent.frame())
 }
 
 logDebug <- function(..., namespace = .report_log$namespace) {
-  logger::log_trace(..., namespace = namespace)
+  logger::log_trace(..., namespace = namespace, .topenv = parent.frame())
 }
 
 logWarn <- function(..., namespace = .report_log$namespace) {
-  logger::log_warn(..., namespace = namespace)
+  logger::log_warn(..., namespace = namespace, .topenv = parent.frame())
 }
 
 logError <- function(..., namespace = .report_log$namespace) {
-  logger::log_error(..., namespace = namespace)
+  logger::log_error(..., namespace = namespace, .topenv = parent.frame())
 }

--- a/reports/common/logging.R
+++ b/reports/common/logging.R
@@ -36,7 +36,7 @@
 #
 # `report` is the report slug used as this report's logger namespace (e.g.
 # "partner-report"); NULL (the default) uses "report-common", for standalone
-# common entry points such as getDataset.R. `verbosity` is one of
+# entry points in the shared `common/` layer. `verbosity` is one of
 # quiet|normal|verbose|debug; NULL reads NEOIPC_LOG_LEVEL (default "normal").
 configure_logging <- function(report = NULL, verbosity = NULL) {
   namespace <- if (is.null(report) || !nzchar(report)) "report-common" else report

--- a/scripts/New-PartnerCertificate.ps1
+++ b/scripts/New-PartnerCertificate.ps1
@@ -52,6 +52,7 @@ param(
     [string]$Token,
 
     [Parameter()]
+    [switch]$Quiet,
     [switch]$JsonReport,
 
     [Parameter()]
@@ -97,7 +98,15 @@ $localeParts = Split-NeoIPCLocale -Locale $OutputLocale
 $quartoFile = Resolve-NeoIPCLocaleQmd -ReportDir $reportDirPath -BaseName 'Partner-Certificate' -Locale $OutputLocale
 $SignatureImagePath = Resolve-Path -LiteralPath $SignatureImagePath.FullName -Relative -RelativeBasePath $reportDirPath
 
-Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null } -ScriptBlock {
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug; the R and
+# Quarto children read it via NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+$logLevel =
+    if ($Quiet) { 'quiet' }
+    elseif ($PSBoundParameters.ContainsKey('Debug')) { 'debug' }
+    elseif ($PSBoundParameters.ContainsKey('Verbose')) { 'verbose' }
+    else { 'normal' }
+
+Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
 $errors = @()
 $outputFiles = @()

--- a/scripts/New-PartnerCertificate.ps1
+++ b/scripts/New-PartnerCertificate.ps1
@@ -98,13 +98,37 @@ $localeParts = Split-NeoIPCLocale -Locale $OutputLocale
 $quartoFile = Resolve-NeoIPCLocaleQmd -ReportDir $reportDirPath -BaseName 'Partner-Certificate' -Locale $OutputLocale
 $SignatureImagePath = Resolve-Path -LiteralPath $SignatureImagePath.FullName -Relative -RelativeBasePath $reportDirPath
 
-# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug; the R and
-# Quarto children read it via NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug. It reaches
+# the Quarto child two ways: the NEOIPC_LOG_LEVEL environment variable (read by
+# the QMD / neoipcr) and native --quiet/--log-level flags on the render command.
+# Snapshot the common-parameter flags and resolve the level (and the Quarto flag
+# array) here in the script scope; inside the Invoke-WithNeoIPCAuth scriptblock
+# $PSBoundParameters is the scriptblock's own (empty) dictionary, so the
+# scriptblock reads the resolved array via closure.
+$debugRequested   = $PSBoundParameters.ContainsKey('Debug')
+$verboseRequested = $PSBoundParameters.ContainsKey('Verbose')
 $logLevel =
     if ($Quiet) { 'quiet' }
-    elseif ($PSBoundParameters.ContainsKey('Debug')) { 'debug' }
-    elseif ($PSBoundParameters.ContainsKey('Verbose')) { 'verbose' }
+    elseif ($debugRequested) { 'debug' }
+    elseif ($verboseRequested) { 'verbose' }
     else { 'normal' }
+
+# -Quiet also silences the wrapper's own progress/verbose/info streams so the
+# whole pipeline is quiet, not just the logger channel.
+if ($Quiet) {
+    $VerbosePreference     = 'SilentlyContinue'
+    $DebugPreference       = 'SilentlyContinue'
+    $InformationPreference = 'SilentlyContinue'
+    $ProgressPreference    = 'SilentlyContinue'
+}
+
+# Native verbosity flags for the Quarto child, derived from the same level.
+$quartoVerbosityArgs = switch ($logLevel) {
+    'quiet'   { @('--quiet') }
+    'verbose' { @('--log-level', 'info') }
+    'debug'   { @('--log-level', 'debug') }
+    default   { @() }
+}
 
 Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
@@ -148,6 +172,7 @@ try {
             if ($Dhis2Hostname) { $quartoArgs += @('-P', "dhis2Hostname:$Dhis2Hostname") }
             if ($Dhis2Port) { $quartoArgs += @('-P', "dhis2Port:$Dhis2Port") }
             if ($Dhis2Path) { $quartoArgs += @('-P', "dhis2Path:$Dhis2Path") }
+            $quartoArgs += $quartoVerbosityArgs
 
             if ($PSCmdlet.ShouldProcess($outFile, "Render partner certificate for $siteCode")) {
                 Write-Host "Generating partner certificate for $siteCode..."
@@ -171,6 +196,7 @@ try {
         if ($Dhis2Hostname) { $quartoArgs += @('-P', "dhis2Hostname:$Dhis2Hostname") }
         if ($Dhis2Port) { $quartoArgs += @('-P', "dhis2Port:$Dhis2Port") }
         if ($Dhis2Path) { $quartoArgs += @('-P', "dhis2Path:$Dhis2Path") }
+        $quartoArgs += $quartoVerbosityArgs
 
         if ($PSCmdlet.ShouldProcess($outFile, "Render partner certificate for $HospitalName")) {
             Write-Host "Generating partner certificate for $HospitalName..."

--- a/scripts/New-PartnerReports.ps1
+++ b/scripts/New-PartnerReports.ps1
@@ -143,10 +143,6 @@ param(
     $SparseDataThreshold,
 
     [Parameter()]
-    [switch]
-    $DebugReport,
-
-    [Parameter()]
     [ValidateSet('pdf','html','docx','json')]
     [string[]]
     $OutputFormats = @('pdf'),
@@ -303,13 +299,43 @@ if ($ValidationExceptionFile) {
 # Pass a dummy auth hashtable that clears env vars without setting new ones.
 $authForEnv = if ($isDataFileMode) { @{ AuthType = 'None' } } else { Resolve-NeoIPCAuth -Token $Token }
 
-# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug; the R and
-# Quarto children read it via NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug. It reaches
+# the child processes two ways: the NEOIPC_LOG_LEVEL environment variable (read
+# by the QMDs / neoipcr) and native --quiet/--verbose/--debug flags on the child
+# commands. Snapshot the common-parameter flags and resolve the level (and the
+# per-child flag arrays) here in the script scope; inside the
+# Invoke-WithNeoIPCAuth scriptblock $PSBoundParameters is the scriptblock's own
+# (empty) dictionary, so the scriptblock reads the resolved arrays via closure.
+$debugRequested   = $PSBoundParameters.ContainsKey('Debug')
+$verboseRequested = $PSBoundParameters.ContainsKey('Verbose')
 $logLevel =
     if ($Quiet) { 'quiet' }
-    elseif ($PSBoundParameters.ContainsKey('Debug')) { 'debug' }
-    elseif ($PSBoundParameters.ContainsKey('Verbose')) { 'verbose' }
+    elseif ($debugRequested) { 'debug' }
+    elseif ($verboseRequested) { 'verbose' }
     else { 'normal' }
+
+# -Quiet also silences the wrapper's own progress/verbose/info streams so the
+# whole pipeline is quiet, not just the logger channel.
+if ($Quiet) {
+    $VerbosePreference     = 'SilentlyContinue'
+    $DebugPreference       = 'SilentlyContinue'
+    $InformationPreference = 'SilentlyContinue'
+    $ProgressPreference    = 'SilentlyContinue'
+}
+
+# Native verbosity flags for the child processes, derived from the same level.
+$rscriptVerbosityArgs = switch ($logLevel) {
+    'quiet'   { @('--quiet') }
+    'verbose' { @('--verbose') }
+    'debug'   { @('--debug') }
+    default   { @() }
+}
+$quartoVerbosityArgs = switch ($logLevel) {
+    'quiet'   { @('--quiet') }
+    'verbose' { @('--log-level', 'info') }
+    'debug'   { @('--log-level', 'debug') }
+    default   { @() }
+}
 
 Invoke-WithNeoIPCAuth -Auth $authForEnv -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
@@ -434,6 +460,7 @@ if (inherits(x, 'neoipcr_bnch_ds')) {
                 if ($Dhis2Hostname) { $rArgs += @('--host', $Dhis2Hostname) }
                 if ($Dhis2Port) { $rArgs += @('--port', $Dhis2Port) }
                 if ($Dhis2Path) { $rArgs += @('--path', $Dhis2Path) }
+                $rArgs += $rscriptVerbosityArgs
 
                 $rResult = Invoke-Rscript -Arguments $rArgs -Command $rscriptCmd -Description "Generate-PartnerData.R ($siteCode)"
 
@@ -518,7 +545,6 @@ if (inherits(x, 'neoipcr_bnch_ds')) {
                 if ($HideMethodsTexts.IsPresent) { $qmdParams['includeMethodsTexts'] = 'false' }
                 if ($SparseDataThreshold) { $qmdParams['sparseDataThreshold'] = $SparseDataThreshold }
                 if ($HideOutlierInterpretation.IsPresent) { $qmdParams['includeOutlierInterpretation'] = 'false' }
-                if ($DebugReport) { $qmdParams['debug'] = 'true' }
 
                 # Apply per-element overrides on top of QMD defaults.
                 # -EnableElements forces listed elements ON; -DisableElements forces them OFF.
@@ -564,6 +590,7 @@ if (inherits(x, 'neoipcr_bnch_ds')) {
                     # All parameters via -P (R reads params$, conditional
                     # blocks use cat() + when-meta="alwaysTrue" wrappers)
                     $quartoArgs += $paramPairs
+                    $quartoArgs += $quartoVerbosityArgs
 
                     # Render (or report) - respect WhatIf via ShouldProcess
                     $completedSteps++

--- a/scripts/New-PartnerReports.ps1
+++ b/scripts/New-PartnerReports.ps1
@@ -209,7 +209,9 @@ param(
         'SurgicalProcedureRates',
         'SecondaryBloodstreamInfectionRates'
     )]
-    [string[]]$DisableElements = @()
+    [string[]]$DisableElements = @(),
+
+    [switch]$Quiet
 )
 
 Import-Module (Join-Path $PSScriptRoot 'modules' 'NeoIPC-Tools') -Force -Verbose:$false
@@ -301,7 +303,15 @@ if ($ValidationExceptionFile) {
 # Pass a dummy auth hashtable that clears env vars without setting new ones.
 $authForEnv = if ($isDataFileMode) { @{ AuthType = 'None' } } else { Resolve-NeoIPCAuth -Token $Token }
 
-Invoke-WithNeoIPCAuth -Auth $authForEnv -ExtraEnvVars @{ 'LC_ALL' = $null } -ScriptBlock {
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug; the R and
+# Quarto children read it via NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+$logLevel =
+    if ($Quiet) { 'quiet' }
+    elseif ($PSBoundParameters.ContainsKey('Debug')) { 'debug' }
+    elseif ($PSBoundParameters.ContainsKey('Verbose')) { 'verbose' }
+    else { 'normal' }
+
+Invoke-WithNeoIPCAuth -Auth $authForEnv -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
 # Prepare build tracking before try block so variables are always initialized,
 # even if an early exception (e.g. auth failure) skips the rest of the try body

--- a/scripts/New-PatientDataReport.ps1
+++ b/scripts/New-PatientDataReport.ps1
@@ -89,13 +89,43 @@ if ($OutputDir) {
     $outputDirExplicit = $false
 }
 
-# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug; the R and
-# Quarto children read it via NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug. It reaches
+# the child processes two ways: the NEOIPC_LOG_LEVEL environment variable (read
+# by the QMDs / neoipcr) and native --quiet/--verbose/--debug flags on the child
+# commands. Snapshot the common-parameter flags and resolve the level (and the
+# per-child flag arrays) here in the script scope; inside the
+# Invoke-WithNeoIPCAuth scriptblock $PSBoundParameters is the scriptblock's own
+# (empty) dictionary, so the scriptblock reads the resolved arrays via closure.
+$debugRequested   = $PSBoundParameters.ContainsKey('Debug')
+$verboseRequested = $PSBoundParameters.ContainsKey('Verbose')
 $logLevel =
     if ($Quiet) { 'quiet' }
-    elseif ($PSBoundParameters.ContainsKey('Debug')) { 'debug' }
-    elseif ($PSBoundParameters.ContainsKey('Verbose')) { 'verbose' }
+    elseif ($debugRequested) { 'debug' }
+    elseif ($verboseRequested) { 'verbose' }
     else { 'normal' }
+
+# -Quiet also silences the wrapper's own progress/verbose/info streams so the
+# whole pipeline is quiet, not just the logger channel.
+if ($Quiet) {
+    $VerbosePreference     = 'SilentlyContinue'
+    $DebugPreference       = 'SilentlyContinue'
+    $InformationPreference = 'SilentlyContinue'
+    $ProgressPreference    = 'SilentlyContinue'
+}
+
+# Native verbosity flags for the child processes, derived from the same level.
+$rscriptVerbosityArgs = switch ($logLevel) {
+    'quiet'   { @('--quiet') }
+    'verbose' { @('--verbose') }
+    'debug'   { @('--debug') }
+    default   { @() }
+}
+$quartoVerbosityArgs = switch ($logLevel) {
+    'quiet'   { @('--quiet') }
+    'verbose' { @('--log-level', 'info') }
+    'debug'   { @('--log-level', 'debug') }
+    default   { @() }
+}
 
 Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
@@ -132,6 +162,7 @@ try {
             if ($Dhis2Hostname) { $rArgs += @('--host', $Dhis2Hostname) }
             if ($Dhis2Port) { $rArgs += @('--port', $Dhis2Port) }
             if ($Dhis2Path) { $rArgs += @('--path', $Dhis2Path) }
+            $rArgs += $rscriptVerbosityArgs
             $rResult = Invoke-Rscript -Arguments $rArgs -Description "Generate-PatientData.R"
             if ($rResult.Status -eq 'Error') {
                 $errors += "Generate-PatientData.R failed (exit code $($rResult.ExitCode))."
@@ -156,6 +187,7 @@ try {
             if ($Dhis2Hostname) { $quartoArgs += @('-P', "dhis2Hostname:$Dhis2Hostname") }
             if ($Dhis2Port) { $quartoArgs += @('-P', "dhis2Port:$Dhis2Port") }
             if ($Dhis2Path) { $quartoArgs += @('-P', "dhis2Path:$Dhis2Path") }
+            $quartoArgs += $quartoVerbosityArgs
             $result = Invoke-QuartoRender -Arguments $quartoArgs -Description "patient data report for $PatientId"
             if ($result.Status -eq 'Error') {
                 $errors += "Quarto render failed for $PatientId (exit code $($result.ExitCode))."

--- a/scripts/New-PatientDataReport.ps1
+++ b/scripts/New-PatientDataReport.ps1
@@ -47,6 +47,7 @@ param(
     [string]$Token,
 
     [Parameter()]
+    [switch]$Quiet,
     [switch]$JsonReport,
 
     [Parameter()]
@@ -88,7 +89,15 @@ if ($OutputDir) {
     $outputDirExplicit = $false
 }
 
-Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null } -ScriptBlock {
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug; the R and
+# Quarto children read it via NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+$logLevel =
+    if ($Quiet) { 'quiet' }
+    elseif ($PSBoundParameters.ContainsKey('Debug')) { 'debug' }
+    elseif ($PSBoundParameters.ContainsKey('Verbose')) { 'verbose' }
+    else { 'normal' }
+
+Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
 $errors = @()
 $outputFiles = @()

--- a/scripts/New-ReferenceReport.ps1
+++ b/scripts/New-ReferenceReport.ps1
@@ -254,7 +254,15 @@ $authForEnv = if (-not $isDataFileMode) { Resolve-NeoIPCAuth -Token $Token } els
 $debugRequested   = $PSBoundParameters.ContainsKey('Debug')
 $verboseRequested = $PSBoundParameters.ContainsKey('Verbose')
 
-Invoke-WithNeoIPCAuth -Auth $authForEnv -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_BACKUP_PASSWORD' = $null } -ScriptBlock {
+# Resolve the unified log verbosity; the R and Quarto children read it via
+# NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+$logLevel =
+    if ($Quiet) { 'quiet' }
+    elseif ($debugRequested) { 'debug' }
+    elseif ($verboseRequested) { 'verbose' }
+    else { 'normal' }
+
+Invoke-WithNeoIPCAuth -Auth $authForEnv -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_BACKUP_PASSWORD' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
 if (-not $isDataFileMode -and $BackupDataset -and [string]::IsNullOrWhiteSpace($env:NEOIPC_BACKUP_PASSWORD)) {
     $secureBackupPassword = Read-Host -Prompt 'Backup password' -AsSecureString

--- a/scripts/New-ReferenceReport.ps1
+++ b/scripts/New-ReferenceReport.ps1
@@ -139,13 +139,6 @@ if ($isDataFileMode -and ($OutputFormats -contains 'json')) {
     throw "The 'json' format is not supported with -DataFile. The data file is already JSON."
 }
 
-if ($Quiet) {
-    $VerbosePreference = 'SilentlyContinue'
-    $DebugPreference = 'SilentlyContinue'
-    $InformationPreference = 'SilentlyContinue'
-    $ProgressPreference = 'SilentlyContinue'
-}
-
 $scriptTimestamp = (Get-Date -AsUTC).ToString("yyyy-MM-dd_HHmmss'Z'")
 $repoRoot = Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')
 $reportDirPath = Resolve-Path -LiteralPath (Join-Path $repoRoot 'reports/Reference-Report')
@@ -247,20 +240,43 @@ if ($isDataFileMode) {
 
 $authForEnv = if (-not $isDataFileMode) { Resolve-NeoIPCAuth -Token $Token } else { @{ AuthType = 'None' } }
 
-# $PSBoundParameters is per-invocation; inside the Invoke-WithNeoIPCAuth
-# scriptblock it refers to the scriptblock's own (empty) parameter dictionary,
-# not this script's. Snapshot common-parameter flags here so the scriptblock
-# can read them via lexical closure.
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug. It reaches
+# the child processes two ways: the NEOIPC_LOG_LEVEL environment variable (read
+# by the QMDs / neoipcr) and native --quiet/--verbose/--debug flags on the child
+# commands. Snapshot the common-parameter flags and resolve the level (and the
+# per-child flag arrays) here in the script scope; inside the
+# Invoke-WithNeoIPCAuth scriptblock $PSBoundParameters is the scriptblock's own
+# (empty) dictionary, so the scriptblock reads the resolved arrays via closure.
 $debugRequested   = $PSBoundParameters.ContainsKey('Debug')
 $verboseRequested = $PSBoundParameters.ContainsKey('Verbose')
-
-# Resolve the unified log verbosity; the R and Quarto children read it via
-# NEOIPC_LOG_LEVEL (see reports/common/logging.R).
 $logLevel =
     if ($Quiet) { 'quiet' }
     elseif ($debugRequested) { 'debug' }
     elseif ($verboseRequested) { 'verbose' }
     else { 'normal' }
+
+# -Quiet also silences the wrapper's own progress/verbose/info streams so the
+# whole pipeline is quiet, not just the logger channel.
+if ($Quiet) {
+    $VerbosePreference     = 'SilentlyContinue'
+    $DebugPreference       = 'SilentlyContinue'
+    $InformationPreference = 'SilentlyContinue'
+    $ProgressPreference    = 'SilentlyContinue'
+}
+
+# Native verbosity flags for the child processes, derived from the same level.
+$rscriptVerbosityArgs = switch ($logLevel) {
+    'quiet'   { @('--quiet') }
+    'verbose' { @('--verbose') }
+    'debug'   { @('--debug') }
+    default   { @() }
+}
+$quartoVerbosityArgs = switch ($logLevel) {
+    'quiet'   { @('--quiet') }
+    'verbose' { @('--log-level', 'info') }
+    'debug'   { @('--log-level', 'debug') }
+    default   { @() }
+}
 
 Invoke-WithNeoIPCAuth -Auth $authForEnv -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_BACKUP_PASSWORD' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
@@ -349,9 +365,7 @@ try {
         if ($PSCmdlet.ShouldProcess($jsonPath, 'Generate reference data JSON')) {
             Write-Verbose "Generating reference data JSON: $jsonPath"
             $rArgs = @('--vanilla', (Join-Path $reportDirPath 'Generate-ReferenceData.R'), '--file', $jsonPath)
-            if ($Quiet) { $rArgs += @('--quiet') }
-            if ($debugRequested) { $rArgs += @('--debug') }
-            if ($verboseRequested) { $rArgs += @('--verbose') }
+            $rArgs += $rscriptVerbosityArgs
             foreach ($kvp in $qmdParams.GetEnumerator()) {
                 if ($null -ne $kvp.Value -and '' -ne $kvp.Value) {
                     $rArgs += @("--$($kvp.Key)", "$($kvp.Value)")
@@ -380,18 +394,7 @@ try {
     }
 
     $quartoArgsCommon = @()
-    if ($Quiet) {$quartoArgsCommon += '--quiet' }
-    if ($debugRequested) {
-        $quartoArgsCommon += '--debug'
-        $quartoArgsCommon += @('--log-level', 'debug')
-    } elseif ($verboseRequested) {
-        $quartoArgsCommon += '--verbose'
-        $quartoArgsCommon += @('--log-level', 'info')
-    } else {
-        if ($Quiet) {
-            $quartoArgsCommon += @('--log-level', 'error')
-        }
-    }
+    $quartoArgsCommon += $quartoVerbosityArgs
     $outputDirRelative = [System.IO.Path]::GetRelativePath($reportDirPath, $outputDirPath)
     $quartoArgsCommon += @('--output-dir', $outputDirRelative)
 

--- a/scripts/New-ValidationReport.ps1
+++ b/scripts/New-ValidationReport.ps1
@@ -137,13 +137,37 @@ if (-not $isCombined) {
 
 $wd = Get-Location
 
-# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug; the R and
-# Quarto children read it via NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug. It reaches
+# the Quarto child two ways: the NEOIPC_LOG_LEVEL environment variable (read by
+# the QMD / neoipcr) and native --quiet/--log-level flags on the render command.
+# Snapshot the common-parameter flags and resolve the level (and the Quarto flag
+# array) here in the script scope; inside the Invoke-WithNeoIPCAuth scriptblock
+# $PSBoundParameters is the scriptblock's own (empty) dictionary, so the
+# scriptblock reads the resolved array via closure.
+$debugRequested   = $PSBoundParameters.ContainsKey('Debug')
+$verboseRequested = $PSBoundParameters.ContainsKey('Verbose')
 $logLevel =
     if ($Quiet) { 'quiet' }
-    elseif ($PSBoundParameters.ContainsKey('Debug')) { 'debug' }
-    elseif ($PSBoundParameters.ContainsKey('Verbose')) { 'verbose' }
+    elseif ($debugRequested) { 'debug' }
+    elseif ($verboseRequested) { 'verbose' }
     else { 'normal' }
+
+# -Quiet also silences the wrapper's own progress/verbose/info streams so the
+# whole pipeline is quiet, not just the logger channel.
+if ($Quiet) {
+    $VerbosePreference     = 'SilentlyContinue'
+    $DebugPreference       = 'SilentlyContinue'
+    $InformationPreference = 'SilentlyContinue'
+    $ProgressPreference    = 'SilentlyContinue'
+}
+
+# Native verbosity flags for the Quarto child, derived from the same level.
+$quartoVerbosityArgs = switch ($logLevel) {
+    'quiet'   { @('--quiet') }
+    'verbose' { @('--log-level', 'info') }
+    'debug'   { @('--log-level', 'debug') }
+    default   { @() }
+}
 
 Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
@@ -188,6 +212,7 @@ try {
         if ($Dhis2Hostname) { $quartoArgs += @('-P', "dhis2Hostname:$Dhis2Hostname") }
         if ($Dhis2Port) { $quartoArgs += @('-P', "dhis2Port:$Dhis2Port") }
         if ($Dhis2Path) { $quartoArgs += @('-P', "dhis2Path:$Dhis2Path") }
+        $quartoArgs += $quartoVerbosityArgs
 
         if ($PSCmdlet.ShouldProcess($outFile, 'Render combined validation report')) {
             Write-Host "Generating combined validation report..."
@@ -218,6 +243,7 @@ try {
             if ($Dhis2Hostname) { $quartoArgs += @('-P', "dhis2Hostname:$Dhis2Hostname") }
             if ($Dhis2Port) { $quartoArgs += @('-P', "dhis2Port:$Dhis2Port") }
             if ($Dhis2Path) { $quartoArgs += @('-P', "dhis2Path:$Dhis2Path") }
+            $quartoArgs += $quartoVerbosityArgs
 
             if ($PSCmdlet.ShouldProcess($outFile, "Render validation report for $siteCode")) {
                 Write-Host "Generating validation report for $siteCode..."

--- a/scripts/New-ValidationReport.ps1
+++ b/scripts/New-ValidationReport.ps1
@@ -68,6 +68,7 @@ param(
     [string]$OutputDir = $null,
 
     [Parameter()]
+    [switch]$Quiet,
     [switch]$JsonReport,
 
     [Parameter()]
@@ -136,7 +137,15 @@ if (-not $isCombined) {
 
 $wd = Get-Location
 
-Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null } -ScriptBlock {
+# Resolve the unified log verbosity from -Quiet / -Verbose / -Debug; the R and
+# Quarto children read it via NEOIPC_LOG_LEVEL (see reports/common/logging.R).
+$logLevel =
+    if ($Quiet) { 'quiet' }
+    elseif ($PSBoundParameters.ContainsKey('Debug')) { 'debug' }
+    elseif ($PSBoundParameters.ContainsKey('Verbose')) { 'verbose' }
+    else { 'normal' }
+
+Invoke-WithNeoIPCAuth -Auth $auth -ExtraEnvVars @{ 'LC_ALL' = $null; 'NEOIPC_LOG_LEVEL' = $logLevel } -ScriptBlock {
 
 $errors = @()
 $outputFiles = @()

--- a/scripts/modules/NeoIPC-Tools/NeoIPC-Tools.psd1
+++ b/scripts/modules/NeoIPC-Tools/NeoIPC-Tools.psd1
@@ -72,6 +72,7 @@
         'Update-NeoIPCMetadata'
         'New-NeoIPCMetadataPackage'
         'Import-NeoIPCMetadata'
+        'Test-NeoIPCMetadataImport'
         'Export-NeoIPCMetadataTranslation'
         'Import-NeoIPCMetadataTranslation'
         'Update-NeoIPCMetadataDirectory'

--- a/scripts/modules/NeoIPC-Tools/Private/DHIS2Http.ps1
+++ b/scripts/modules/NeoIPC-Tools/Private/DHIS2Http.ps1
@@ -82,7 +82,9 @@ function Invoke-NeoIPCDhis2Get {
         Uri         = $uri
         ErrorAction = 'Stop'
     }
-    Set-NeoIPCDhis2Auth -InvokeParams $invokeParams -Auth $Auth
+    # -AllowUnencrypted so Basic auth works over the local http dev/test stack, matching the POST helper
+    # (harmless over https — it only permits, never forces, unencrypted Basic auth).
+    Set-NeoIPCDhis2Auth -InvokeParams $invokeParams -Auth $Auth -AllowUnencrypted
 
     if ($PSCmdlet.ShouldProcess(
             "GET $uri",

--- a/scripts/modules/NeoIPC-Tools/Private/MetadataTypeMaps.ps1
+++ b/scripts/modules/NeoIPC-Tools/Private/MetadataTypeMaps.ps1
@@ -272,6 +272,32 @@ $script:NeoIPCMetadataOrderedRefProps = [System.Collections.Generic.HashSet[stri
     }),
     [System.StringComparer]::Ordinal)
 
+# The ref-collections DHIS2 actually persists as ORDERED <list>s (a sort_order list-index column), keyed by
+# "<type>|<property>". This is the round-trip VERIFIER's source of truth for an order check (Test-NeoIPCMetadataImport
+# OrderDrift): only these collections are guaranteed to read back in the imported order, so only these may be compared
+# positionally against DHIS2. It is deliberately NARROWER than $NeoIPCMetadataOrderedRefProps above, for two reasons:
+# (1) that set is keyed by property NAME and serves the NORMALIZER's cell determinism (preserve-in-cell, NOT
+#     server-order), so it cannot distinguish two types that share a property name; and
+# (2) `dataElementGroups.dataElements` is classed idArrayOrdered there only so its CSV cell stays stable, but DHIS2
+#     maps DataElementGroup.members as an unordered <set> (no list-index — DataElementGroup.hbm.xml), so it is
+#     EXCLUDED here: ordering it positionally would false-positive (the server returns members in hash order).
+# Each entry verified against refs/dhis2-core *.hbm.xml as a <list> with <list-index column="sort_order" base="1">.
+$script:NeoIPCMetadataServerOrderedRefs = [System.Collections.Generic.HashSet[string]]::new(
+    [string[]]@(
+        'optionGroupSets|optionGroups'                  # OptionGroupSet.hbm.xml <list>
+        'categories|categoryOptions'                    # Category.hbm.xml <list>
+        'categoryCombos|categories'                     # CategoryCombo.hbm.xml <list>
+        'programStageSections|dataElements'             # ProgramStageSection.hbm.xml <list> (form layout)
+        'programStageSections|programIndicators'        # ProgramStageSection.hbm.xml <list>
+        'programSections|trackedEntityAttributes'       # ProgramSection.hbm.xml <list>
+        # NestedOnly attribute lists — genuine <list> with sort_order, but their order lives on the PARENT
+        # collection (TrackedEntityTypeAttribute has no element sortOrder at all), so the verifier checks it
+        # positionally on the parent's child-id sequence (the NestedOnly pass), not via a parent field compare.
+        'programs|programTrackedEntityAttributes'       # Program.hbm.xml <list name="programAttributes">
+        'trackedEntityTypes|trackedEntityTypeAttributes' # TrackedEntityType.hbm.xml <list>
+    ),
+    [System.StringComparer]::Ordinal)
+
 # Translatable base property -> DHIS2 ObjectTranslation TOKEN. A translations[] entry serializes as
 # { property = <TOKEN>, locale = <java-locale string, e.g. "de">, value = <translated string> }
 # (refs/dhis2-core dhis-api .../translation/Translation.java). The TOKEN is the literal @Translatable.key()

--- a/scripts/modules/NeoIPC-Tools/Public/Metadata.ps1
+++ b/scripts/modules/NeoIPC-Tools/Public/Metadata.ps1
@@ -595,8 +595,9 @@ function Import-NeoIPCMetadata {
         8080 and a Basic-auth hashtable.
 
         The summary object carries DryRun, HttpStatusCode (transport), Status (OK / WARNING / ERROR), the create/
-        update/delete/ignore/total counts, the per-type reports, and Raw (the full parsed response) for callers
-        that need the conflict detail. A non-OK status is reported, not thrown — the caller decides how to react
+        update/delete/ignore/total counts, the per-type reports, ErrorMessage (the top-level WebMessage
+        message when the body carries no structured report — e.g. a Hibernate persistence error), and Raw (the
+        full parsed response) for callers that need the conflict detail. A non-OK status is reported, not thrown — the caller decides how to react
         (a seed continues on WARNING; a strict gate fails). The body is read whatever the transport code, because
         DHIS2 answers an import with conflicts HTTP 409 while still returning the full report.
     .PARAMETER Path
@@ -667,9 +668,21 @@ function Import-NeoIPCMetadata {
     $status = if ($report -and ($report.PSObject.Properties.Name -contains 'status')) { $report.status }
     elseif ($body -and ($body.PSObject.Properties.Name -contains 'status')) { $body.status } else { $null }
 
-    Write-Verbose ("metadata import ({0}): HTTP {1}, status {2}{3}." -f `
+    # When the import fails at the persistence layer (e.g. a Hibernate not-null/transient flush error),
+    # DHIS2 returns a bare WebMessage with a top-level `message` and NO `.response`/typeReports node — so
+    # the structured-report fields above are all null and the real cause hides in `message`. Surface it so
+    # callers and logs name the actual fault instead of an opaque "status ERROR (HTTP 409)".
+    $errorMessage = if (-not $hasResponse -and $body) {
+        $m = if ($body.PSObject.Properties.Name -contains 'message') { $body.message } else { $null }
+        $dm = if ($body.PSObject.Properties.Name -contains 'devMessage') { $body.devMessage } else { $null }
+        (@($m, $dm) | Where-Object { $_ }) -join ' / '
+    }
+    else { $null }
+
+    Write-Verbose ("metadata import ({0}): HTTP {1}, status {2}{3}{4}." -f `
         ($(if ($DryRun) { 'dry-run' } else { 'commit' })), $response.StatusCode, $status,
-        $(if ($stats) { ", created=$($stats.created) updated=$($stats.updated) ignored=$($stats.ignored) total=$($stats.total)" } else { '' }))
+        $(if ($stats) { ", created=$($stats.created) updated=$($stats.updated) ignored=$($stats.ignored) total=$($stats.total)" } else { '' }),
+        $(if ($errorMessage) { " — $errorMessage" } else { '' }))
 
     [pscustomobject]@{
         DryRun         = [bool]$DryRun
@@ -681,6 +694,7 @@ function Import-NeoIPCMetadata {
         Ignored        = if ($stats) { $stats.ignored } else { $null }
         Total          = if ($stats) { $stats.total } else { $null }
         TypeReports    = if ($report -and ($report.PSObject.Properties.Name -contains 'typeReports')) { $report.typeReports } else { $null }
+        ErrorMessage   = $errorMessage
         Raw            = $body
     }
 }

--- a/scripts/modules/NeoIPC-Tools/Public/Metadata.ps1
+++ b/scripts/modules/NeoIPC-Tools/Public/Metadata.ps1
@@ -612,6 +612,14 @@ function Import-NeoIPCMetadata {
         DHIS2 atomicMode: ALL (default — all-or-nothing) or NONE (import what is valid, report the rest).
     .PARAMETER DryRun
         Validate only (importMode=VALIDATE); the server commits nothing.
+    .PARAMETER ConnectReferences
+        After a committing import, re-apply the package a SECOND time to connect OWNED reference collections that
+        DHIS2 does not link to objects created in the SAME payload. Verified empirically: a single combined import
+        leaves optionGroupSet.optionGroups, programRule.programRuleActions and userGroup.managedGroups members-less
+        even though it reports status=OK — the analogous optionGroup.options links fine, so it is specific to those
+        group-set / rule-action / managed-group collections. The second pass, where every referenced object now
+        exists, connects them. No effect with -DryRun. The returned object's ConnectPassStatus carries the second
+        pass's status; the round-trip Test-NeoIPCMetadataImport is the authoritative gate that it worked.
     #>
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High', DefaultParameterSetName = 'Path')]
     [OutputType([pscustomobject])]
@@ -624,7 +632,8 @@ function Import-NeoIPCMetadata {
         [Nullable[int]]$Port = $null,
         [ValidateSet('CREATE_AND_UPDATE', 'CREATE', 'UPDATE', 'DELETE')][string]$ImportStrategy = 'CREATE_AND_UPDATE',
         [ValidateSet('ALL', 'NONE')][string]$AtomicMode = 'ALL',
-        [switch]$DryRun
+        [switch]$DryRun,
+        [switch]$ConnectReferences
     )
     if ($PSCmdlet.ParameterSetName -eq 'Path') {
         if (-not (Test-Path -LiteralPath $Path)) { throw "Metadata package not found: '$Path'." }
@@ -684,6 +693,21 @@ function Import-NeoIPCMetadata {
         $(if ($stats) { ", created=$($stats.created) updated=$($stats.updated) ignored=$($stats.ignored) total=$($stats.total)" } else { '' }),
         $(if ($errorMessage) { " — $errorMessage" } else { '' }))
 
+    # Connect pass: DHIS2's metadata import does not link an object's OWNED reference collections to objects
+    # created in the SAME payload (optionGroupSet.optionGroups, programRule.programRuleActions,
+    # userGroup.managedGroups — verified: they import members-less even though status=OK, while the analogous
+    # optionGroup.options links fine). Re-applying the package once every referenced object exists connects them.
+    # Only after a committing pass that did not hard-fail; Test-NeoIPCMetadataImport is the authoritative gate.
+    $connectPassStatus = $null
+    if ($ConnectReferences -and -not $DryRun -and $status -in 'OK', 'WARNING') {
+        Write-Verbose 'Connect pass: re-applying the package to connect same-payload owned-collection memberships...'
+        $connectBody = (Invoke-NeoIPCDhis2Post @postArgs -Confirm:$false).Body
+        $connectReport = if ($connectBody -and ($connectBody.PSObject.Properties.Name -contains 'response') -and $connectBody.response) { $connectBody.response } else { $connectBody }
+        $connectPassStatus = if ($connectReport -and ($connectReport.PSObject.Properties.Name -contains 'status')) { $connectReport.status }
+        elseif ($connectBody -and ($connectBody.PSObject.Properties.Name -contains 'status')) { $connectBody.status } else { $null }
+        Write-Verbose "Connect pass: status $connectPassStatus."
+    }
+
     [pscustomobject]@{
         DryRun         = [bool]$DryRun
         HttpStatusCode = $response.StatusCode
@@ -694,8 +718,9 @@ function Import-NeoIPCMetadata {
         Ignored        = if ($stats) { $stats.ignored } else { $null }
         Total          = if ($stats) { $stats.total } else { $null }
         TypeReports    = if ($report -and ($report.PSObject.Properties.Name -contains 'typeReports')) { $report.typeReports } else { $null }
-        ErrorMessage   = $errorMessage
-        Raw            = $body
+        ErrorMessage      = $errorMessage
+        ConnectPassStatus = $connectPassStatus
+        Raw               = $body
     }
 }
 

--- a/scripts/modules/NeoIPC-Tools/Public/MetadataVerify.ps1
+++ b/scripts/modules/NeoIPC-Tools/Public/MetadataVerify.ps1
@@ -1,10 +1,11 @@
 # Round-trip verification of a metadata import: the companion to Import-NeoIPCMetadata. After a package is
-# imported it proves the import did not SILENTLY drop objects or owned-collection memberships. This guards a real
-# DHIS2 import behaviour: a single combined /api/metadata import does NOT connect an optionGroupSet's
-# `optionGroups` membership to optionGroups created in the SAME payload (verified empirically — the groups and the
-# option->optionGroup links persist, only the group-set->group link is dropped), so an import that reports
-# status=OK can still leave a group set with zero members. Reading every object back with fields=:owner and
-# diffing it against the package catches that and any analogous drop across every type at once.
+# imported it proves the import did not SILENTLY drop objects, owned-collection memberships, ordered-list
+# order, or stringArray values. This guards a real DHIS2 import behaviour: a single combined /api/metadata
+# import does NOT connect an optionGroupSet's `optionGroups` membership to optionGroups created in the SAME
+# payload (verified empirically — the groups and the option->optionGroup links persist, only the
+# group-set->group link is dropped), so an import that reports status=OK can still leave a group set with
+# zero members. Reading every object back with fields=:owner and diffing it against the package catches that
+# and any analogous drop across every type at once.
 
 function Test-NeoIPCMetadataImport {
     <#
@@ -15,24 +16,53 @@ function Test-NeoIPCMetadataImport {
         For every object in $Package, fetches the imported object from DHIS2 with fields=:owner (all OWNED
         properties, including owned reference collections) and compares it against the package object. Emits one
         record per discrepancy:
-          - Missing      — a package object absent from DHIS2 (the import dropped the whole object).
+          - Missing      — a package object absent from DHIS2 (the import dropped the whole object). Also raised
+                           for a NestedOnly child (see below) the parent no longer carries.
           - LinkDrop     — an owned reference / reference-collection the package specifies that DHIS2 did not
                            store: a dropped group-set membership (optionGroupSet.optionGroups), or any other
                            reference field (optionSet.options, optionGroup.options, program.programStages,
                            programStage.programStageDataElements, ...). Reference collections are compared as
-                           id-SETS: a member the package lists but DHIS2 lacks IS caught, but a difference in
-                           member ORDER is NOT — for ordered collections (optionGroupSet.optionGroups,
-                           programStageSection.dataElements, ...) a wrong-order reconnection passes clean. A
-                           known limitation; the membership check is the proven part.
-          - FieldMismatch — a non-reference scalar/array field whose stored value differs from the package.
+                           id-SETS so a member the package lists but DHIS2 lacks IS caught.
+          - OrderDrift   — a genuinely ORDERED reference collection (a DHIS2 <list> with a sort_order list-index:
+                           optionGroupSet.optionGroups, category.categoryOptions, categoryCombo.categories,
+                           programStageSection.dataElements / programIndicators, programSection.trackedEntityAttributes,
+                           and the NestedOnly attribute lists program.programTrackedEntityAttributes /
+                           trackedEntityType.trackedEntityTypeAttributes — checked on the parent's child-id sequence)
+                           whose members all round-trip but in a DIFFERENT order. The order set is
+                           $NeoIPCMetadataServerOrderedRefs (keyed by "<type>|<property>") — deliberately narrower
+                           than the normalizer's name-keyed $NeoIPCMetadataOrderedRefProps: e.g. dataElementGroup.members
+                           is a DHIS2 <set> (read back in hash order) and is NOT order-checked even though its CSV cell
+                           keeps a stable order.
+          - ValueDrop    — a `stringArray` / `intArray` value (authorities, restrictions, deliveryChannels,
+                           objectTypes, aggregationLevels, organisationUnitLevels) the package lists but DHIS2
+                           did not store. Compared order-insensitively (these are DHIS2 <set>s), so a reordering
+                           is NOT flagged — only a genuine value drop.
+          - FieldMismatch — a non-reference scalar / nested-object field whose stored value differs from the
+                           package (DHIS2 value normalization typically).
           - FetchFailed  — a whole type could not be read back (network / endpoint error). Reported as a record;
                            the caller decides severity — the seed's round-trip gate (Initialize-TestDhis2.ps1)
                            treats it as fatal, since its objects are then unverified.
 
+        NestedOnly children (programStageDataElements, programTrackedEntityAttributes, trackedEntityTypeAttributes)
+        have NO addressable top-level GET endpoint in DHIS2 2.40 (their SchemaDescriptors never set a relative API
+        endpoint, and there is no controller — verified against refs/dhis2-core 2.40.3.2), and a bare fields=:owner
+        on the parent returns them as id-ONLY (FieldPathHelper expands an un-elaborated owned ref-collection to its
+        ids). So to diff their OWNED fields (compulsory, sortOrder, renderType, ...) the parent is fetched with the
+        child collection EXPLICITLY expanded — fields=:owner,<arrayProp>[:owner] — and each child is compared out of
+        the parent response. A NestedOnly child whose parent fk is synthetic (analyticsPeriodBoundaries) is not an
+        independently identified object, so it stays membership-only (checked through its parent's collection field).
+
+        Option sortOrder needs NO special handling and produces NO noise: DHIS2 maps OptionSet.options as a
+        Hibernate <list> with <list-index column="sort_order" base="1"> (OptionSet.hbm.xml) and Option.sortOrder
+        maps to the SAME column, so the persisted list position becomes the stored sortOrder — a 1-based dense rank
+        per set. The package already emits option sortOrder as a 1-based contiguous sequence per set (the directory
+        CSV and the pathogen / antibiotic generators alike), so the value round-trips exactly. Verified against
+        refs/dhis2-core.
+
         The PACKAGE is the source of truth: only the fields the package actually specifies are checked, so
         server-filled defaults never produce false positives. Server-managed / noisy dimensions (translations,
         sharing, audit, access) are skipped by default (-IgnoreField). An empty result means a perfect
-        round-trip — every object present, every link intact.
+        round-trip — every object present, every link intact, every ordered list in order.
 
         Read-only (GETs only). It DRIVES a DHIS2 instance, so it is intended for the local / test stack; pass
         -Scheme http -Hostname localhost -Port 8080 with a Basic-auth hashtable for the local stack.
@@ -89,6 +119,9 @@ function Test-NeoIPCMetadataImport {
     $getArgs = @{ Auth = $Auth; Scheme = $Scheme; Hostname = $Hostname }
     if ($null -ne $Port) { $getArgs['Port'] = $Port }
 
+    $records = [System.Collections.Generic.List[object]]::new()
+    $ordinal = [System.StringComparer]::Ordinal
+
     # A reference is any object carrying an `id`; in fields=:owner output DHIS2 returns owned references as bare
     # { id } objects, matching the package. Extract the id whether the object is a package hashtable or a parsed
     # DHIS2 PSCustomObject.
@@ -102,22 +135,129 @@ function Test-NeoIPCMetadataImport {
         return ($null -ne $x -and $null -ne $x.PSObject -and $null -ne $x.PSObject.Properties['id'])
     }
 
-    $records = [System.Collections.Generic.List[object]]::new()
-    $ordinal = [System.StringComparer]::Ordinal
+    # An ordered ref-collection drifts when its members all round-trip (membership is checked separately) but in
+    # a different sequence. Returns a detail string when the package order is not preserved, else $null. A count
+    # mismatch means a membership problem (Missing / LinkDrop, reported elsewhere), not an order one — so skip it.
+    function Get-NeoIPCOrderDriftDetail($ExpIds, $ActIds) {
+        $exp = @($ExpIds)
+        if ($exp.Count -le 1) { return $null }
+        $expSet = [System.Collections.Generic.HashSet[string]]::new([string[]]$exp, $ordinal)
+        $actInExp = @(@($ActIds) | Where-Object { $expSet.Contains($_) })
+        if ($actInExp.Count -ne $exp.Count) { return $null }
+        for ($k = 0; $k -lt $exp.Count; $k++) {
+            if ($exp[$k] -cne $actInExp[$k]) {
+                $expShown = (@($exp) | Select-Object -First 8) -join ','
+                $actShown = (@($actInExp) | Select-Object -First 8) -join ','
+                return "ordered list reconnected out of order: package [$expShown] DHIS2 [$actShown]"
+            }
+        }
+        return $null
+    }
 
+    # Diff one package object's specified fields against its DHIS2 read-back, appending discrepancy records.
+    # $SkipFields holds property names to bypass (the NestedOnly child collections on a parent, which are diffed
+    # element-wise in their own pass — so the parent does not also membership-flag them).
+    function Add-NeoIPCFieldDiscrepancies($Type, $PObj, $Imp, $Map, $SkipFields) {
+        $id = [string]$PObj['id']
+        $code = [string]$PObj['code']
+        foreach ($field in @($PObj.Keys)) {
+            $fname = [string]$field
+            if ($fname -eq 'id' -or $fname -eq '__fk' -or $ignore.Contains($fname)) { continue }
+            if ($SkipFields -and $SkipFields.Contains($fname)) { continue }
+            $expected = $PObj[$field]
+            $impProp = $Imp.PSObject.Properties[$fname]
+            $actual = if ($impProp) { $impProp.Value } else { $null }
+            $class = if ($Map -and $Map.Properties -and $Map.Properties.Contains($fname)) { [string]$Map.Properties[$fname] } else { '' }
+
+            # stringArray / intArray: DHIS2 <set>s — compare values order-insensitively; a package value DHIS2
+            # lacks is a ValueDrop. (Not a reference, so it never reaches the id-set branch below.)
+            if ($class -eq 'stringArray' -or $class -eq 'intArray') {
+                $expVals = @(@($expected) | Where-Object { $null -ne $_ } | ForEach-Object { [string]$_ })
+                $actVals = [System.Collections.Generic.HashSet[string]]::new($ordinal)
+                foreach ($v in @($actual)) { if ($null -ne $v) { [void]$actVals.Add([string]$v) } }
+                $missing = @($expVals | Where-Object { -not $actVals.Contains($_) })
+                if ($missing.Count -gt 0) {
+                    $shown = (@($missing) | Select-Object -First 8) -join ','
+                    if ($missing.Count -gt 8) { $shown += ',…' }
+                    $records.Add([pscustomobject]@{ Type = $Type; Id = $id; Code = $code; Kind = 'ValueDrop'; Field = $fname
+                            Detail = "package lists $($expVals.Count) value(s), DHIS2 has $($actVals.Count); missing $($missing.Count): $shown" })
+                }
+                continue
+            }
+
+            $expArr = @($expected)
+            if (($expArr.Count -gt 0 -and (Test-NeoIPCIsRef $expArr[0])) -or $class -eq 'idArray' -or $class -eq 'idArrayOrdered' -or $class -eq 'id') {
+                # Reference (single or collection): compare membership as id-sets so a dropped link is caught.
+                # For collections DHIS2 persists as ordered <list>s ($NeoIPCMetadataServerOrderedRefs) additionally
+                # compare position so a wrong-order reconnection is caught (OrderDrift).
+                $expIds = @($expArr | ForEach-Object { Get-NeoIPCRefId $_ } | Where-Object { $_ })
+                $actIds = @(@($actual) | ForEach-Object { Get-NeoIPCRefId $_ } | Where-Object { $_ })
+                $actSet = [System.Collections.Generic.HashSet[string]]::new($ordinal)
+                foreach ($a in $actIds) { [void]$actSet.Add($a) }
+                $missing = @($expIds | Where-Object { -not $actSet.Contains($_) })
+                if ($missing.Count -gt 0) {
+                    $shown = (@($missing) | Select-Object -First 8) -join ','
+                    if ($missing.Count -gt 8) { $shown += ',…' }
+                    $records.Add([pscustomobject]@{ Type = $Type; Id = $id; Code = $code; Kind = 'LinkDrop'; Field = $fname
+                            Detail = "package lists $($expIds.Count) ref(s), DHIS2 has $($actSet.Count); missing $($missing.Count): $shown" })
+                    continue
+                }
+                if ($script:NeoIPCMetadataServerOrderedRefs.Contains("$Type|$fname")) {
+                    $detail = Get-NeoIPCOrderDriftDetail $expIds $actIds
+                    if ($detail) {
+                        $records.Add([pscustomobject]@{ Type = $Type; Id = $id; Code = $code; Kind = 'OrderDrift'; Field = $fname; Detail = $detail })
+                    }
+                }
+                continue
+            }
+            $e = $expected | ConvertTo-Json -Compress -Depth 20
+            $a = $actual | ConvertTo-Json -Compress -Depth 20
+            if ($e -cne $a) {
+                $records.Add([pscustomobject]@{ Type = $Type; Id = $id; Code = $code; Kind = 'FieldMismatch'; Field = $fname
+                        Detail = "package=$e DHIS2=$a" })
+            }
+        }
+    }
+
+    # The work list: every top-level package type with id-bearing objects. NestedOnly children are NOT verified as
+    # their own type (no top-level endpoint in 2.40) — they are diffed out of their parent's expanded read-back.
+    $typeObjects = [ordered]@{}
     foreach ($type in @($pkg.Keys)) {
         $objs = @(@($pkg[$type]) | Where-Object { $_ -is [System.Collections.IDictionary] -and $_['id'] })
+        if ($objs.Count -gt 0) { $typeObjects[$type] = $objs }
+    }
+
+    # parent type -> the NestedOnly child collections to expand + diff in the parent's read-back (skip synthetic-fk
+    # children, which are not independently identified objects).
+    $nestedByParent = @{}
+    foreach ($childType in $script:NeoIPCMetadataTypeMaps.Keys) {
+        $cmap = $script:NeoIPCMetadataTypeMaps[$childType]
+        if ($cmap.Nesting -ne 'NestedOnly' -or $cmap.Parent.FkSynthetic) { continue }
+        $pt = [string]$cmap.Parent.Type
+        if (-not $nestedByParent.ContainsKey($pt)) { $nestedByParent[$pt] = [System.Collections.Generic.List[object]]::new() }
+        $nestedByParent[$pt].Add(@{ ChildType = $childType; ArrayProp = [string]$cmap.Parent.ArrayProp })
+    }
+
+    foreach ($type in @($typeObjects.Keys)) {
+        $objs = @($typeObjects[$type])
         if ($objs.Count -eq 0) { continue }
+        $map = $script:NeoIPCMetadataTypeMaps[$type]
+        $childExpansions = if ($nestedByParent.ContainsKey($type)) { @($nestedByParent[$type]) } else { @() }
+        $skipFields = [System.Collections.Generic.HashSet[string]]::new($ordinal)
+        $fields = [System.Collections.Generic.List[string]]::new()
+        $fields.Add(':owner')
+        foreach ($ce in $childExpansions) { $fields.Add("$($ce.ArrayProp)[:owner]"); [void]$skipFields.Add([string]$ce.ArrayProp) }
         Write-Verbose "Verifying $($objs.Count) $type ..."
 
-        # Read the imported objects of this type back with all owned fields, batched by id.
+        # Read the imported objects of this type back with all owned fields (and any NestedOnly children expanded),
+        # batched by id.
         $importedById = @{}
         $fetchFailed = $false
         for ($i = 0; $i -lt $objs.Count; $i += $BatchSize) {
             $batch = @($objs[$i..([Math]::Min($i + $BatchSize, $objs.Count) - 1)])
             $ids = @($batch | ForEach-Object { [string]$_['id'] })
             try {
-                $resp = Invoke-NeoIPCDhis2Get @getArgs -Path "api/$type" -Fields ':owner' -Filter "id:in:[$($ids -join ',')]" -Confirm:$false
+                $resp = Invoke-NeoIPCDhis2Get @getArgs -Path "api/$type" -Fields $fields.ToArray() -Filter "id:in:[$($ids -join ',')]" -Confirm:$false
             }
             catch {
                 $records.Add([pscustomobject]@{ Type = $type; Id = ''; Code = ''; Kind = 'FetchFailed'; Field = ''; Detail = $_.Exception.Message })
@@ -144,35 +284,43 @@ function Test-NeoIPCMetadataImport {
                 $records.Add([pscustomobject]@{ Type = $type; Id = $id; Code = $code; Kind = 'Missing'; Field = ''; Detail = 'object not present in DHIS2 after import' })
                 continue
             }
-            $imp = $importedById[$id]
-            foreach ($field in @($pObj.Keys)) {
-                $fname = [string]$field
-                if ($fname -eq 'id' -or $ignore.Contains($fname)) { continue }
-                $expected = $pObj[$field]
-                $impProp = $imp.PSObject.Properties[$fname]
-                $actual = if ($impProp) { $impProp.Value } else { $null }
+            Add-NeoIPCFieldDiscrepancies $type $pObj $importedById[$id] $map $skipFields
+        }
 
-                $expArr = @($expected)
-                if ($expArr.Count -gt 0 -and (Test-NeoIPCIsRef $expArr[0])) {
-                    # Reference (single or collection): compare as id-sets so order is irrelevant; a member the
-                    # package lists but DHIS2 lacks is a dropped link.
-                    $expIds = @($expArr | ForEach-Object { Get-NeoIPCRefId $_ } | Where-Object { $_ })
-                    $actSet = [System.Collections.Generic.HashSet[string]]::new($ordinal)
-                    foreach ($a in @($actual)) { $rid = Get-NeoIPCRefId $a; if ($rid) { [void]$actSet.Add($rid) } }
-                    $missing = @($expIds | Where-Object { -not $actSet.Contains($_) })
-                    if ($missing.Count -gt 0) {
-                        $shown = (@($missing) | Select-Object -First 8) -join ','
-                        if ($missing.Count -gt 8) { $shown += ',…' }
-                        $records.Add([pscustomobject]@{ Type = $type; Id = $id; Code = $code; Kind = 'LinkDrop'; Field = $fname
-                                Detail = "package lists $($expIds.Count) ref(s), DHIS2 has $($actSet.Count); missing $($missing.Count): $shown" })
+        # NestedOnly children: diff each child's OWNED fields out of its parent's expanded read-back.
+        foreach ($ce in $childExpansions) {
+            $childType = $ce.ChildType
+            $arrayProp = $ce.ArrayProp
+            $childMap = $script:NeoIPCMetadataTypeMaps[$childType]
+            $respChildById = @{}
+            foreach ($rp in $importedById.Values) {
+                $rpProp = $rp.PSObject.Properties[$arrayProp]
+                if ($rpProp) { foreach ($rc in @($rpProp.Value)) { if ($null -ne $rc -and $rc.id) { $respChildById[[string]$rc.id] = $rc } } }
+            }
+            $isOrderedChild = $script:NeoIPCMetadataServerOrderedRefs.Contains("$type|$arrayProp")
+            foreach ($pObj in $objs) {
+                if (-not ($pObj -is [System.Collections.IDictionary]) -or -not $pObj.Contains($arrayProp)) { continue }
+                foreach ($pc in @($pObj[$arrayProp])) {
+                    if (-not ($pc -is [System.Collections.IDictionary]) -or -not $pc['id']) { continue }
+                    $cid = [string]$pc['id']
+                    if (-not $respChildById.ContainsKey($cid)) {
+                        $records.Add([pscustomobject]@{ Type = $childType; Id = $cid; Code = [string]$pc['code']; Kind = 'Missing'; Field = ''; Detail = "nested object absent from its parent ($type) after import" })
+                        continue
                     }
-                    continue
+                    Add-NeoIPCFieldDiscrepancies $childType $pc $respChildById[$cid] $childMap $null
                 }
-                $e = $expected | ConvertTo-Json -Compress -Depth 20
-                $a = $actual | ConvertTo-Json -Compress -Depth 20
-                if ($e -cne $a) {
-                    $records.Add([pscustomobject]@{ Type = $type; Id = $id; Code = $code; Kind = 'FieldMismatch'; Field = $fname
-                            Detail = "package=$e DHIS2=$a" })
+                # The child collection is a DHIS2 <list> whose order is the parent's (not recoverable from an
+                # element sortOrder — trackedEntityTypeAttributes has none), so check it positionally on the
+                # parent's child-id sequence. The parent field itself is skipped in the parent compare above.
+                if ($isOrderedChild -and $importedById.ContainsKey([string]$pObj['id'])) {
+                    $imp = $importedById[[string]$pObj['id']]
+                    $expIds = @(@($pObj[$arrayProp]) | ForEach-Object { Get-NeoIPCRefId $_ } | Where-Object { $_ })
+                    $rpProp = $imp.PSObject.Properties[$arrayProp]
+                    $actIds = if ($rpProp) { @(@($rpProp.Value) | ForEach-Object { Get-NeoIPCRefId $_ } | Where-Object { $_ }) } else { @() }
+                    $detail = Get-NeoIPCOrderDriftDetail $expIds $actIds
+                    if ($detail) {
+                        $records.Add([pscustomobject]@{ Type = $type; Id = [string]$pObj['id']; Code = [string]$pObj['code']; Kind = 'OrderDrift'; Field = $arrayProp; Detail = $detail })
+                    }
                 }
             }
         }

--- a/scripts/modules/NeoIPC-Tools/Public/MetadataVerify.ps1
+++ b/scripts/modules/NeoIPC-Tools/Public/MetadataVerify.ps1
@@ -154,6 +154,30 @@ function Test-NeoIPCMetadataImport {
         return $null
     }
 
+    # Canonicalize a value for order-insensitive comparison: recursively sort the keys of every nested object
+    # (the package emits an [ordered] hashtable, DHIS2 reads back a PSCustomObject, and the two can hold the SAME
+    # nested data in a DIFFERENT key order — renderType { DESKTOP, MOBILE }, style { icon, color } — which a raw
+    # ConvertTo-Json string compare would wrongly flag as a FieldMismatch and block a good seed). Array order is
+    # preserved (it is semantically meaningful and checked in the reference / *Array branches above); only object
+    # keys are reordered. Scalars pass through unchanged, so genuine value differences still surface.
+    function ConvertTo-NeoIPCCanonical($Value) {
+        if ($null -eq $Value) { return $null }
+        if ($Value -is [System.Collections.IDictionary]) {
+            $out = [ordered]@{}
+            foreach ($k in (@($Value.Keys) | Sort-Object)) { $out[[string]$k] = ConvertTo-NeoIPCCanonical $Value[$k] }
+            return $out
+        }
+        if ($Value -is [System.Management.Automation.PSCustomObject]) {
+            $out = [ordered]@{}
+            foreach ($p in (@($Value.PSObject.Properties) | Sort-Object Name)) { $out[$p.Name] = ConvertTo-NeoIPCCanonical $p.Value }
+            return $out
+        }
+        if ($Value -is [System.Collections.IEnumerable] -and $Value -isnot [string]) {
+            return @(foreach ($item in $Value) { ConvertTo-NeoIPCCanonical $item })
+        }
+        return $Value
+    }
+
     # Diff one package object's specified fields against its DHIS2 read-back, appending discrepancy records.
     # $SkipFields holds property names to bypass (the NestedOnly child collections on a parent, which are diffed
     # element-wise in their own pass — so the parent does not also membership-flag them).
@@ -210,8 +234,8 @@ function Test-NeoIPCMetadataImport {
                 }
                 continue
             }
-            $e = $expected | ConvertTo-Json -Compress -Depth 20
-            $a = $actual | ConvertTo-Json -Compress -Depth 20
+            $e = ConvertTo-Json -InputObject (ConvertTo-NeoIPCCanonical $expected) -Compress -Depth 20
+            $a = ConvertTo-Json -InputObject (ConvertTo-NeoIPCCanonical $actual) -Compress -Depth 20
             if ($e -cne $a) {
                 $records.Add([pscustomobject]@{ Type = $Type; Id = $id; Code = $code; Kind = 'FieldMismatch'; Field = $fname
                         Detail = "package=$e DHIS2=$a" })

--- a/scripts/modules/NeoIPC-Tools/Public/MetadataVerify.ps1
+++ b/scripts/modules/NeoIPC-Tools/Public/MetadataVerify.ps1
@@ -1,0 +1,184 @@
+# Round-trip verification of a metadata import: the companion to Import-NeoIPCMetadata. After a package is
+# imported it proves the import did not SILENTLY drop objects or owned-collection memberships. This guards a real
+# DHIS2 import behaviour: a single combined /api/metadata import does NOT connect an optionGroupSet's
+# `optionGroups` membership to optionGroups created in the SAME payload (verified empirically — the groups and the
+# option->optionGroup links persist, only the group-set->group link is dropped), so an import that reports
+# status=OK can still leave a group set with zero members. Reading every object back with fields=:owner and
+# diffing it against the package catches that and any analogous drop across every type at once.
+
+function Test-NeoIPCMetadataImport {
+    <#
+    .SYNOPSIS
+        Round-trip verification: assert every object in a metadata package is present in DHIS2 and correctly
+        linked after import.
+    .DESCRIPTION
+        For every object in $Package, fetches the imported object from DHIS2 with fields=:owner (all OWNED
+        properties, including owned reference collections) and compares it against the package object. Emits one
+        record per discrepancy:
+          - Missing      — a package object absent from DHIS2 (the import dropped the whole object).
+          - LinkDrop     — an owned reference / reference-collection the package specifies that DHIS2 did not
+                           store: a dropped group-set membership (optionGroupSet.optionGroups), or any other
+                           reference field (optionSet.options, optionGroup.options, program.programStages,
+                           programStage.programStageDataElements, ...). Reference collections are compared as
+                           id-SETS: a member the package lists but DHIS2 lacks IS caught, but a difference in
+                           member ORDER is NOT — for ordered collections (optionGroupSet.optionGroups,
+                           programStageSection.dataElements, ...) a wrong-order reconnection passes clean. A
+                           known limitation; the membership check is the proven part.
+          - FieldMismatch — a non-reference scalar/array field whose stored value differs from the package.
+          - FetchFailed  — a whole type could not be read back (network / endpoint error). Reported as a record;
+                           the caller decides severity — the seed's round-trip gate (Initialize-TestDhis2.ps1)
+                           treats it as fatal, since its objects are then unverified.
+
+        The PACKAGE is the source of truth: only the fields the package actually specifies are checked, so
+        server-filled defaults never produce false positives. Server-managed / noisy dimensions (translations,
+        sharing, audit, access) are skipped by default (-IgnoreField). An empty result means a perfect
+        round-trip — every object present, every link intact.
+
+        Read-only (GETs only). It DRIVES a DHIS2 instance, so it is intended for the local / test stack; pass
+        -Scheme http -Hostname localhost -Port 8080 with a Basic-auth hashtable for the local stack.
+    .PARAMETER Path
+        Path to a metadata package JSON file to verify.
+    .PARAMETER Package
+        The package to verify instead of -Path: the JSON string or the parsed hashtable from
+        New-NeoIPCMetadataPackage.
+    .PARAMETER Auth
+        Auth hashtable from Resolve-NeoIPCAuth (Token or Basic).
+    .PARAMETER Scheme
+        DHIS2 scheme (http/https). Default https.
+    .PARAMETER Hostname
+        DHIS2 hostname. Default neoipc.charite.de.
+    .PARAMETER Port
+        DHIS2 port. Default none (scheme default).
+    .PARAMETER IgnoreField
+        Object property names to skip. Defaults to the server-managed / noisy set (translations, sharing,
+        access, audit) plus `password`, so a synthetic user's login password is never echoed into a
+        FieldMismatch detail.
+    .PARAMETER BatchSize
+        Maximum object ids per `id:in:[...]` request. Default 120 (keeps the request URL well within limits).
+    .OUTPUTS
+        [object[]] of discrepancy records { Type; Id; Code; Kind; Field; Detail }. Empty = perfect round-trip.
+    #>
+    [CmdletBinding(DefaultParameterSetName = 'Path')]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory, ParameterSetName = 'Path')][string]$Path,
+        [Parameter(Mandatory, ParameterSetName = 'Package')]$Package,
+        [Parameter(Mandatory)][hashtable]$Auth,
+        [string]$Scheme = 'https',
+        [string]$Hostname = 'neoipc.charite.de',
+        [Nullable[int]]$Port = $null,
+        [string[]]$IgnoreField = @(
+            'translations', 'sharing', 'access', 'publicAccess', 'externalAccess',
+            'user', 'userAccesses', 'userGroupAccesses', 'favorites', 'favorite',
+            'password', 'created', 'lastUpdated', 'createdBy', 'lastUpdatedBy',
+            'createdByUserInfo', 'lastUpdatedByUserInfo', 'href'),
+        [ValidateRange(1, 1000)][int]$BatchSize = 120
+    )
+
+    if ($PSCmdlet.ParameterSetName -eq 'Path') {
+        if (-not (Test-Path -LiteralPath $Path)) { throw "Metadata package not found: '$Path'." }
+        $pkg = [System.IO.File]::ReadAllText($Path) | ConvertFrom-Json -AsHashtable -Depth 100
+    }
+    elseif ($Package -is [string]) { $pkg = $Package | ConvertFrom-Json -AsHashtable -Depth 100 }
+    elseif ($Package -is [System.Collections.IDictionary]) { $pkg = $Package }
+    else { throw 'Package must be a JSON string, a parsed hashtable, or supply -Path.' }
+
+    $ignore = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    foreach ($f in $IgnoreField) { [void]$ignore.Add($f) }
+
+    $getArgs = @{ Auth = $Auth; Scheme = $Scheme; Hostname = $Hostname }
+    if ($null -ne $Port) { $getArgs['Port'] = $Port }
+
+    # A reference is any object carrying an `id`; in fields=:owner output DHIS2 returns owned references as bare
+    # { id } objects, matching the package. Extract the id whether the object is a package hashtable or a parsed
+    # DHIS2 PSCustomObject.
+    function Get-NeoIPCRefId($x) {
+        if ($null -eq $x) { return $null }
+        if ($x -is [System.Collections.IDictionary]) { if ($x.Contains('id')) { return [string]$x['id'] } return $null }
+        $p = $x.PSObject.Properties['id']; if ($p) { return [string]$p.Value } return $null
+    }
+    function Test-NeoIPCIsRef($x) {
+        if ($x -is [System.Collections.IDictionary]) { return $x.Contains('id') }
+        return ($null -ne $x -and $null -ne $x.PSObject -and $null -ne $x.PSObject.Properties['id'])
+    }
+
+    $records = [System.Collections.Generic.List[object]]::new()
+    $ordinal = [System.StringComparer]::Ordinal
+
+    foreach ($type in @($pkg.Keys)) {
+        $objs = @(@($pkg[$type]) | Where-Object { $_ -is [System.Collections.IDictionary] -and $_['id'] })
+        if ($objs.Count -eq 0) { continue }
+        Write-Verbose "Verifying $($objs.Count) $type ..."
+
+        # Read the imported objects of this type back with all owned fields, batched by id.
+        $importedById = @{}
+        $fetchFailed = $false
+        for ($i = 0; $i -lt $objs.Count; $i += $BatchSize) {
+            $batch = @($objs[$i..([Math]::Min($i + $BatchSize, $objs.Count) - 1)])
+            $ids = @($batch | ForEach-Object { [string]$_['id'] })
+            try {
+                $resp = Invoke-NeoIPCDhis2Get @getArgs -Path "api/$type" -Fields ':owner' -Filter "id:in:[$($ids -join ',')]" -Confirm:$false
+            }
+            catch {
+                $records.Add([pscustomobject]@{ Type = $type; Id = ''; Code = ''; Kind = 'FetchFailed'; Field = ''; Detail = $_.Exception.Message })
+                $fetchFailed = $true
+                break
+            }
+            # A 200 with no `$type` collection key (an unexpected envelope) is a read-back failure, not "all
+            # objects missing" — record FetchFailed (fatal at the seed gate) rather than let `$resp.$type` throw
+            # under StrictMode or flood every object as Missing.
+            if ($null -eq $resp -or -not $resp.PSObject.Properties[$type]) {
+                $records.Add([pscustomobject]@{ Type = $type; Id = ''; Code = ''; Kind = 'FetchFailed'; Field = ''; Detail = "response did not contain a '$type' collection" })
+                $fetchFailed = $true
+                break
+            }
+            foreach ($o in @($resp.$type)) { if ($null -ne $o -and $o.id) { $importedById[[string]$o.id] = $o } }
+        }
+        if ($fetchFailed) { continue }
+        Write-Verbose "  read back $($importedById.Count) of $($objs.Count) $type"
+
+        foreach ($pObj in $objs) {
+            $id = [string]$pObj['id']
+            $code = [string]$pObj['code']
+            if (-not $importedById.ContainsKey($id)) {
+                $records.Add([pscustomobject]@{ Type = $type; Id = $id; Code = $code; Kind = 'Missing'; Field = ''; Detail = 'object not present in DHIS2 after import' })
+                continue
+            }
+            $imp = $importedById[$id]
+            foreach ($field in @($pObj.Keys)) {
+                $fname = [string]$field
+                if ($fname -eq 'id' -or $ignore.Contains($fname)) { continue }
+                $expected = $pObj[$field]
+                $impProp = $imp.PSObject.Properties[$fname]
+                $actual = if ($impProp) { $impProp.Value } else { $null }
+
+                $expArr = @($expected)
+                if ($expArr.Count -gt 0 -and (Test-NeoIPCIsRef $expArr[0])) {
+                    # Reference (single or collection): compare as id-sets so order is irrelevant; a member the
+                    # package lists but DHIS2 lacks is a dropped link.
+                    $expIds = @($expArr | ForEach-Object { Get-NeoIPCRefId $_ } | Where-Object { $_ })
+                    $actSet = [System.Collections.Generic.HashSet[string]]::new($ordinal)
+                    foreach ($a in @($actual)) { $rid = Get-NeoIPCRefId $a; if ($rid) { [void]$actSet.Add($rid) } }
+                    $missing = @($expIds | Where-Object { -not $actSet.Contains($_) })
+                    if ($missing.Count -gt 0) {
+                        $shown = (@($missing) | Select-Object -First 8) -join ','
+                        if ($missing.Count -gt 8) { $shown += ',…' }
+                        $records.Add([pscustomobject]@{ Type = $type; Id = $id; Code = $code; Kind = 'LinkDrop'; Field = $fname
+                                Detail = "package lists $($expIds.Count) ref(s), DHIS2 has $($actSet.Count); missing $($missing.Count): $shown" })
+                    }
+                    continue
+                }
+                $e = $expected | ConvertTo-Json -Compress -Depth 20
+                $a = $actual | ConvertTo-Json -Compress -Depth 20
+                if ($e -cne $a) {
+                    $records.Add([pscustomobject]@{ Type = $type; Id = $id; Code = $code; Kind = 'FieldMismatch'; Field = $fname
+                            Detail = "package=$e DHIS2=$a" })
+                }
+            }
+        }
+    }
+
+    $summary = $records | Group-Object Kind | ForEach-Object { "$($_.Name)=$($_.Count)" }
+    Write-Verbose ("Round-trip verification: {0}." -f $(if ($summary) { $summary -join ' ' } else { 'no discrepancies' }))
+    , [object[]]$records.ToArray()
+}

--- a/scripts/modules/NeoIPC-Tools/Tests/Metadata.Tests.ps1
+++ b/scripts/modules/NeoIPC-Tools/Tests/Metadata.Tests.ps1
@@ -4796,6 +4796,10 @@ Hierarchies:
             # (WebMessageUtils.importReport builds `new WebMessage(Status.WARNING, CONFLICT)`); the cmdlet reads
             # .response.status first, so it still surfaces ERROR. The fixture mirrors that real shape.
             $script:errorReport = '{"httpStatus":"Conflict","httpStatusCode":409,"status":"WARNING","response":{"responseType":"ImportReport","status":"ERROR","stats":{"created":0,"updated":0,"deleted":0,"ignored":4,"total":4}}}' | ConvertFrom-Json
+            # A persistence-layer failure (e.g. a Hibernate not-null/transient flush) comes back as a BARE WebMessage:
+            # top-level status/message/devMessage and NO .response/typeReports node, so the structured stats are all
+            # null and the real cause lives only in `message` — the case the ErrorMessage surfacing exists for.
+            $script:bareWebMessage = '{"httpStatus":"Conflict","httpStatusCode":409,"status":"ERROR","message":"Could not commit transaction.","devMessage":"PersistenceException: not-null property references a null or transient value"}' | ConvertFrom-Json
             $script:testAuth = @{ AuthType = 'Token'; Token = 'd2pat_xTESTtoken' }
         }
 
@@ -4872,6 +4876,48 @@ Hierarchies:
             Mock Invoke-NeoIPCDhis2Post { [pscustomobject]@{ StatusCode = 200; Body = $script:wrappedReport } }
             Import-NeoIPCMetadata -Json '{}' -Auth $script:testAuth -WhatIf | Out-Null
             Should -Invoke Invoke-NeoIPCDhis2Post -Times 0 -Exactly
+        }
+
+        It 'surfaces the joined message / devMessage when DHIS2 returns a bare WebMessage (no .response)' {
+            Mock Invoke-NeoIPCDhis2Post { [pscustomobject]@{ StatusCode = 409; Body = $script:bareWebMessage } }
+            $r = Import-NeoIPCMetadata -Json '{}' -Auth $script:testAuth -Confirm:$false
+            $r.HttpStatusCode | Should -Be 409
+            $r.Status | Should -Be 'ERROR'
+            $r.ErrorMessage | Should -Be 'Could not commit transaction. / PersistenceException: not-null property references a null or transient value'
+        }
+
+        It 'leaves ErrorMessage null on a happy-path (WebMessage-wrapped) import' {
+            Mock Invoke-NeoIPCDhis2Post { [pscustomobject]@{ StatusCode = 200; Body = $script:wrappedReport } }
+            $r = Import-NeoIPCMetadata -Json '{}' -Auth $script:testAuth -DryRun
+            $r.ErrorMessage | Should -BeNullOrEmpty
+        }
+
+        It 'does not run a connect pass by default (no -ConnectReferences)' {
+            Mock Invoke-NeoIPCDhis2Post { [pscustomobject]@{ StatusCode = 200; Body = $script:wrappedReport } }
+            $r = Import-NeoIPCMetadata -Json '{}' -Auth $script:testAuth -Confirm:$false
+            Should -Invoke Invoke-NeoIPCDhis2Post -Times 1 -Exactly
+            $r.ConnectPassStatus | Should -BeNullOrEmpty
+        }
+
+        It 'runs a second connect-pass POST when -ConnectReferences and the import status is OK/WARNING' {
+            Mock Invoke-NeoIPCDhis2Post { [pscustomobject]@{ StatusCode = 200; Body = $script:wrappedReport } }
+            $r = Import-NeoIPCMetadata -Json '{}' -Auth $script:testAuth -ConnectReferences -Confirm:$false
+            Should -Invoke Invoke-NeoIPCDhis2Post -Times 2 -Exactly
+            $r.ConnectPassStatus | Should -Be 'OK'
+        }
+
+        It 'skips the connect pass when the import status is ERROR, even with -ConnectReferences' {
+            Mock Invoke-NeoIPCDhis2Post { [pscustomobject]@{ StatusCode = 409; Body = $script:errorReport } }
+            $r = Import-NeoIPCMetadata -Json '{}' -Auth $script:testAuth -ConnectReferences -Confirm:$false
+            Should -Invoke Invoke-NeoIPCDhis2Post -Times 1 -Exactly
+            $r.ConnectPassStatus | Should -BeNullOrEmpty
+        }
+
+        It 'does not run the connect pass on a dry-run even with -ConnectReferences' {
+            Mock Invoke-NeoIPCDhis2Post { [pscustomobject]@{ StatusCode = 200; Body = $script:wrappedReport } }
+            $r = Import-NeoIPCMetadata -Json '{}' -Auth $script:testAuth -ConnectReferences -DryRun
+            Should -Invoke Invoke-NeoIPCDhis2Post -Times 1 -Exactly
+            $r.ConnectPassStatus | Should -BeNullOrEmpty
         }
     }
 

--- a/scripts/modules/NeoIPC-Tools/Tests/MetadataVerify.Tests.ps1
+++ b/scripts/modules/NeoIPC-Tools/Tests/MetadataVerify.Tests.ps1
@@ -217,5 +217,35 @@ InModuleScope 'NeoIPC-Tools' {
             }
             (Get-VDisc $pkg).Count | Should -Be 0
         }
+
+        It 'does NOT flag a nested object whose keys round-trip in a different order (renderType)' {
+            # renderType is a multi-key nested object on programStageDataElements with no reference / *Array class,
+            # so it reaches the FieldMismatch branch. DHIS2 can return its keys (DESKTOP/MOBILE) in a different
+            # order than the package emitted; order-insensitive canonicalization must NOT flag identical data.
+            $script:VState = @{ programStages = @([pscustomobject]@{ id = 'ps1'; name = 'S'
+                        programStageDataElements = @([pscustomobject]@{ id = 'psde1'; compulsory = $true
+                                renderType  = [pscustomobject]@{ MOBILE = [pscustomobject]@{ type = 'DEFAULT' }; DESKTOP = [pscustomobject]@{ type = 'DEFAULT' } }
+                                dataElement = [pscustomobject]@{ id = 'de1' }; programStage = [pscustomobject]@{ id = 'ps1' } }) }) }
+            $pkg = @{ programStages = @([ordered]@{ id = 'ps1'; name = 'S'
+                        programStageDataElements = @([ordered]@{ id = 'psde1'; compulsory = $true
+                                renderType  = [ordered]@{ DESKTOP = [ordered]@{ type = 'DEFAULT' }; MOBILE = [ordered]@{ type = 'DEFAULT' } }
+                                dataElement = [ordered]@{ id = 'de1' }; programStage = [ordered]@{ id = 'ps1' } }) }) }
+            @((Get-VDisc $pkg) | Where-Object { $_.Kind -eq 'FieldMismatch' }).Count | Should -Be 0
+        }
+
+        It 'still flags a nested object whose value genuinely differs (canonicalization does not mask real drift)' {
+            # Same shape as above but DESKTOP.type genuinely differs — canonicalization sorts keys, it does not
+            # collapse values, so a real value drift must still surface as a FieldMismatch on renderType.
+            $script:VState = @{ programStages = @([pscustomobject]@{ id = 'ps1'; name = 'S'
+                        programStageDataElements = @([pscustomobject]@{ id = 'psde1'; compulsory = $true
+                                renderType  = [pscustomobject]@{ DESKTOP = [pscustomobject]@{ type = 'VERTICAL_RADIOBUTTONS' }; MOBILE = [pscustomobject]@{ type = 'DEFAULT' } }
+                                dataElement = [pscustomobject]@{ id = 'de1' }; programStage = [pscustomobject]@{ id = 'ps1' } }) }) }
+            $pkg = @{ programStages = @([ordered]@{ id = 'ps1'; name = 'S'
+                        programStageDataElements = @([ordered]@{ id = 'psde1'; compulsory = $true
+                                renderType  = [ordered]@{ DESKTOP = [ordered]@{ type = 'DEFAULT' }; MOBILE = [ordered]@{ type = 'DEFAULT' } }
+                                dataElement = [ordered]@{ id = 'de1' }; programStage = [ordered]@{ id = 'ps1' } }) }) }
+            $fm = @((Get-VDisc $pkg) | Where-Object { $_.Kind -eq 'FieldMismatch' -and $_.Field -eq 'renderType' })
+            $fm.Count | Should -Be 1
+        }
     }
 }

--- a/scripts/modules/NeoIPC-Tools/Tests/MetadataVerify.Tests.ps1
+++ b/scripts/modules/NeoIPC-Tools/Tests/MetadataVerify.Tests.ps1
@@ -1,0 +1,221 @@
+# Pester 5 tests for the round-trip import verifier (Public/MetadataVerify.ps1). Self-contained: the DHIS2
+# read-back (Invoke-NeoIPCDhis2Get) is mocked from a synthetic in-memory "server state", so no live instance
+# is needed. The mock returns, per `api/<type>` request, a { <type> = [...] } envelope built from
+# $script:VState — the shape fields=:owner produces (owned ref-collections as bare { id } objects). NestedOnly
+# children are diffed out of their PARENT's expanded read-back (the verifier requests
+# fields=:owner,<arrayProp>[:owner]), so the parent's VState entry carries the children as FULL objects — there
+# is no separate child-type endpoint (it does not exist in DHIS2 2.40).
+#
+# Discrepancies are read via Get-VDisc, which filters to the records that carry a Kind — matching how the
+# seed gate consumes the result (`$disc | Where-Object { $_.Kind -in ... }`). That also sidesteps the
+# verifier's `, [object[]]@()` return idiom, which an `@(...)` wrapper would otherwise count as one element.
+#
+# Run:  Invoke-Pester -Path scripts/modules/NeoIPC-Tools/Tests/MetadataVerify.Tests.ps1
+
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot '..') -Force
+
+InModuleScope 'NeoIPC-Tools' {
+
+    Describe 'Test-NeoIPCMetadataImport (round-trip verifier)' {
+        BeforeAll {
+            $script:VAuth = @{ Basic = 'ignored-by-the-mock' }
+            function Get-VDisc($Package) {
+                $d = Test-NeoIPCMetadataImport -Package $Package -Auth $script:VAuth
+                , @($d | Where-Object { $_.Kind })
+            }
+        }
+        BeforeEach {
+            $script:VState = @{}
+            Mock Invoke-NeoIPCDhis2Get {
+                $t = $Path -replace '^api/', ''
+                $items = if ($script:VState.ContainsKey($t)) { @($script:VState[$t]) } else { @() }
+                [pscustomobject]@{ $t = $items }
+            }
+        }
+
+        It 'reports nothing for a perfect round-trip' {
+            $script:VState = @{ optionGroupSets = @([pscustomobject]@{ id = 'ogsAAA00001'; code = 'OGS1'
+                        optionGroups = @([pscustomobject]@{ id = 'og0000000a1' }, [pscustomobject]@{ id = 'og0000000b2' }) }) }
+            $pkg = @{ optionGroupSets = @([ordered]@{ id = 'ogsAAA00001'; code = 'OGS1'
+                        optionGroups = @([ordered]@{ id = 'og0000000a1' }, [ordered]@{ id = 'og0000000b2' }) }) }
+            (Get-VDisc $pkg).Count | Should -Be 0
+        }
+
+        It 'flags Missing when an object is absent after import' {
+            $script:VState = @{ optionSets = @() }
+            $pkg = @{ optionSets = @([ordered]@{ id = 'optSet00001'; code = 'OS1'; name = 'N'; valueType = 'TEXT' }) }
+            $disc = Get-VDisc $pkg
+            $disc.Count | Should -Be 1
+            $disc[0].Kind | Should -Be 'Missing'
+        }
+
+        It 'flags LinkDrop when a ref-collection member is missing' {
+            $script:VState = @{ optionGroupSets = @([pscustomobject]@{ id = 'ogs1'; code = 'OGS1'
+                        optionGroups = @([pscustomobject]@{ id = 'a' }) }) }
+            $pkg = @{ optionGroupSets = @([ordered]@{ id = 'ogs1'; code = 'OGS1'
+                        optionGroups = @([ordered]@{ id = 'a' }, [ordered]@{ id = 'b' }) }) }
+            $disc = Get-VDisc $pkg
+            $disc.Count | Should -Be 1
+            $disc[0].Kind | Should -Be 'LinkDrop'
+            $disc[0].Field | Should -Be 'optionGroups'
+        }
+
+        It 'flags OrderDrift when a genuinely ORDERED <list> reconnects out of order' {
+            # optionGroupSets.optionGroups is a DHIS2 <list> with sort_order -> in $NeoIPCMetadataServerOrderedRefs.
+            $script:VState = @{ optionGroupSets = @([pscustomobject]@{ id = 'ogs1'; code = 'OGS1'
+                        optionGroups = @([pscustomobject]@{ id = 'b' }, [pscustomobject]@{ id = 'a' }, [pscustomobject]@{ id = 'c' }) }) }
+            $pkg = @{ optionGroupSets = @([ordered]@{ id = 'ogs1'; code = 'OGS1'
+                        optionGroups = @([ordered]@{ id = 'a' }, [ordered]@{ id = 'b' }, [ordered]@{ id = 'c' }) }) }
+            $disc = Get-VDisc $pkg
+            $disc.Count | Should -Be 1
+            $disc[0].Kind | Should -Be 'OrderDrift'
+            $disc[0].Field | Should -Be 'optionGroups'
+        }
+
+        It 'does NOT flag dataElementGroups.dataElements reordered (idArrayOrdered in the type map, but a DHIS2 <set>)' {
+            # dataElementGroups.members is a <set> (read back in hash order); it is excluded from the server-ordered
+            # set, so a reordering must NOT produce a (fatal) OrderDrift. This is the regression the review caught.
+            $script:VState = @{ dataElementGroups = @([pscustomobject]@{ id = 'deg1'; code = 'DEG1'; name = 'G'
+                        dataElements = @([pscustomobject]@{ id = 'de2' }, [pscustomobject]@{ id = 'de1' }, [pscustomobject]@{ id = 'de3' }) }) }
+            $pkg = @{ dataElementGroups = @([ordered]@{ id = 'deg1'; code = 'DEG1'; name = 'G'
+                        dataElements = @([ordered]@{ id = 'de1' }, [ordered]@{ id = 'de2' }, [ordered]@{ id = 'de3' }) }) }
+            (Get-VDisc $pkg).Count | Should -Be 0
+        }
+
+        It 'does NOT flag an UNORDERED ref-collection (idArray) that is merely reordered' {
+            $script:VState = @{ organisationUnitGroupSets = @([pscustomobject]@{ id = 'ougs1'; code = 'OUGS1'
+                        organisationUnitGroups = @([pscustomobject]@{ id = 'oug2' }, [pscustomobject]@{ id = 'oug1' }) }) }
+            $pkg = @{ organisationUnitGroupSets = @([ordered]@{ id = 'ougs1'; code = 'OUGS1'
+                        organisationUnitGroups = @([ordered]@{ id = 'oug1' }, [ordered]@{ id = 'oug2' }) }) }
+            (Get-VDisc $pkg).Count | Should -Be 0
+        }
+
+        It 'flags ValueDrop on a dropped stringArray value and ignores reordering' {
+            $script:VState = @{ userRoles = @([pscustomobject]@{ id = 'ur1'; code = 'UR1'; name = 'R'
+                        authorities = @('F_Z', 'F_X') }) }   # F_Y dropped; remaining reordered
+            $pkg = @{ userRoles = @([ordered]@{ id = 'ur1'; code = 'UR1'; name = 'R'
+                        authorities = @('F_X', 'F_Y', 'F_Z') }) }
+            $disc = Get-VDisc $pkg
+            $vd = @($disc | Where-Object { $_.Kind -eq 'ValueDrop' })
+            $vd.Count | Should -Be 1
+            $vd[0].Field | Should -Be 'authorities'
+            $vd[0].Detail | Should -Match 'F_Y'
+            @($disc | Where-Object { $_.Kind -eq 'FieldMismatch' }).Count | Should -Be 0
+        }
+
+        It 'flags ValueDrop when a stringArray is entirely absent from the read-back' {
+            $script:VState = @{ userRoles = @([pscustomobject]@{ id = 'ur1'; code = 'UR1'; name = 'R' }) }   # authorities not returned
+            $pkg = @{ userRoles = @([ordered]@{ id = 'ur1'; code = 'UR1'; name = 'R'; authorities = @('F_A', 'F_B') }) }
+            $disc = Get-VDisc $pkg
+            $vd = @($disc | Where-Object { $_.Kind -eq 'ValueDrop' -and $_.Field -eq 'authorities' })
+            $vd.Count | Should -Be 1
+            $vd[0].Detail | Should -Match 'F_A'
+        }
+
+        It 'flags ValueDrop on a dropped intArray value (same branch as stringArray)' {
+            # dataElements.aggregationLevels is intArray; integer values coerce via [string].
+            $script:VState = @{ dataElements = @([pscustomobject]@{ id = 'deX0000001'; code = 'DEX'; name = 'N'; valueType = 'NUMBER'
+                        aggregationLevels = @(1) }) }
+            $pkg = @{ dataElements = @([ordered]@{ id = 'deX0000001'; code = 'DEX'; name = 'N'; valueType = 'NUMBER'
+                        aggregationLevels = @(1, 2, 3) }) }
+            $disc = Get-VDisc $pkg
+            $vd = @($disc | Where-Object { $_.Kind -eq 'ValueDrop' -and $_.Field -eq 'aggregationLevels' })
+            $vd.Count | Should -Be 1
+            $vd[0].Detail | Should -Match '2'
+        }
+
+        It 'verifies NestedOnly children inner fields (FieldMismatch on drift) from the parent read-back, membership intact' {
+            # The parent is fetched with the child collection expanded (fields=:owner,programStageDataElements[:owner]),
+            # so the inner field (compulsory) is diffed out of the parent response — there is no child-type endpoint.
+            $script:VState = @{
+                programStages = @([pscustomobject]@{ id = 'ps1'; name = 'S'
+                        programStageDataElements = @([pscustomobject]@{ id = 'psde1'; compulsory = $false
+                                dataElement = [pscustomobject]@{ id = 'de1' }; programStage = [pscustomobject]@{ id = 'ps1' } }) }) }
+            $pkg = @{ programStages = @([ordered]@{ id = 'ps1'; name = 'S'
+                        programStageDataElements = @([ordered]@{ id = 'psde1'; compulsory = $true
+                                dataElement = [ordered]@{ id = 'de1' }; programStage = [ordered]@{ id = 'ps1' } }) }) }
+            $disc = Get-VDisc $pkg
+            $fm = @($disc | Where-Object { $_.Type -eq 'programStageDataElements' -and $_.Kind -eq 'FieldMismatch' -and $_.Field -eq 'compulsory' })
+            $fm.Count | Should -Be 1
+            @($disc | Where-Object { $_.Kind -eq 'LinkDrop' }).Count | Should -Be 0
+        }
+
+        It 'flags Missing for a NestedOnly child dropped from its parent on import' {
+            # The reason children are diffed at all: a silently-dropped child must surface, not hide behind the parent.
+            $script:VState = @{ programStages = @([pscustomobject]@{ id = 'ps1'; name = 'S'
+                        programStageDataElements = @() }) }   # psde1 dropped
+            $pkg = @{ programStages = @([ordered]@{ id = 'ps1'; name = 'S'
+                        programStageDataElements = @([ordered]@{ id = 'psde1'; compulsory = $true
+                                dataElement = [ordered]@{ id = 'de1' }; programStage = [ordered]@{ id = 'ps1' } }) }) }
+            $disc = Get-VDisc $pkg
+            $m = @($disc | Where-Object { $_.Type -eq 'programStageDataElements' -and $_.Kind -eq 'Missing' -and $_.Id -eq 'psde1' })
+            $m.Count | Should -Be 1
+        }
+
+        It 'flags OrderDrift on a reordered NestedOnly attribute <list> (trackedEntityTypeAttributes)' {
+            # TrackedEntityType.trackedEntityTypeAttributes is a genuine <list> with sort_order, but the child has
+            # NO element-level sortOrder — its order lives solely on the parent, so it is checked positionally on
+            # the parent's child-id sequence (verified against refs/dhis2-core TrackedEntityType.hbm.xml).
+            $script:VState = @{ trackedEntityTypes = @([pscustomobject]@{ id = 'tet1'; name = 'T'
+                        trackedEntityTypeAttributes = @(
+                            [pscustomobject]@{ id = 'tta2'; trackedEntityAttribute = [pscustomobject]@{ id = 'tea2' }; trackedEntityType = [pscustomobject]@{ id = 'tet1' } }
+                            [pscustomobject]@{ id = 'tta1'; trackedEntityAttribute = [pscustomobject]@{ id = 'tea1' }; trackedEntityType = [pscustomobject]@{ id = 'tet1' } }) }) }
+            $pkg = @{ trackedEntityTypes = @([ordered]@{ id = 'tet1'; name = 'T'
+                        trackedEntityTypeAttributes = @(
+                            [ordered]@{ id = 'tta1'; trackedEntityAttribute = [ordered]@{ id = 'tea1' }; trackedEntityType = [ordered]@{ id = 'tet1' } }
+                            [ordered]@{ id = 'tta2'; trackedEntityAttribute = [ordered]@{ id = 'tea2' }; trackedEntityType = [ordered]@{ id = 'tet1' } }) }) }
+            $disc = Get-VDisc $pkg
+            $od = @($disc | Where-Object { $_.Kind -eq 'OrderDrift' -and $_.Field -eq 'trackedEntityTypeAttributes' })
+            $od.Count | Should -Be 1
+            $od[0].Type | Should -Be 'trackedEntityTypes'
+        }
+
+        It 'does NOT flag a NestedOnly attribute <list> kept in the same order' {
+            $script:VState = @{ trackedEntityTypes = @([pscustomobject]@{ id = 'tet1'; name = 'T'
+                        trackedEntityTypeAttributes = @(
+                            [pscustomobject]@{ id = 'tta1'; trackedEntityAttribute = [pscustomobject]@{ id = 'tea1' }; trackedEntityType = [pscustomobject]@{ id = 'tet1' } }
+                            [pscustomobject]@{ id = 'tta2'; trackedEntityAttribute = [pscustomobject]@{ id = 'tea2' }; trackedEntityType = [pscustomobject]@{ id = 'tet1' } }) }) }
+            $pkg = @{ trackedEntityTypes = @([ordered]@{ id = 'tet1'; name = 'T'
+                        trackedEntityTypeAttributes = @(
+                            [ordered]@{ id = 'tta1'; trackedEntityAttribute = [ordered]@{ id = 'tea1' }; trackedEntityType = [ordered]@{ id = 'tet1' } }
+                            [ordered]@{ id = 'tta2'; trackedEntityAttribute = [ordered]@{ id = 'tea2' }; trackedEntityType = [ordered]@{ id = 'tet1' } }) }) }
+            (Get-VDisc $pkg).Count | Should -Be 0
+        }
+
+        It 'leaves a synthetic-fk NestedOnly child (analyticsPeriodBoundaries) membership-only, not expanded/diffed' {
+            # analyticsPeriodBoundaries (FkSynthetic) is not expanded; its inner field drift below must NOT surface,
+            # and the parent membership stays intact -> clean.
+            $script:VState = @{ programIndicators = @([pscustomobject]@{ id = 'pi1'; code = 'PI1'; name = 'N'
+                        analyticsPeriodBoundaries = @([pscustomobject]@{ id = 'apb1' }) }) }
+            $pkg = @{ programIndicators = @([ordered]@{ id = 'pi1'; code = 'PI1'; name = 'N'
+                        analyticsPeriodBoundaries = @([ordered]@{ id = 'apb1'; analyticsPeriodBoundaryType = 'BEFORE_END_OF_REPORTING_PERIOD' }) }) }
+            $disc = Get-VDisc $pkg
+            @($disc | Where-Object { $_.Type -eq 'analyticsPeriodBoundaries' }).Count | Should -Be 0
+            $disc.Count | Should -Be 0
+        }
+
+        It 'round-trips option sortOrder by value (1-based dense — no spurious FieldMismatch)' {
+            # DHIS2 stores option sortOrder as the persisted 1-based list position (OptionSet.hbm.xml <list-index base=1>);
+            # the package already emits 1-based contiguous sortOrder, so the value matches and optionSet.options
+            # (idArray) reordering is ignored. Guards the "#4 is a non-issue" finding.
+            $script:VState = @{
+                optionSets = @([pscustomobject]@{ id = 'os1'; code = 'OS1'; name = 'N'; valueType = 'TEXT'
+                        options = @([pscustomobject]@{ id = 'o3' }, [pscustomobject]@{ id = 'o1' }, [pscustomobject]@{ id = 'o2' }) })
+                options    = @(
+                    [pscustomobject]@{ id = 'o1'; code = '1'; name = 'A'; sortOrder = 1; optionSet = [pscustomobject]@{ id = 'os1' } }
+                    [pscustomobject]@{ id = 'o2'; code = '2'; name = 'B'; sortOrder = 2; optionSet = [pscustomobject]@{ id = 'os1' } }
+                    [pscustomobject]@{ id = 'o3'; code = '3'; name = 'C'; sortOrder = 3; optionSet = [pscustomobject]@{ id = 'os1' } })
+            }
+            $pkg = @{
+                optionSets = @([ordered]@{ id = 'os1'; code = 'OS1'; name = 'N'; valueType = 'TEXT'
+                        options = @([ordered]@{ id = 'o1' }, [ordered]@{ id = 'o2' }, [ordered]@{ id = 'o3' }) })
+                options    = @(
+                    [ordered]@{ id = 'o1'; code = '1'; name = 'A'; sortOrder = 1; optionSet = [ordered]@{ id = 'os1' } }
+                    [ordered]@{ id = 'o2'; code = '2'; name = 'B'; sortOrder = 2; optionSet = [ordered]@{ id = 'os1' } }
+                    [ordered]@{ id = 'o3'; code = '3'; name = 'C'; sortOrder = 3; optionSet = [ordered]@{ id = 'os1' } })
+            }
+            (Get-VDisc $pkg).Count | Should -Be 0
+        }
+    }
+}


### PR DESCRIPTION
Two related strands of work on the reports pipeline and the metadata tooling.

### Report logging
Routes the reports through the shared `logger`-based logging (new `reports/common/logging.R`), so report runs emit structured, level-controlled diagnostics consistent with neoipcr's logging.

- Unifies log-verbosity control across all reports and retires the Partner-Report-specific debug parameter.
- Resolves log-message placeholders in the caller's frame.

### Metadata-import verification
Strengthens the metadata round-trip verifier in the `NeoIPC-Tools` module (`MetadataVerify.ps1`, with Pester coverage):

- Connects same-payload owned references on import and verifies them.
- Surfaces the DHIS2 import error message when the server returns a bare WebMessage, instead of a generic failure.
