### PR TITLE
Report render resilience: backtrace on failure, correct figure N

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,7 +68,7 @@ Reports live under `reports/`:
 
 ### Shared Infrastructure
 
-- **Shared R code**: `reports/common/` — `helpers.R` (locale parsing, string resource loading, DHIS2 connection helpers), `load-neoipcr.R`, `parse-args.R` (CLI arg parsing), `getDataset.R` (dataset export), `logging.R` (unified `logger`-based logging: `configure_logging()` + `logInfo`/`logVerbose`/`logDebug`/`logWarn`/`logError`), `reference.docx` (Word template)
+- **Shared R code**: `reports/common/` — `helpers.R` (locale parsing, string resource loading, DHIS2 connection helpers), `load-neoipcr.R`, `parse-args.R` (CLI arg parsing), `getDataset.R` (dataset export), `logging.R` (unified `logger`-based logging: `configure_logging()` + `logInfo`/`logVerbose`/`logDebug`/`logWarn`/`logError`, plus `with_error_trace()` to log a full backtrace when a render-time computation fails), `reference.docx` (Word template)
 - **Base string resources**: `reports/common.yaml` (English domain terms, table headers, footnotes)
 - **Pandoc filters**: `reports/filters/pandoc-quotes.lua` (language-aware typographic quotes)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Reports live under `reports/`:
 
 ### Shared Infrastructure
 
-- **Shared R code**: `reports/common/` — `helpers.R` (locale parsing, string resource loading, DHIS2 connection helpers), `load-neoipcr.R`, `parse-args.R` (CLI arg parsing), `getDataset.R` (dataset export), `logging.R` (unified `logger`-based logging: `configure_logging()` + `logInfo`/`logVerbose`/`logDebug`/`logWarn`/`logError`), `reference.docx` (Word template)
+- **Shared R code**: `reports/common/` — `helpers.R` (locale parsing, string resource loading, DHIS2 connection helpers), `load-neoipcr.R`, `parse-args.R` (CLI arg parsing), `getDataset.R` (dataset export), `logging.R` (unified `logger`-based logging: `configure_logging()` + `logInfo`/`logVerbose`/`logDebug`/`logWarn`/`logError`, plus `with_error_trace()` to log a full backtrace when a render-time computation fails), `reference.docx` (Word template)
 - **Base string resources**: `reports/common.yaml` (English domain terms, table headers, footnotes)
 - **Pandoc filters**: `reports/filters/pandoc-quotes.lua` (language-aware typographic quotes)
 

--- a/reports/Partner-Certificate/_setup.qmd
+++ b/reports/Partner-Certificate/_setup.qmd
@@ -58,7 +58,7 @@ if (is.null(data$startYear) || is.null(data$endYear) || is.null(data$hospitalNam
     port = params$dhis2Port, path = params$dhis2Path)
 
   # Import date from our DHIS2 server
-  ds <- neoipcr::import_dhis2(
+  ds <- with_error_trace(neoipcr::import_dhis2(
     connection_options = connection_options,
     dataset_options = neoipcr::dhis2_dataset_options(
       surveillance_end_from = startFrom,
@@ -70,7 +70,7 @@ if (is.null(data$startYear) || is.null(data$endYear) || is.null(data$hospitalNam
                            "delivery_mode", "siblings"),
       include_enrollment = "full",
       include_event = "full"
-      ))
+      )))
 
   department <- ds$metadata$departments |>
     dplyr::filter(code == data$departmentCode) |>

--- a/reports/Partner-Report/_setup.qmd
+++ b/reports/Partner-Report/_setup.qmd
@@ -1638,7 +1638,7 @@ if (!is.null(params$partnerDataFile)) {
     typedParams$unitCodes <- data_unit_codes
   }
 } else {
-  get_unit_data <- function() import_dhis2(
+  get_unit_data <- function() with_error_trace(import_dhis2(
       connection_options = get_connection_options(
         scheme = params$dhis2Scheme, hostname = params$dhis2Hostname,
         port = params$dhis2Port, path = params$dhis2Path),
@@ -1663,7 +1663,7 @@ if (!is.null(params$partnerDataFile)) {
         include_event = "full",
         include_test_data = isTRUE(params$includeTestData)
         )) |>
-    neoipcr::calculate_department_data()
+    neoipcr::calculate_department_data())
 
   benchmark_data <- if (is.null(reference_data)) {
     neoipcr::get_benchmark_data(

--- a/reports/Partner-Report/figures/_fig-bw.qmd
+++ b/reports/Partner-Report/figures/_fig-bw.qmd
@@ -18,7 +18,7 @@ include_localised("_fig-intro-birth-weight.Rmd")
 ```{r}
 #| label: fig-bw
 #| results: asis
-#| fig-cap: !expr 'paste(sR$`fig-cap`[[1]]$`fig-bw`, sprintf(sR$fig_sample_size, dR$own$numberOfPatients), sprintf(if("ref" %in% benchmark_data$dataset_names) sR$`fig-cap`[[2]]$bnch else sR$`fig-cap`[[2]]$`no-bnch`, sprintf("%i%s%s", 50L, sR$unit_separator, sR$gramm_abbreviation)), sprintf(if("ref" %in% benchmark_data$dataset_names) sR$`fig-cap`[[3]]$bnch else sR$`fig-cap`[[3]]$`no-bnch`, sprintf("%i%s", 25L, sR$percent_symbol), sprintf("%i%s", 50L, sR$percent_symbol), sprintf("%i%s", 75L, sR$percent_symbol)))'
+#| fig-cap: !expr 'paste(sR$`fig-cap`[[1]]$`fig-bw`, sprintf(sR$fig_sample_size, format_integer(if (is.null(benchmark_data$birth_weight_figure)) 0L else sum(dplyr::filter(benchmark_data$birth_weight_figure$frequency, dataset == "own")$n))), sprintf(if("ref" %in% benchmark_data$dataset_names) sR$`fig-cap`[[2]]$bnch else sR$`fig-cap`[[2]]$`no-bnch`, sprintf("%i%s%s", 50L, sR$unit_separator, sR$gramm_abbreviation)), sprintf(if("ref" %in% benchmark_data$dataset_names) sR$`fig-cap`[[3]]$bnch else sR$`fig-cap`[[3]]$`no-bnch`, sprintf("%i%s", 25L, sR$percent_symbol), sprintf("%i%s", 50L, sR$percent_symbol), sprintf("%i%s", 75L, sR$percent_symbol)))'
 
 has_bw <- FALSE
 if (!is.null(benchmark_data) && !is.null(benchmark_data$birth_weight_figure)) {

--- a/reports/Partner-Report/figures/_fig-ga.qmd
+++ b/reports/Partner-Report/figures/_fig-ga.qmd
@@ -18,7 +18,7 @@ include_localised("_fig-intro-gestational-age.Rmd")
 ```{r}
 #| label: fig-ga
 #| results: asis
-#| fig-cap: !expr 'paste(sR$`fig-cap`[[1]]$`fig-ga`, sprintf(sR$fig_sample_size, dR$own$numberOfPatients), sprintf(if("ref" %in% benchmark_data$dataset_names) sR$`fig-cap`[[2]]$bnch else sR$`fig-cap`[[2]]$`no-bnch`, sprintf("%i%s%s", 7L, sR$unit_separator, sR$day)), sprintf(if("ref" %in% benchmark_data$dataset_names) sR$`fig-cap`[[3]]$bnch else sR$`fig-cap`[[3]]$`no-bnch`, sprintf("%i%s", 25L, sR$percent_symbol), sprintf("%i%s", 50L, sR$percent_symbol), sprintf("%i%s", 75L, sR$percent_symbol)))'
+#| fig-cap: !expr 'paste(sR$`fig-cap`[[1]]$`fig-ga`, sprintf(sR$fig_sample_size, format_integer(if (is.null(benchmark_data$gestational_age_figure)) 0L else sum(dplyr::filter(benchmark_data$gestational_age_figure$frequency, dataset == "own")$n))), sprintf(if("ref" %in% benchmark_data$dataset_names) sR$`fig-cap`[[2]]$bnch else sR$`fig-cap`[[2]]$`no-bnch`, sprintf("%i%s%s", 7L, sR$unit_separator, sR$day)), sprintf(if("ref" %in% benchmark_data$dataset_names) sR$`fig-cap`[[3]]$bnch else sR$`fig-cap`[[3]]$`no-bnch`, sprintf("%i%s", 25L, sR$percent_symbol), sprintf("%i%s", 50L, sR$percent_symbol), sprintf("%i%s", 75L, sR$percent_symbol)))'
 
 has_ga <- FALSE
 if (!is.null(benchmark_data) && !is.null(benchmark_data$gestational_age_figure)) {

--- a/reports/Patient-Data-Report/_setup.qmd
+++ b/reports/Patient-Data-Report/_setup.qmd
@@ -29,7 +29,7 @@ connection_options <- get_connection_options(
   scheme = params$dhis2Scheme, hostname = params$dhis2Hostname,
   port = params$dhis2Port, path = params$dhis2Path)
 
-ds <- neoipcr::import_dhis2(
+ds <- with_error_trace(neoipcr::import_dhis2(
   connection_options = connection_options,
   dataset_options = neoipcr::dhis2_dataset_options(
     department_filter = department_code,
@@ -50,7 +50,7 @@ ds <- neoipcr::import_dhis2(
     include_incomplete = c("enrollments", "events"),
     translate = TRUE,
     locale = locale
-  ))
+  )))
 ```
 
 ```{r}

--- a/reports/Reference-Report/_setup.qmd
+++ b/reports/Reference-Report/_setup.qmd
@@ -201,22 +201,23 @@ if (!is.null(params$referenceDataFile)) {
         params$referenceDataFile,
         file.info(params$referenceDataFile)$size))
 } else {
-  reference_data <- import_dhis2(
-    connection_options = get_connection_options(
-      scheme = params$dhis2Scheme, hostname = params$dhis2Hostname,
-      port = params$dhis2Port, path = params$dhis2Path),
-    dataset_options = get_dataset_options(
-      reportingPeriodFrom = params$reportingPeriodFrom,
-      reportingPeriodTo = params$reportingPeriodTo,
-      birthWeightFrom = params$birthWeightFrom,
-      birthWeightTo = params$birthWeightTo,
-      gestationWeeksFrom = params$gestationWeeksFrom,
-      gestationWeeksTo = params$gestationWeeksTo,
-      reportingCountries = params$reportingCountries,
-      testUnitFilter = params$testUnitFilter,
-      defaultPatientFilter = params$defaultPatientFilter,
-      validationExceptionFile = params$validationExceptionFile)) |>
-    neoipcr::calculate_reference_data()
+  reference_data <- with_error_trace(
+    import_dhis2(
+      connection_options = get_connection_options(
+        scheme = params$dhis2Scheme, hostname = params$dhis2Hostname,
+        port = params$dhis2Port, path = params$dhis2Path),
+      dataset_options = get_dataset_options(
+        reportingPeriodFrom = params$reportingPeriodFrom,
+        reportingPeriodTo = params$reportingPeriodTo,
+        birthWeightFrom = params$birthWeightFrom,
+        birthWeightTo = params$birthWeightTo,
+        gestationWeeksFrom = params$gestationWeeksFrom,
+        gestationWeeksTo = params$gestationWeeksTo,
+        reportingCountries = params$reportingCountries,
+        testUnitFilter = params$testUnitFilter,
+        defaultPatientFilter = params$defaultPatientFilter,
+        validationExceptionFile = params$validationExceptionFile)) |>
+      neoipcr::calculate_reference_data())
 }
 
 ```

--- a/reports/Reference-Report/figures/_fig-bw.qmd
+++ b/reports/Reference-Report/figures/_fig-bw.qmd
@@ -1,6 +1,6 @@
 ```{r}
 #| label: fig-bw
-#| fig-cap: !expr 'paste(sR$`fig-cap`[[1]]$`fig-bw`, sprintf(sR$fig_sample_size, format_integer(ref_counts$n_patients)), sprintf(sR$`fig-cap`[[2]]$`no-bnch`, sprintf("%i%s%s", 50L, sR$unit_separator, sR$gramm_abbreviation)), sprintf(sR$`fig-cap`[[3]]$`no-bnch`, sprintf("%i%s", 25L, sR$percent_symbol), sprintf("%i%s", 50L, sR$percent_symbol), sprintf("%i%s", 75L, sR$percent_symbol)))'
+#| fig-cap: !expr 'paste(sR$`fig-cap`[[1]]$`fig-bw`, sprintf(sR$fig_sample_size, format_integer(sum(reference_data$birth_weight_figure$frequency$n))), sprintf(sR$`fig-cap`[[2]]$`no-bnch`, sprintf("%i%s%s", 50L, sR$unit_separator, sR$gramm_abbreviation)), sprintf(sR$`fig-cap`[[3]]$`no-bnch`, sprintf("%i%s", 25L, sR$percent_symbol), sprintf("%i%s", 50L, sR$percent_symbol), sprintf("%i%s", 75L, sR$percent_symbol)))'
 
 bw_scale_min <- reference_data$birth_weight_figure$scale$min
 bw_scale_max <- reference_data$birth_weight_figure$scale$max

--- a/reports/Reference-Report/figures/_fig-ga.qmd
+++ b/reports/Reference-Report/figures/_fig-ga.qmd
@@ -1,6 +1,6 @@
 ```{r}
 #| label: fig-ga
-#| fig-cap: !expr 'paste(sR$`fig-cap`[[1]]$`fig-ga`, sprintf(sR$fig_sample_size, format_integer(ref_counts$n_patients)), sprintf(sR$`fig-cap`[[2]]$`no-bnch`, sprintf("%i%s%s", 7L, sR$unit_separator, sR$day)), sprintf(sR$`fig-cap`[[3]]$`no-bnch`, sprintf("%i%s", 25L, sR$percent_symbol), sprintf("%i%s", 50L, sR$percent_symbol), sprintf("%i%s", 75L, sR$percent_symbol)))'
+#| fig-cap: !expr 'paste(sR$`fig-cap`[[1]]$`fig-ga`, sprintf(sR$fig_sample_size, format_integer(sum(reference_data$gestational_age_figure$frequency$n))), sprintf(sR$`fig-cap`[[2]]$`no-bnch`, sprintf("%i%s%s", 7L, sR$unit_separator, sR$day)), sprintf(sR$`fig-cap`[[3]]$`no-bnch`, sprintf("%i%s", 25L, sR$percent_symbol), sprintf("%i%s", 50L, sR$percent_symbol), sprintf("%i%s", 75L, sR$percent_symbol)))'
 
 ga_scale_min <- reference_data$gestational_age_figure$scale$min
 ga_scale_max <- reference_data$gestational_age_figure$scale$max

--- a/reports/Validation-Report/_setup.qmd
+++ b/reports/Validation-Report/_setup.qmd
@@ -54,9 +54,9 @@ dataset_options <- neoipcr::dhis2_dataset_options(
   include_invalid_patients = TRUE,
   locale = locale)
 
-data <- neoipcr::import_dhis2(
+data <- with_error_trace(neoipcr::import_dhis2(
   connection_options = connection_options,
-  dataset_options = dataset_options)
+  dataset_options = dataset_options))
 ```
 
 ```{r Filter metadata to in-scope departments}

--- a/reports/common/logging.R
+++ b/reports/common/logging.R
@@ -163,3 +163,26 @@ logWarn <- function(..., namespace = .report_log$namespace) {
 logError <- function(..., namespace = .report_log$namespace) {
   logger::log_error(..., namespace = namespace, .topenv = parent.frame())
 }
+
+# Run `expr`, logging a full R backtrace if it raises, then let the error
+# propagate. A failure deep in neoipcr (e.g. a quantile() on an unexpected NA)
+# otherwise surfaces only as an opaque one-line error with no call site. The
+# calling handler runs before the stack unwinds, so rlang::trace_back() captures
+# the frame that raised. Emitting through the logger keeps the trace on the
+# report's namespaced channel — reliably captured by the .NET service's JSON log
+# when NEOIPC_LOG_FILE is set, and written to stderr on a console render.
+# skip_formatter stops logger glue-interpolating braces in the trace text; the
+# try() guard ensures a failure in the logging channel itself (e.g. an
+# unwritable NEOIPC_LOG_FILE) can never replace the original error this helper
+# exists to surface.
+with_error_trace <- function(expr) {
+  withCallingHandlers(
+    expr,
+    error = function(e) {
+      try(
+        logError(logger::skip_formatter(paste0(
+          conditionMessage(e), "\n",
+          paste(format(rlang::trace_back()), collapse = "\n")))),
+        silent = TRUE)
+    })
+}


### PR DESCRIPTION
Adds `with_error_trace()` to the shared logging layer and wraps every report's render-time import/compute, so a failure deep in neoipcr surfaces with a full R backtrace on the report's log channel instead of an opaque, location-less error.

Pairs with the neoipcr optional-attribute NA fix (NeoIPC/neoipcr#19): the birth-weight and gestational-age distribution figures now plot only patients with a recorded value, so their sample-size captions report the recorded count rather than the total patient count.