### PR TITLE
Protocol documentation catalogue maintenance from Hosted Weblate

### DIFF
--- a/po/documentation.af.po
+++ b/po/documentation.af.po
@@ -30,22 +30,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -62,12 +91,27 @@ msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
 msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
 msgstr ""
 
 #. type: Title ===
@@ -78,17 +122,30 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
@@ -98,22 +155,31 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
 msgstr ""
 
 #. type: Title ===
@@ -124,7 +190,24 @@ msgstr ""
 
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
 msgstr ""
 
 #. type: Title ===
@@ -135,22 +218,43 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -170,7 +274,9 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -190,22 +296,42 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
 msgstr ""
 
 #. type: Title ==
@@ -222,7 +348,16 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
 msgstr ""
 
 #. type: Title ====
@@ -233,7 +368,22 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
 msgstr ""
 
 #. type: Title ====
@@ -244,22 +394,49 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
 msgstr ""
 
 #. type: Title ===
@@ -270,47 +447,80 @@ msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
 msgstr ""
 
 #. type: Title ==
@@ -321,17 +531,41 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
 msgstr ""
 
 #. type: #data-collection
@@ -346,7 +580,9 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
 msgstr ""
 
 #. type: #data-collection
@@ -356,7 +592,10 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
 msgstr ""
 
 #. type: #data-collection
@@ -385,17 +624,25 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
 msgstr ""
 
 #. type: Title ===
@@ -426,7 +673,10 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
 msgstr ""
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -463,7 +713,9 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
 msgstr ""
 
 #. type: Title ===
@@ -474,7 +726,10 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
 msgstr ""
 
 #. type: Title ====
@@ -485,27 +740,57 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
 msgstr ""
 
 #. type: Block title
@@ -549,12 +834,25 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
 msgstr ""
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -580,17 +878,41 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
 msgstr ""
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -616,7 +938,17 @@ msgstr ""
 
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
 msgstr ""
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -642,27 +974,68 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
 msgstr ""
 
 #. type: Title ====
@@ -673,7 +1046,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -700,7 +1078,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -720,7 +1103,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -747,7 +1135,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -773,7 +1166,11 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
@@ -803,7 +1200,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
 msgstr ""
 
 #. type: Block title
@@ -828,12 +1230,18 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
 msgstr ""
 
 #. type: Title ====
@@ -844,17 +1252,26 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
 msgstr ""
 
 #. type: loweralpha
@@ -883,7 +1300,9 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
 msgstr ""
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -915,17 +1334,38 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
@@ -950,7 +1390,9 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
 msgstr ""
 
 #. type: Block title
@@ -974,32 +1416,65 @@ msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
 msgstr ""
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
@@ -1055,17 +1530,26 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1075,17 +1559,21 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1103,7 +1591,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1129,7 +1620,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
 msgstr ""
 
 #. type: Title ====
@@ -1140,7 +1633,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1151,7 +1646,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1162,7 +1659,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
 msgstr ""
 
 #. type: Title ==
@@ -1173,12 +1673,22 @@ msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
 msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1212,12 +1722,21 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
 msgstr ""
 
 #. type: Labeled list
@@ -1228,7 +1747,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
 msgstr ""
 
 #. type: Labeled list
@@ -1244,7 +1766,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
 msgstr ""
 
 #. type: Labeled list
@@ -1255,7 +1782,13 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
 msgstr ""
 
 #. type: Labeled list
@@ -1266,7 +1799,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
 msgstr ""
 
 #. type: Labeled list
@@ -1277,7 +1815,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
@@ -1340,7 +1881,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
 msgstr ""
 
 #. type: Title ====
@@ -1357,7 +1901,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
 msgstr ""
 
 #. type: Labeled list
@@ -1368,12 +1914,16 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
@@ -1394,7 +1944,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
 msgstr ""
 
 #. type: Title ====
@@ -1411,7 +1964,8 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
-msgid "The day the data collection and follow-up for the patient has been stopped."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
 msgstr ""
 
 #. type: Labeled list
@@ -1443,7 +1997,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
 msgstr ""
 
 #. type: Labeled list
@@ -1454,7 +2011,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1465,7 +2024,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1476,7 +2037,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1487,7 +2050,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1498,7 +2064,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
 msgstr ""
 
 #. type: Labeled list
@@ -1509,7 +2078,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
 msgstr ""
 
 #. type: Labeled list
@@ -1520,7 +2091,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
 msgstr ""
 
 #. type: Labeled list
@@ -1531,7 +2105,17 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
 msgstr ""
 
 #. type: Labeled list
@@ -1542,7 +2126,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
 msgstr ""
 
 #. type: Title ===
@@ -1570,7 +2156,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
 msgstr ""
 
 #. type: Labeled list
@@ -1581,7 +2170,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
 msgstr ""
 
 #. type: Labeled list
@@ -1592,7 +2186,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
 msgstr ""
 
 #. type: Labeled list
@@ -1603,7 +2200,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
 msgstr ""
 
 #. type: Labeled list
@@ -1614,7 +2213,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
 msgstr ""
 
 #. type: Labeled list
@@ -1625,7 +2228,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
 msgstr ""
 
 #. type: Labeled list
@@ -1636,7 +2245,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
 msgstr ""
 
 #. type: Labeled list
@@ -1647,7 +2261,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
 msgstr ""
 
 #. type: Labeled list
@@ -1658,7 +2276,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
 msgstr ""
 
 #. type: Labeled list
@@ -1669,7 +2291,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
 msgstr ""
 
 #. type: Labeled list
@@ -1713,7 +2338,8 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
-msgid "A patient with severe systemic disease that is a constant threat to life"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
 msgstr ""
 
 #. type: Labeled list
@@ -1729,7 +2355,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 msgstr ""
 
 #. type: Labeled list
@@ -1761,7 +2389,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -1772,7 +2402,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
@@ -1799,12 +2431,21 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
 msgstr ""
 
 #. type: Labeled list
@@ -1815,7 +2456,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
 msgstr ""
 
 #. type: Labeled list
@@ -1826,7 +2470,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
 msgstr ""
 
 #. type: Labeled list
@@ -1837,7 +2485,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
 msgstr ""
 
 #. type: Block title
@@ -1848,27 +2502,44 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
@@ -1878,12 +2549,19 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
 msgstr ""
 
 #. type: Title ===
@@ -1906,7 +2584,9 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
 msgstr ""
 
 #. type: Labeled list
@@ -1917,7 +2597,12 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
 msgstr ""
 
 #. type: Labeled list
@@ -1948,17 +2633,25 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -1968,17 +2661,22 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
 msgstr ""
 
 #. type: Labeled list
@@ -1989,22 +2687,36 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -2026,12 +2738,17 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2046,12 +2763,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2117,7 +2837,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2128,7 +2852,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2139,7 +2865,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
 msgstr ""
 
 #. type: Labeled list
@@ -2150,7 +2878,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
 msgstr ""
 
 #. type: Labeled list
@@ -2161,7 +2897,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2172,7 +2910,16 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Labeled list
@@ -2183,7 +2930,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2194,7 +2945,10 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
 msgstr ""
 
 #. type: Labeled list
@@ -2205,7 +2959,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
 msgstr ""
 
 #. type: Title ====
@@ -2245,7 +3001,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
 msgstr ""
 
 #. type: Plain text
@@ -2260,13 +3018,17 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
 msgstr ""
 
 #. type: Labeled list
@@ -2288,12 +3050,18 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
 msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2315,7 +3083,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2326,7 +3098,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2348,7 +3122,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2359,7 +3137,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2370,7 +3150,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Labeled list
@@ -2381,7 +3165,10 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
 msgstr ""
 
 #. type: Labeled list
@@ -2409,7 +3196,10 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -2421,12 +3211,17 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
 msgstr ""
 
 #. type: Labeled list
@@ -2437,27 +3232,44 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
 msgstr ""
 
 #. type: Labeled list
@@ -2468,7 +3280,11 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Title ==
@@ -2479,12 +3295,17 @@ msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
 msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
 msgstr ""
 
 #. type: #data-analysis
@@ -2521,27 +3342,38 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2552,47 +3384,76 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2603,22 +3464,33 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: Title ===
@@ -2635,22 +3507,32 @@ msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: Title ====
@@ -2661,42 +3543,70 @@ msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2707,7 +3617,18 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
@@ -2727,32 +3648,50 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
 msgstr ""
 
 #. type: Title ==
@@ -2769,7 +3708,9 @@ msgstr ""
 
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
 msgstr ""
 
 #. type: Labeled list
@@ -3256,7 +4197,9 @@ msgstr ""
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
 msgstr ""
 
 #. type: #imprint
@@ -3282,7 +4225,9 @@ msgstr ""
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3293,17 +4238,23 @@ msgstr ""
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3311,7 +4262,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:8
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3328,7 +4281,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:42
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3336,7 +4291,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3344,7 +4301,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:12
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3376,7 +4335,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:16
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3436,7 +4397,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3453,7 +4423,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3470,22 +4442,36 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
 msgstr ""
 
 #. type: Plain text
@@ -3496,7 +4482,11 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: Block title
@@ -3507,7 +4497,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
 msgstr ""
 
 #. type: Block title
@@ -3519,7 +4511,9 @@ msgstr ""
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3535,12 +4529,22 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3551,7 +4555,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: Block title
@@ -3562,7 +4568,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3603,7 +4611,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3650,32 +4659,51 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3690,7 +4718,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3700,7 +4730,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3710,12 +4742,15 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3725,27 +4760,40 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
 msgstr ""
 
 #. type: Plain text
@@ -3755,12 +4803,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
 msgstr ""
 
 #. type: Block title
@@ -3776,7 +4828,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
 msgstr ""
 
 #. type: loweralpha
@@ -3786,47 +4839,75 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
 msgstr ""
 
 #. type: Content of: <root><data><value>

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -11,7 +11,8 @@ msgstr ""
 "POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2025-12-30 17:59+0100\n"
 "Last-Translator: Brar Piening <brar.piening@charite.de>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/de/>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-"
+"core-surveillance-protocol/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -32,22 +33,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -64,13 +94,47 @@ msgstr "Was lesen Sie hier?"
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
-msgstr "Dieses Dokument ist das Surveillance-Protokoll für das Kernmodul der NeoIPC-Surveillance, das die Surveillance nosokomialer Infektionen bei Neugeborenen mit sehr niedrigem Geburtsgewicht [Very Low Birth Weight] (VLBW)/Sehr Frühgeborenen [Very Preterm] (VPT) umfasst.  Es ist Teil eines Toolkits für die Surveillance von nosokomialen Infektionen (NI) in der Neonatologie, das wir im Rahmen des NeoIPC-Projekts entwickelt haben.  Wenn Sie eine Surveillance von früh auftretenden [early-onset] Infektionen oder nosokomialen Infektionen bei Neugeborenen mit einem Geburtsgewicht von über 1500 g und einem Gestationsalter von mehr als 32 Wochen durchführen möchten, bietet das Toolkit zusätzliche Methoden, die in separaten Protokollen behandelt werden."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
+msgstr ""
+"Dieses Dokument ist das Surveillance-Protokoll für das Kernmodul der NeoIPC-"
+"Surveillance, das die Surveillance nosokomialer Infektionen bei Neugeborenen "
+"mit sehr niedrigem Geburtsgewicht [Very Low Birth Weight] (VLBW)/Sehr "
+"Frühgeborenen [Very Preterm] (VPT) umfasst.  Es ist Teil eines Toolkits für "
+"die Surveillance von nosokomialen Infektionen (NI) in der Neonatologie, das "
+"wir im Rahmen des NeoIPC-Projekts entwickelt haben.  Wenn Sie eine "
+"Surveillance von früh auftretenden [early-onset] Infektionen oder "
+"nosokomialen Infektionen bei Neugeborenen mit einem Geburtsgewicht von über "
+"1500 g und einem Gestationsalter von mehr als 32 Wochen durchführen möchten, "
+"bietet das Toolkit zusätzliche Methoden, die in separaten Protokollen "
+"behandelt werden."
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
-msgstr "Dieses Protokoll bietet methodische Hinweise und Unterstützung für die Surveillance von nosokomialen Infektionen auf Neugeborenenstationen oder für diejenigen, die die Entwicklung eines Programms zur Surveillance von nosokomialen Infektionen planen.  Wenn Sie sich an die hier aufgeführten Methoden und Definitionen halten, können Sie sicherstellen, dass die von Ihnen generierten Surveillance-Daten mit den Referenzdaten des NeoIPC-Projekts vergleichbar sind, auch wenn Sie nicht aktiv an dem Projekt beteiligt sind."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
+msgstr ""
+"Dieses Protokoll bietet methodische Hinweise und Unterstützung für die "
+"Surveillance von nosokomialen Infektionen auf Neugeborenenstationen oder für "
+"diejenigen, die die Entwicklung eines Programms zur Surveillance von "
+"nosokomialen Infektionen planen.  Wenn Sie sich an die hier aufgeführten "
+"Methoden und Definitionen halten, können Sie sicherstellen, dass die von "
+"Ihnen generierten Surveillance-Daten mit den Referenzdaten des NeoIPC-"
+"Projekts vergleichbar sind, auch wenn Sie nicht aktiv an dem Projekt "
+"beteiligt sind."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:29
@@ -80,18 +144,45 @@ msgstr "Was ist das NeoIPC Projekt"
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
-msgstr "Im Rahmen des NeoIPC-Projekts möchten wir Sie mit Interventionen und Strategien zur Infektionsprävention und -kontrolle (IPC) auf Ihrer Neugeborenen-Intensivstation unterstützen, insbesondere wenn Sie eine hohe Prävalenz von nosokomialen Infektionen oder multiresistenten Erregern (MRE) beobachten.  Wir sind ein internationales Team von Klinikern und Wissenschaftlern aus 13 kooperierenden Partnerinstitutionen mit nachgewiesener Erfahrung in den Bereichen neonatologische Intensivmedizin, neonatale Infektionen, Infektionsprävention und -kontrolle (IPC), Implementierungswissenschaft, Mikrobiologie und Surveillance, die an diesem Projekt mitarbeiten um zwei übergeordnete Ziele zu erreichen:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
+msgstr ""
+"Im Rahmen des NeoIPC-Projekts möchten wir Sie mit Interventionen und "
+"Strategien zur Infektionsprävention und -kontrolle (IPC) auf Ihrer "
+"Neugeborenen-Intensivstation unterstützen, insbesondere wenn Sie eine hohe "
+"Prävalenz von nosokomialen Infektionen oder multiresistenten Erregern (MRE) "
+"beobachten.  Wir sind ein internationales Team von Klinikern und "
+"Wissenschaftlern aus 13 kooperierenden Partnerinstitutionen mit "
+"nachgewiesener Erfahrung in den Bereichen neonatologische Intensivmedizin, "
+"neonatale Infektionen, Infektionsprävention und -kontrolle (IPC), "
+"Implementierungswissenschaft, Mikrobiologie und Surveillance, die an diesem "
+"Projekt mitarbeiten um zwei übergeordnete Ziele zu erreichen:"
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
-msgstr "Entwicklung und Umsetzung eines innovativen Ansatzes zur Bewertung von IPC-Interventionen in der Neonatologie durch:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
+msgstr ""
+"Entwicklung und Umsetzung eines innovativen Ansatzes zur Bewertung von IPC-"
+"Interventionen in der Neonatologie durch:"
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
-msgstr "Robuste Bewertung der Wirksamkeit von Interventionen in einer randomisierten kontrollierten Studie (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
+msgstr ""
+"Robuste Bewertung der Wirksamkeit von Interventionen in einer randomisierten "
+"kontrollierten Studie (RCT)"
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:36
@@ -100,23 +191,43 @@ msgstr "Identifizierung einer geeigneten Umsetzungsstrategie."
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
-msgstr "Generierung weithin relevanter und global übertragbarer Ergebnisse zur Verbesserung von IPC in der Neugeborenenversorgung durch:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
+msgstr ""
+"Generierung weithin relevanter und global übertragbarer Ergebnisse zur "
+"Verbesserung von IPC in der Neugeborenenversorgung durch:"
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
-msgstr "Bildung eines klinischen Praxisnetzwerks zur Unterstützung der Implementierung von IPC in der Neonatologie, in einer Vielzahl von unterschiedlichen Bereichen, wie Neugeborenen-Intensivstation (NICU), High Care-, Special Care- und Känguru-Pflege (KC) Stationen."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgstr ""
+"Bildung eines klinischen Praxisnetzwerks zur Unterstützung der "
+"Implementierung von IPC in der Neonatologie, in einer Vielzahl von "
+"unterschiedlichen Bereichen, wie Neugeborenen-Intensivstation (NICU), High "
+"Care-, Special Care- und Känguru-Pflege (KC) Stationen."
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
-msgstr "Entwicklung einer offenen Struktur zur gezielten Surveillance von IPC-Prozessen und -Ergebnissen in einer Vielzahl von Umgebungen."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
+msgstr ""
+"Entwicklung einer offenen Struktur zur gezielten Surveillance von IPC-"
+"Prozessen und -Ergebnissen in einer Vielzahl von Umgebungen."
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
-msgstr "Dieses Projekt wurde vom Forschungs- und Innovationsprogramm Horizon 2020 der Europäischen Union im Rahmen der Finanzhilfevereinbarung Nr. 965328 finanziert."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
+msgstr ""
+"Dieses Projekt wurde vom Forschungs- und Innovationsprogramm Horizon 2020 "
+"der Europäischen Union im Rahmen der Finanzhilfevereinbarung Nr. 965328 "
+"finanziert."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:43
@@ -126,8 +237,44 @@ msgstr "Hintergrund"
 
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
-msgstr "Weltweit gehören Neugeborene und insbesondere Frühgeborene zu den Patientengruppen mit der höchsten Inzidenz nosokomialer Infektionen.  Einige dieser Infektionen können durch infektionspräventive Maßnahmen verhindert werden, die auf jeder einzelnen Neugeborenenstation umgesetzt und an die spezifischen Infektionsrisiken der Patienten angepasst werden müssen.  In vielen Krankenhäusern in Europa und weltweit verfügen Ärzte und Pflegekräfte nicht über gute Daten, um die Krankheitslast durch nosokomiale Infektionen und die zu ihrer Entwicklung beitragenden Risikofaktoren einzuschätzen oder die Wirksamkeit von Maßnahmen zur Infektionsprävention zu bewerten.  Unterstützung für die Surveillance von nosokomialen Infektionen bei Neugeborenen oder Referenzdaten für Benchmarking sind in den meisten Ländern nicht verfügbar.  Wo nationale und supranationale Datenerhebungssysteme existieren, haben sie häufig einen breiten Ansatz, der nur begrenzt in der Lage ist, die Situation in Bezug auf Infektionsprävention und -kontrolle zu beurteilen.  Kurzfristig versuchen wir, diese Situation zu verbessern, indem wir Menschen, die an IPC-Surveillance in der Neonatologie interessiert sind, Werkzeuge und Methoden für den Einstieg zur Verfügung stellen um möglicherweise langfristig zur Bildung regionaler Surveillance-Infrastrukturen beitragen."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
+msgstr ""
+"Weltweit gehören Neugeborene und insbesondere Frühgeborene zu den "
+"Patientengruppen mit der höchsten Inzidenz nosokomialer Infektionen.  Einige "
+"dieser Infektionen können durch infektionspräventive Maßnahmen verhindert "
+"werden, die auf jeder einzelnen Neugeborenenstation umgesetzt und an die "
+"spezifischen Infektionsrisiken der Patienten angepasst werden müssen.  In "
+"vielen Krankenhäusern in Europa und weltweit verfügen Ärzte und Pflegekräfte "
+"nicht über gute Daten, um die Krankheitslast durch nosokomiale Infektionen "
+"und die zu ihrer Entwicklung beitragenden Risikofaktoren einzuschätzen oder "
+"die Wirksamkeit von Maßnahmen zur Infektionsprävention zu bewerten.  "
+"Unterstützung für die Surveillance von nosokomialen Infektionen bei "
+"Neugeborenen oder Referenzdaten für Benchmarking sind in den meisten Ländern "
+"nicht verfügbar.  Wo nationale und supranationale Datenerhebungssysteme "
+"existieren, haben sie häufig einen breiten Ansatz, der nur begrenzt in der "
+"Lage ist, die Situation in Bezug auf Infektionsprävention und -kontrolle zu "
+"beurteilen.  Kurzfristig versuchen wir, diese Situation zu verbessern, indem "
+"wir Menschen, die an IPC-Surveillance in der Neonatologie interessiert sind, "
+"Werkzeuge und Methoden für den Einstieg zur Verfügung stellen um "
+"möglicherweise langfristig zur Bildung regionaler Surveillance-"
+"Infrastrukturen beitragen."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:52
@@ -137,23 +284,70 @@ msgstr "Hinweise zur Nutzung und Teilnahmevoraussetzungen"
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
-msgstr "Wenn Sie mit der Erfassung von Daten mithilfe der NeoIPC Surveillance-Methoden und -Werkzeuge beginnen möchten, können Sie dies einfach tun, ohne uns um Erlaubnis zu fragen oder Gebühren zu zahlen.  Alle Handbücher und Tools können kostenlos verwendet werden, und Sie können sie sofort verwenden, wenn Sie der Meinung sind, dass sie zur Qualitätsverbesserung der Infektionsprävention in Ihrer Abteilung beitragen."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
+msgstr ""
+"Wenn Sie mit der Erfassung von Daten mithilfe der NeoIPC Surveillance-"
+"Methoden und -Werkzeuge beginnen möchten, können Sie dies einfach tun, ohne "
+"uns um Erlaubnis zu fragen oder Gebühren zu zahlen.  Alle Handbücher und "
+"Tools können kostenlos verwendet werden, und Sie können sie sofort "
+"verwenden, wenn Sie der Meinung sind, dass sie zur Qualitätsverbesserung der "
+"Infektionsprävention in Ihrer Abteilung beitragen."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
-msgstr "Indem Sie mit Papierformularen beginnen und Berechnungen mit Stift und Papier oder mit einer Tabellenkalkulation durchführen, haben Sie eine sehr niedrige Eintrittsbarriere, und es kann Ihnen sogar helfen, ein gründliches Verständnis der Berechnungen zu erlangen, die intern von den fortgeschritteneren Tools durchgeführt werden.  Wenn Sie die Dinge über einen längeren Zeitraum effektiv am Laufen halten möchten und über die erforderlichen Ressourcen verfügen, möchten Sie möglicherweise von der Verwendung der fortschrittlicheren Surveilance-Software vor Ort profitieren oder sich an NeoIPC oder einem regionalen Surveilance-Netzwerk auf der Grundlage seiner Methoden beteiligen."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
+msgstr ""
+"Indem Sie mit Papierformularen beginnen und Berechnungen mit Stift und "
+"Papier oder mit einer Tabellenkalkulation durchführen, haben Sie eine sehr "
+"niedrige Eintrittsbarriere, und es kann Ihnen sogar helfen, ein gründliches "
+"Verständnis der Berechnungen zu erlangen, die intern von den "
+"fortgeschritteneren Tools durchgeführt werden.  Wenn Sie die Dinge über "
+"einen längeren Zeitraum effektiv am Laufen halten möchten und über die "
+"erforderlichen Ressourcen verfügen, möchten Sie möglicherweise von der "
+"Verwendung der fortschrittlicheren Surveilance-Software vor Ort profitieren "
+"oder sich an NeoIPC oder einem regionalen Surveilance-Netzwerk auf der "
+"Grundlage seiner Methoden beteiligen."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
-msgstr "Für einen langfristigen Erfolg bei der Surveilance nosokomialer Infektionen ist es entscheidend, Daten zu sammeln und verlässliche und vergleichbare Informationen in Ihrer Abteilung über einen langen Zeitraum zu produzieren.  Um die Erfassung solcher Daten zu erleichtern, möchten Sie möglicherweise Daten zum NeoIPC-Surveilance-Netzwerk beitragen.  Diese Daten können verwendet werden, um Auswertungen zu erstellen und die Infektionsraten Ihrer Neugeborenenabteilung mit anderen zu vergleichen."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
+msgstr ""
+"Für einen langfristigen Erfolg bei der Surveilance nosokomialer Infektionen "
+"ist es entscheidend, Daten zu sammeln und verlässliche und vergleichbare "
+"Informationen in Ihrer Abteilung über einen langen Zeitraum zu produzieren.  "
+"Um die Erfassung solcher Daten zu erleichtern, möchten Sie möglicherweise "
+"Daten zum NeoIPC-Surveilance-Netzwerk beitragen.  Diese Daten können "
+"verwendet werden, um Auswertungen zu erstellen und die Infektionsraten Ihrer "
+"Neugeborenenabteilung mit anderen zu vergleichen."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
-msgstr "Wenn Sie Daten sammeln und übermitteln und für die Qualitätsverbesserung verantwortlich sind, ist es wichtig, dass Sie folgendes Dinge gut verstanden haben:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
+msgstr ""
+"Wenn Sie Daten sammeln und übermitteln und für die Qualitätsverbesserung "
+"verantwortlich sind, ist es wichtig, dass Sie folgendes Dinge gut verstanden "
+"haben:"
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:66
@@ -172,8 +366,13 @@ msgstr "Verfahren zum Ausfüllen und Speichern von Formularen"
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
-msgstr "Datensicherheit und Datenschutz (Schutz von Informationen, die zur Identifizierung eines Patienten außerhalb Ihrer Abteilung oder Ihres Krankenhauses verwendet werden könnten)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
+msgstr ""
+"Datensicherheit und Datenschutz (Schutz von Informationen, die zur "
+"Identifizierung eines Patienten außerhalb Ihrer Abteilung oder Ihres "
+"Krankenhauses verwendet werden könnten)"
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:70
@@ -188,27 +387,71 @@ msgstr "Verfahren für Datenverwaltung und Datenabschluss"
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:72
 msgid "Use of NeoIPC reports for monitoring and improving patient care"
-msgstr "Verwendung von NeoIPC-Auswertungen zur Beobachtung und Verbesserung der Patientenversorgung"
+msgstr ""
+"Verwendung von NeoIPC-Auswertungen zur Beobachtung und Verbesserung der "
+"Patientenversorgung"
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
-msgstr "Sie sollten sicherstellen, dass das gesamte Datenerfassungsteam in Ihrem Zentrum die in diesem Protokoll enthaltenen Definitionen akzeptiert und ihre Daten entsprechend übermittelt.  Um regelmäßig aktuelle Referenzdaten erstellen zu können, fordert NeoIPC die Teilnehmer auf, regelmäßig Daten über die webbasierte Schnittstelle zu übermitteln und sicherzustellen, dass ihre Software- und Hardwaresysteme die Mindestanforderungen erfüllen."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
+msgstr ""
+"Sie sollten sicherstellen, dass das gesamte Datenerfassungsteam in Ihrem "
+"Zentrum die in diesem Protokoll enthaltenen Definitionen akzeptiert und ihre "
+"Daten entsprechend übermittelt.  Um regelmäßig aktuelle Referenzdaten "
+"erstellen zu können, fordert NeoIPC die Teilnehmer auf, regelmäßig Daten "
+"über die webbasierte Schnittstelle zu übermitteln und sicherzustellen, dass "
+"ihre Software- und Hardwaresysteme die Mindestanforderungen erfüllen."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
-msgstr "Die Richtlinien und Verfahren Ihres Zentrums müssen die Privatsphäre der Patienten und die Datensicherheit gewährleisten.  Es ist wichtig, die personenbezogenen Daten der Patienten und andere Daten die zu ihrer Identifikation führen können, gemäß den für Ihr Zentrum geltenden Gesetzen und Richtlinien zu schützen.  Senden Sie keine personenbezogenen Daten von Patienten an das NeoIPC-Netzwerk."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
+msgstr ""
+"Die Richtlinien und Verfahren Ihres Zentrums müssen die Privatsphäre der "
+"Patienten und die Datensicherheit gewährleisten.  Es ist wichtig, die "
+"personenbezogenen Daten der Patienten und andere Daten die zu ihrer "
+"Identifikation führen können, gemäß den für Ihr Zentrum geltenden Gesetzen "
+"und Richtlinien zu schützen.  Senden Sie keine personenbezogenen Daten von "
+"Patienten an das NeoIPC-Netzwerk."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
-msgstr "Wir stellen sicher, dass die von den einzelnen Abteilungen übermittelten disaggregierten Daten streng vertraulich behandelt werden, und stellen Ihnen regelmäßig standardisierte und stratifizierte Referenzdaten zur Verfügung, die aggregierte Daten enthalten, sodass kein einzelner Patient oder keine einzelne Abteilung identifiziert werden kann."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
+msgstr ""
+"Wir stellen sicher, dass die von den einzelnen Abteilungen übermittelten "
+"disaggregierten Daten streng vertraulich behandelt werden, und stellen Ihnen "
+"regelmäßig standardisierte und stratifizierte Referenzdaten zur Verfügung, "
+"die aggregierte Daten enthalten, sodass kein einzelner Patient oder keine "
+"einzelne Abteilung identifiziert werden kann."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
-msgstr "Um Sie bei der Anwendung der bereitgestellten Werkzeuge und Methoden zu unterstützen, bieten wir unter https://neoipc.org/surveillance/ Surveillance-Protokolle und Schulungsmaterialien an.  Obwohl unsere Ressourcen für die persönliche Interaktion begrenzt sind, werden wir auch versuchen, Ihr Team zu unterstützen, wenn Sie Ihre Fragen an surveillance@neoipc.org senden."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
+msgstr ""
+"Um Sie bei der Anwendung der bereitgestellten Werkzeuge und Methoden zu "
+"unterstützen, bieten wir unter https://neoipc.org/surveillance/ Surveillance-"
+"Protokolle und Schulungsmaterialien an.  Obwohl unsere Ressourcen für die "
+"persönliche Interaktion begrenzt sind, werden wir auch versuchen, Ihr Team "
+"zu unterstützen, wenn Sie Ihre Fragen an surveillance@neoipc.org senden."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:86
@@ -224,8 +467,27 @@ msgstr "Datenschutz und -sicherheit"
 
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
-msgstr "Die routinemäßige Surveillance nosokomialer Infektionen ist keine Forschung, sondern eine Art der Qualitätssicherung, die Teil der regulären Patientenversorgung ist.  Aus diesem Grund ist die damit verbundene Datenerhebung in der Regel durch die regulären Krankenhausbehandlungsverträge oder spezielle Gesetze abgedeckt, die dies vorschreiben, und bedarf keiner ausdrücklichen Zustimmung der betroffenen Patienten oder ihrer Erziehungsberechtigten.  Dennoch sollten Sie sich vergewissern, dass dies in Ihrem Land gilt, bevor Sie mit der Datenerhebung beginnen, und sich darüber hinaus an einige universelle Mindeststandards halten, die unabhängig von den gesetzlichen Rahmenbedingungen gelten sollten."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
+msgstr ""
+"Die routinemäßige Surveillance nosokomialer Infektionen ist keine Forschung, "
+"sondern eine Art der Qualitätssicherung, die Teil der regulären "
+"Patientenversorgung ist.  Aus diesem Grund ist die damit verbundene "
+"Datenerhebung in der Regel durch die regulären "
+"Krankenhausbehandlungsverträge oder spezielle Gesetze abgedeckt, die dies "
+"vorschreiben, und bedarf keiner ausdrücklichen Zustimmung der betroffenen "
+"Patienten oder ihrer Erziehungsberechtigten.  Dennoch sollten Sie sich "
+"vergewissern, dass dies in Ihrem Land gilt, bevor Sie mit der Datenerhebung "
+"beginnen, und sich darüber hinaus an einige universelle Mindeststandards "
+"halten, die unabhängig von den gesetzlichen Rahmenbedingungen gelten sollten."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:94
@@ -235,8 +497,40 @@ msgstr "Patienteninformationen"
 
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
-msgstr "Gesundheitsinformationen gehören in den meisten Kulturen zu den vertraulichsten Kategorien von Informationen über Menschen und sollten mit besonderer Sorgfalt behandelt werden.  Wenn Informationen gespeichert oder übermittelt werden, die zur Identifizierung eines einzelnen Patienten führen können, sollte dies grundsätzlich so geschehen, dass kein unbefugter Dritter darauf zugreifen kann.  Während dies bei typischen menschlichen Identifikatoren wie der Kombination aus Familienname, Vorname und Geburtsdatum meist sehr klar ist, kann bei Neugeborenen auch ein sehr seltenes Geburtsgewicht oder Gestationsalter zur Identifizierung eines individuellen Patienten führen wenn es mit genügend anderen Informationen, wie dem Geburtsdatum oder dem Krankenhaus, in dem der Patient behandelt wird, verknüpft wird.  Denken Sie an dieses besondere Phänomen, wenn Sie Daten oder Informationen veröffentlichen, die aus Ihren Surveillance-bezogenen Aktivitäten resultieren, oder sie an ein System übermitteln, das nicht von Ihrem Krankenhaus zugelassen ist.  Dies kann sogar für eine extern gewartete NeoIPC-Surveillance-Software gelten, sofern keine Verträge bestehen, welche die Datenverarbeitung regeln."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
+msgstr ""
+"Gesundheitsinformationen gehören in den meisten Kulturen zu den "
+"vertraulichsten Kategorien von Informationen über Menschen und sollten mit "
+"besonderer Sorgfalt behandelt werden.  Wenn Informationen gespeichert oder "
+"übermittelt werden, die zur Identifizierung eines einzelnen Patienten führen "
+"können, sollte dies grundsätzlich so geschehen, dass kein unbefugter Dritter "
+"darauf zugreifen kann.  Während dies bei typischen menschlichen "
+"Identifikatoren wie der Kombination aus Familienname, Vorname und "
+"Geburtsdatum meist sehr klar ist, kann bei Neugeborenen auch ein sehr "
+"seltenes Geburtsgewicht oder Gestationsalter zur Identifizierung eines "
+"individuellen Patienten führen wenn es mit genügend anderen Informationen, "
+"wie dem Geburtsdatum oder dem Krankenhaus, in dem der Patient behandelt "
+"wird, verknüpft wird.  Denken Sie an dieses besondere Phänomen, wenn Sie "
+"Daten oder Informationen veröffentlichen, die aus Ihren Surveillance-"
+"bezogenen Aktivitäten resultieren, oder sie an ein System übermitteln, das "
+"nicht von Ihrem Krankenhaus zugelassen ist.  Dies kann sogar für eine extern "
+"gewartete NeoIPC-Surveillance-Software gelten, sofern keine Verträge "
+"bestehen, welche die Datenverarbeitung regeln."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:102
@@ -246,23 +540,83 @@ msgstr "Krankenhausinformationen"
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
-msgstr "Informationen über Krankenhäuser sind im Allgemeinen nicht gesetzlich geschützt, aber einige Informationen können als Betriebsgeheimnis betrachtet werden und in diesem Fall dürfen Sie sie als Mitarbeiter normalerweise nicht offenlegen.  Ob Surveillance-Informationen („Krankenhausinfektionsraten“) ein Betriebsgeheimnis sind oder sein sollten, ist Gegenstand umfangreicher Debatten und es ist verständlich, dass Patientenrechtsorganisationen diesbezüglich für Transparenz plädieren.  Dennoch kann die Veröffentlichung von Surveillance-Daten sowohl die Wahrnehmung der Behandlungsqualität eines Krankenhauses als auch die Fähigkeit des Surveillance-Teams, die Surveillance ehrlich und selbstkritisch durchzuführen, nachteilig beeinflussen."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
+msgstr ""
+"Informationen über Krankenhäuser sind im Allgemeinen nicht gesetzlich "
+"geschützt, aber einige Informationen können als Betriebsgeheimnis betrachtet "
+"werden und in diesem Fall dürfen Sie sie als Mitarbeiter normalerweise nicht "
+"offenlegen.  Ob Surveillance-Informationen („Krankenhausinfektionsraten“) "
+"ein Betriebsgeheimnis sind oder sein sollten, ist Gegenstand umfangreicher "
+"Debatten und es ist verständlich, dass Patientenrechtsorganisationen "
+"diesbezüglich für Transparenz plädieren.  Dennoch kann die Veröffentlichung "
+"von Surveillance-Daten sowohl die Wahrnehmung der Behandlungsqualität eines "
+"Krankenhauses als auch die Fähigkeit des Surveillance-Teams, die "
+"Surveillance ehrlich und selbstkritisch durchzuführen, nachteilig "
+"beeinflussen."
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
-msgstr "Als Instrument der internen Qualitätssicherung kann die Surveillance nicht alle Formen von Subjektivität und Unehrlichkeit ausschließen, und öffentlicher Druck tendiert dazu, die Datenerhebung in Richtung einer übermäßig kritischen Bewertung von Infektionsaufzeichnungen zu verlagern, was zu niedrigen Raten führt, die nicht mehr zu Verbesserung von Behandlungsqualität genutzt werden können.  Neben diesem Problem der „pro forma Surveillance“ kann es durchaus legitime oder sogar ehrenwerte Gründe für hohe Infektionsraten in einem Krankenhaus geben, wie etwa die Behandlung von Patienten mit besonders hohem Infektionsrisiko, die mit einfachen statistischen Mitteln wie der Risiko-Standardisierung und -Stratifizierung nicht kompensiert werden können.  Solche Zusammenhänge sind der breiten Öffentlichkeit erfahrungsgemäß schwer zu vermitteln, was zu einer übermäßigen Vereinfachung und politischem Missbrauch führen kann."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
+msgstr ""
+"Als Instrument der internen Qualitätssicherung kann die Surveillance nicht "
+"alle Formen von Subjektivität und Unehrlichkeit ausschließen, und "
+"öffentlicher Druck tendiert dazu, die Datenerhebung in Richtung einer "
+"übermäßig kritischen Bewertung von Infektionsaufzeichnungen zu verlagern, "
+"was zu niedrigen Raten führt, die nicht mehr zu Verbesserung von "
+"Behandlungsqualität genutzt werden können.  Neben diesem Problem der „pro "
+"forma Surveillance“ kann es durchaus legitime oder sogar ehrenwerte Gründe "
+"für hohe Infektionsraten in einem Krankenhaus geben, wie etwa die Behandlung "
+"von Patienten mit besonders hohem Infektionsrisiko, die mit einfachen "
+"statistischen Mitteln wie der Risiko-Standardisierung und -Stratifizierung "
+"nicht kompensiert werden können.  Solche Zusammenhänge sind der breiten "
+"Öffentlichkeit erfahrungsgemäß schwer zu vermitteln, was zu einer "
+"übermäßigen Vereinfachung und politischem Missbrauch führen kann."
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
-msgstr "Da es für diese Probleme keine einfache Lösung gibt, wird NeoIPC die Identität einzelner teilnehmender Krankenhäuser nicht offenlegen und sicherstellen, dass Veröffentlichungen und Berichte keine Informationen enthalten, die zur Identifizierung eines einzelnen Krankenhauses führen könnten."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
+msgstr ""
+"Da es für diese Probleme keine einfache Lösung gibt, wird NeoIPC die "
+"Identität einzelner teilnehmender Krankenhäuser nicht offenlegen und "
+"sicherstellen, dass Veröffentlichungen und Berichte keine Informationen "
+"enthalten, die zur Identifizierung eines einzelnen Krankenhauses führen "
+"könnten."
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
-msgstr "Wenn Sie Daten selbst oder als regionales Netzwerk veröffentlichen, sollten Sie die möglichen Auswirkungen der Aufnahme von Informationen auf Krankenhausebene sorgfältig prüfen und dies in enger Abstimmung mit den verschiedenen Interessensgruppen tun."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
+msgstr ""
+"Wenn Sie Daten selbst oder als regionales Netzwerk veröffentlichen, sollten "
+"Sie die möglichen Auswirkungen der Aufnahme von Informationen auf "
+"Krankenhausebene sorgfältig prüfen und dies in enger Abstimmung mit den "
+"verschiedenen Interessensgruppen tun."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:116
@@ -272,48 +626,117 @@ msgstr "Datenübermittlung"
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
-msgstr "Wie xref:participation_requirements[oben] erwähnt, können Sie die vom NeoIPC-Projekt entwickelten Werkzeuge und Methoden verwenden, um die Surveillance nosokomialer Infektionen in Ihrer neonatologischen Abteilung durchzuführen, ohne Informationen an das NeoIPC-Projekt oder ein regionales Netzwerk zu übermitteln."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
+msgstr ""
+"Wie xref:participation_requirements[oben] erwähnt, können Sie die vom NeoIPC-"
+"Projekt entwickelten Werkzeuge und Methoden verwenden, um die Surveillance "
+"nosokomialer Infektionen in Ihrer neonatologischen Abteilung durchzuführen, "
+"ohne Informationen an das NeoIPC-Projekt oder ein regionales Netzwerk zu "
+"übermitteln."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
-msgstr "Wenn Sie sich jedoch entschließen, Daten zu übermitteln, empfehlen wir Ihnen dringend, das webbasierte Meldesystem zu verwenden, das wir auf der Grundlage des Gesundheitsinformationsmanagementsystems https://dhis2.org/[DHIS2] entwickelt haben."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
+msgstr ""
+"Wenn Sie sich jedoch entschließen, Daten zu übermitteln, empfehlen wir Ihnen "
+"dringend, das webbasierte Meldesystem zu verwenden, das wir auf der "
+"Grundlage des Gesundheitsinformationsmanagementsystems https://dhis2.org/"
+"[DHIS2] entwickelt haben."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
-msgstr "Da DHIS2 ein frei verfügbares Open-Source-System ist, haben Sie mehrere Möglichkeiten, es zu nutzen:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
+msgstr ""
+"Da DHIS2 ein frei verfügbares Open-Source-System ist, haben Sie mehrere "
+"Möglichkeiten, es zu nutzen:"
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
-msgstr "Sie können es lokal in Ihrem Krankenhaus einsetzen und es für die NeoIPC-Datenerfassung innerhalb Ihres Krankenhauses sowie für andere potenzielle Anwendungsfälle nutzen."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
+msgstr ""
+"Sie können es lokal in Ihrem Krankenhaus einsetzen und es für die NeoIPC-"
+"Datenerfassung innerhalb Ihres Krankenhauses sowie für andere potenzielle "
+"Anwendungsfälle nutzen."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
-msgstr "Sie können es auf nationaler oder regionaler Ebene einsetzen (oder ein bestehendes nationales oder regionales System nutzen), um ein nationales oder regionales Netz von Abteilungen zu bilden, die Surveillance betreiben."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
+msgstr ""
+"Sie können es auf nationaler oder regionaler Ebene einsetzen (oder ein "
+"bestehendes nationales oder regionales System nutzen), um ein nationales "
+"oder regionales Netz von Abteilungen zu bilden, die Surveillance betreiben."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
-msgstr "Sie nutzen die https://neoipc.charite.de/[Instanz] des NeoIPC-Projekts, die derzeit vom Team des deutschen Nationalen Referenzzentrums für Surveillance von nosokomialen Infektionen am Institut für Hygiene und Umweltmedizin der Charité betrieben wird."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
+msgstr ""
+"Sie nutzen die https://neoipc.charite.de/[Instanz] des NeoIPC-Projekts, die "
+"derzeit vom Team des deutschen Nationalen Referenzzentrums für Surveillance "
+"von nosokomialen Infektionen am Institut für Hygiene und Umweltmedizin der "
+"Charité betrieben wird."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
-msgstr "Einer der Vorteile des webbasierten Erfassungssystems ist die Tatsache, dass Sie damit jederzeit mit wenigen Klicks standardisierte, abteilungsbezogene Auswertungen erstellen und diese mit den jährlich erscheinenden NeoIPC-Referenzberichten vergleichen können."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
+msgstr ""
+"Einer der Vorteile des webbasierten Erfassungssystems ist die Tatsache, dass "
+"Sie damit jederzeit mit wenigen Klicks standardisierte, abteilungsbezogene "
+"Auswertungen erstellen und diese mit den jährlich erscheinenden NeoIPC-"
+"Referenzberichten vergleichen können."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
-msgstr "Zur Erstellung der Rederenzdaten führen wir jedes Jahr zu einem bestimmten Zeitpunkt eine Berechnung mit den zu diesem Zeitpunkt in der NeoIPC-Datenbank vorhandenen Daten durch.  Um dies zu ermöglichen, müssen Sie alle Dateneingaben und die Ergänzung fehlender Informationen aus dem Vorjahr innerhalb von 6 Wochen nach Ende eines Kalenderjahres abgeschlossen haben.  Dies gilt für Patienten, deren Surveillance-Zeitraum im Vorjahr endete."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
+msgstr ""
+"Zur Erstellung der Rederenzdaten führen wir jedes Jahr zu einem bestimmten "
+"Zeitpunkt eine Berechnung mit den zu diesem Zeitpunkt in der NeoIPC-"
+"Datenbank vorhandenen Daten durch.  Um dies zu ermöglichen, müssen Sie alle "
+"Dateneingaben und die Ergänzung fehlender Informationen aus dem Vorjahr "
+"innerhalb von 6 Wochen nach Ende eines Kalenderjahres abgeschlossen haben.  "
+"Dies gilt für Patienten, deren Surveillance-Zeitraum im Vorjahr endete."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
-msgstr "Sollte das webbasierte Erfassungssystem vorübergehend nicht verfügbar sein (z. B. aufgrund von Wartungsarbeiten oder technischen Problemen), verwenden Sie in dieser Zeit bitte die Erfassungsbögen in Papierform zur Dokumentation und denken Sie daran, diese Daten so schnell wie möglich in die Webplattform einzugeben, sobald diese wieder verfügbar ist."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
+msgstr ""
+"Sollte das webbasierte Erfassungssystem vorübergehend nicht verfügbar sein "
+"(z. B. aufgrund von Wartungsarbeiten oder technischen Problemen), verwenden "
+"Sie in dieser Zeit bitte die Erfassungsbögen in Papierform zur Dokumentation "
+"und denken Sie daran, diese Daten so schnell wie möglich in die Webplattform "
+"einzugeben, sobald diese wieder verfügbar ist."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:136
@@ -323,18 +746,69 @@ msgstr "Datenerhebung"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
-msgstr "Das primäre Ziel der vom NeoIPC Surveillance System angewandten Methoden ist es, die internen Qualitätssicherungsstandards zu unterstützen, valide Aussagen über die Häufigkeit von nosokomialen Infektionen bei den in Frage kommenden Kindern während ihres stationären Aufenthaltes zu machen und die Umsetzung von IPC-Strategien in einer neonatologischen Abteilung zu fördern."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
+msgstr ""
+"Das primäre Ziel der vom NeoIPC Surveillance System angewandten Methoden ist "
+"es, die internen Qualitätssicherungsstandards zu unterstützen, valide "
+"Aussagen über die Häufigkeit von nosokomialen Infektionen bei den in Frage "
+"kommenden Kindern während ihres stationären Aufenthaltes zu machen und die "
+"Umsetzung von IPC-Strategien in einer neonatologischen Abteilung zu fördern."
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
-msgstr "Aufgrund unserer Erfahrungen gehen wir davon aus, dass Sie Daten sowohl durch die Durchsicht von Krankenakten als auch durch die Interaktion mit den Kollegen, die an der Behandlung und Pflege des zu überwachenden Patienten beteiligt sind, erheben werden.  Aus diesem Grund sollte die Datenerhebung idealerweise am Krankenbett des Patienten erfolgen, um die Menge der verfügbaren Informationen zu maximieren (indem die behandelnden Ärzte unklare oder unvollständige Einträge in der Krankenakte klären können) und um den Zeitaufwand für das Aufspüren von Krankenakten nach dem Verlassen des Krankenhauses zu minimieren.  Die Identifizierung von Patienten mit nosokomialen Infektionen erfolgt in der Regel durch die regelmäßige Prüfung der vorhandenen Patientenakten der Abteilung, einschließlich der Laborergebnisse.  Der Erfolg Ihrer Teilnahme an der NeoIPC Surveillance hängt in hohem Maße von der engen Kommunikation zwischen denjenigen ab, die die Surveillance durchführen (in der Regel Fachleute für Infektionsprävention und -kontrolle), und denjenigen, die den Patienten versorgen (in der Regel Fachleute für Neonatologie).  Da die gesammelten Daten letztendlich in einen Computer eingegeben werden müssen, können Sie durch die Kombination von Datenerfassung und Dateneingabe in einem einzigen Verfahren Zeit sparen und das Risiko von Fehlern beim Kopieren von Daten verringern."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
+msgstr ""
+"Aufgrund unserer Erfahrungen gehen wir davon aus, dass Sie Daten sowohl "
+"durch die Durchsicht von Krankenakten als auch durch die Interaktion mit den "
+"Kollegen, die an der Behandlung und Pflege des zu überwachenden Patienten "
+"beteiligt sind, erheben werden.  Aus diesem Grund sollte die Datenerhebung "
+"idealerweise am Krankenbett des Patienten erfolgen, um die Menge der "
+"verfügbaren Informationen zu maximieren (indem die behandelnden Ärzte "
+"unklare oder unvollständige Einträge in der Krankenakte klären können) und "
+"um den Zeitaufwand für das Aufspüren von Krankenakten nach dem Verlassen des "
+"Krankenhauses zu minimieren.  Die Identifizierung von Patienten mit "
+"nosokomialen Infektionen erfolgt in der Regel durch die regelmäßige Prüfung "
+"der vorhandenen Patientenakten der Abteilung, einschließlich der "
+"Laborergebnisse.  Der Erfolg Ihrer Teilnahme an der NeoIPC Surveillance "
+"hängt in hohem Maße von der engen Kommunikation zwischen denjenigen ab, die "
+"die Surveillance durchführen (in der Regel Fachleute für "
+"Infektionsprävention und -kontrolle), und denjenigen, die den Patienten "
+"versorgen (in der Regel Fachleute für Neonatologie).  Da die gesammelten "
+"Daten letztendlich in einen Computer eingegeben werden müssen, können Sie "
+"durch die Kombination von Datenerfassung und Dateneingabe in einem einzigen "
+"Verfahren Zeit sparen und das Risiko von Fehlern beim Kopieren von Daten "
+"verringern."
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
-msgstr "Für alle einzuschließenden Patienten des NeoIPC Surveillance-Programms müssen zwei Datenerfassungsbögen ausgefüllt werden:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
+msgstr ""
+"Für alle einzuschließenden Patienten des NeoIPC Surveillance-Programms "
+"müssen zwei Datenerfassungsbögen ausgefüllt werden:"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:148
@@ -348,8 +822,12 @@ msgstr "Patientenverlaufsbogen"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
-msgstr "Ein dritter Datenerhebungsbogen muss ebenfalls ausgefüllt werden, wenn sich der Patient einem chirurgischen Eingriff unterzieht:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
+msgstr ""
+"Ein dritter Datenerhebungsbogen muss ebenfalls ausgefüllt werden, wenn sich "
+"der Patient einem chirurgischen Eingriff unterzieht:"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:153
@@ -358,8 +836,14 @@ msgstr "Erhebungsbogen für chirurgische Eingriffe"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
-msgstr "Entwickelt ein teilnahmeberechtigtes Kind innerhalb des NeoIPC-Follow-up-Zeitraums eine nosokomiale Infektion, so ist/sind zusätzlich der/die entsprechende(n) Erhebungsbogen für Infektionen auszufüllen:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
+msgstr ""
+"Entwickelt ein teilnahmeberechtigtes Kind innerhalb des NeoIPC-Follow-up-"
+"Zeitraums eine nosokomiale Infektion, so ist/sind zusätzlich der/die "
+"entsprechende(n) Erhebungsbogen für Infektionen auszufüllen:"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:157
@@ -387,18 +871,35 @@ msgstr "Postoperative Wundinfektion"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
-msgstr "Nur diese in den teilnehmenden neonatologischen Abteilungen erworbenen Infektionen sollten erfasst werden."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
+msgstr ""
+"Nur diese in den teilnehmenden neonatologischen Abteilungen erworbenen "
+"Infektionen sollten erfasst werden."
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
-msgstr "Alle in Frage kommenden Kinder sollten bis zum Ende des Surveillance-Zeitraums beobachtet werden, d. h. bis zum Zeitpunkt, an dem das Kind stirbt, verlegt oder aus dem Krankenhaus entlassen wird."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
+msgstr ""
+"Alle in Frage kommenden Kinder sollten bis zum Ende des Surveillance-"
+"Zeitraums beobachtet werden, d. h. bis zum Zeitpunkt, an dem das Kind "
+"stirbt, verlegt oder aus dem Krankenhaus entlassen wird."
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
-msgstr "Im Falle eines chirurgischen Eingriffs werden die Patienten zusätzlich 30 oder 90 Tage lang auf SSIs überwacht, je nachdem, ob ein Implantat vorhanden ist.  Ausführliche Informationen finden Sie unter Postoperative Wundinfektionen."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
+msgstr ""
+"Im Falle eines chirurgischen Eingriffs werden die Patienten zusätzlich 30 "
+"oder 90 Tage lang auf SSIs überwacht, je nachdem, ob ein Implantat vorhanden "
+"ist.  Ausführliche Informationen finden Sie unter Postoperative "
+"Wundinfektionen."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:169
@@ -424,12 +925,20 @@ msgstr "**UND/ODER**"
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:177
 msgid "whose gestational age is less than 32 weeks (31 weeks 6 days inclusive)"
-msgstr "dessen Gestationsalter weniger als 32 Wochen (einschließlich 31 Wochen und 6 Tage) beträgt"
+msgstr ""
+"dessen Gestationsalter weniger als 32 Wochen (einschließlich 31 Wochen und 6 "
+"Tage) beträgt"
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
-msgstr "die **innerhalb von 120 Tagen nach der Geburt** auf einer Station Ihrer Neugeborenenabteilung aufgenommen werden, kommen für die Aufnahme in das Kernmodul des NeoIPC Surveillance Programms in Frage."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
+msgstr ""
+"die **innerhalb von 120 Tagen nach der Geburt** auf einer Station Ihrer "
+"Neugeborenenabteilung aufgenommen werden, kommen für die Aufnahme in das "
+"Kernmodul des NeoIPC Surveillance Programms in Frage."
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:180
@@ -476,8 +985,12 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
-msgstr "Ein Kind, das im Kernmodul nicht berücksichtigt wird, kann dennoch in einem anderen NeoIPC-Surveillancemodul berücksichtigt werden."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
+msgstr ""
+"Ein Kind, das im Kernmodul nicht berücksichtigt wird, kann dennoch in einem "
+"anderen NeoIPC-Surveillancemodul berücksichtigt werden."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:198
@@ -487,8 +1000,14 @@ msgstr "Erfassung von Patientendaten"
 
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
-msgstr "Sobald ein einzuschließender Patient in Ihrer neonatologischen Abteilung aufgenommen oder wieder aufgenommen wird, sollten Sie diesen erfassen, vorzugsweise direkt im Online-Erfassunsgsystem."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
+msgstr ""
+"Sobald ein einzuschließender Patient in Ihrer neonatologischen Abteilung "
+"aufgenommen oder wieder aufgenommen wird, sollten Sie diesen erfassen, "
+"vorzugsweise direkt im Online-Erfassunsgsystem."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:202
@@ -498,28 +1017,93 @@ msgstr "Pseudonymisierungstabelle"
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
-msgstr "Wenn Sie aus rechtlichen oder anderen Gründen verpflichtet sind, Patienten im Online-Erfassungssystem eindeutig zu identifizieren, müssen Sie jedem Patienten zum Zeitpunkt der Anmeldung eine NeoIPC-ID zuweisen.  Die NeoIPC-ID ist ein eindeutiger, zufälliger Identifikator, mit dem Sie den Patienten innerhalb Ihrer Abteilung identifizieren können.  Dies ermöglicht es Ihnen, die im System gespeicherten anonymen Daten zu nutzen, um sich auf bestimmte Patienten zu beziehen, z. B. im Falle einer Wiederaufnahme oder Datenkorrektur, und macht es Dritten unmöglich, dasselbe zu tun."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
+msgstr ""
+"Wenn Sie aus rechtlichen oder anderen Gründen verpflichtet sind, Patienten "
+"im Online-Erfassungssystem eindeutig zu identifizieren, müssen Sie jedem "
+"Patienten zum Zeitpunkt der Anmeldung eine NeoIPC-ID zuweisen.  Die NeoIPC-"
+"ID ist ein eindeutiger, zufälliger Identifikator, mit dem Sie den Patienten "
+"innerhalb Ihrer Abteilung identifizieren können.  Dies ermöglicht es Ihnen, "
+"die im System gespeicherten anonymen Daten zu nutzen, um sich auf bestimmte "
+"Patienten zu beziehen, z. B. im Falle einer Wiederaufnahme oder "
+"Datenkorrektur, und macht es Dritten unmöglich, dasselbe zu tun."
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
-msgstr "Jeder Patient kann nur eine NeoIPC-Identifikationsnummer haben.  Wenn ein Patient entlassen und dann wieder aufgenommen wird, endet die anfängliche Nachverfolgung zum Zeitpunkt der Entlassung, und es muss eine neue Anmeldung unter Verwendung derselben NeoIPC-Identifikationsnummer vorgenommen werden, wenn der Patient wieder aufgenommen wird."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
+msgstr ""
+"Jeder Patient kann nur eine NeoIPC-Identifikationsnummer haben.  Wenn ein "
+"Patient entlassen und dann wieder aufgenommen wird, endet die anfängliche "
+"Nachverfolgung zum Zeitpunkt der Entlassung, und es muss eine neue Anmeldung "
+"unter Verwendung derselben NeoIPC-Identifikationsnummer vorgenommen werden, "
+"wenn der Patient wieder aufgenommen wird."
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
-msgstr "Sie sind für die Organisation des Abrufs von Patientendaten auf der Grundlage eindeutiger IDs verantwortlich.  Wir empfehlen Ihnen, eine Pseudonymisierungsliste zu erstellen, die die NeoIPC-ID (eindeutige Zufallszahlen) zusammen mit anderen identifizierenden Informationen (Name, Geburtsdatum, Patienten-ID aus dem Krankenhausinformationssystem) enthält, oder diese Informationen auf dem papierbasierten Patientenüberwachungs-Stammdatenblatt zu vermerken.  Sie müssen die Pseudonymisierungsliste und die Papierblätter unter denselben Bedingungen aufbewahren, unter denen Sie geheime Gesundheitsdaten von Patienten aufbewahren, und sie oder die darin enthaltenen Informationen auf sichere Weise vernichten, sobald sie nicht mehr benötigt werden.  Um den Datenschutz zu gewährleisten, sollten Sie bei der Erstellung der NeoIPC-ID niemals einen Identifikator verwenden, der in einem anderen Kontext als der NeoIPC-Surveillance verwendet wird und den Sie nicht vollständig kontrollieren können (verwenden Sie z. B. **nicht** die Patienten-ID aus Ihrem Krankenhausinformationssystem, den Patientennamen oder einen eindeutigen Identifikator, der anderswo verwendet wird)."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
+msgstr ""
+"Sie sind für die Organisation des Abrufs von Patientendaten auf der "
+"Grundlage eindeutiger IDs verantwortlich.  Wir empfehlen Ihnen, eine "
+"Pseudonymisierungsliste zu erstellen, die die NeoIPC-ID (eindeutige "
+"Zufallszahlen) zusammen mit anderen identifizierenden Informationen (Name, "
+"Geburtsdatum, Patienten-ID aus dem Krankenhausinformationssystem) enthält, "
+"oder diese Informationen auf dem papierbasierten Patientenüberwachungs-"
+"Stammdatenblatt zu vermerken.  Sie müssen die Pseudonymisierungsliste und "
+"die Papierblätter unter denselben Bedingungen aufbewahren, unter denen Sie "
+"geheime Gesundheitsdaten von Patienten aufbewahren, und sie oder die darin "
+"enthaltenen Informationen auf sichere Weise vernichten, sobald sie nicht "
+"mehr benötigt werden.  Um den Datenschutz zu gewährleisten, sollten Sie bei "
+"der Erstellung der NeoIPC-ID niemals einen Identifikator verwenden, der in "
+"einem anderen Kontext als der NeoIPC-Surveillance verwendet wird und den Sie "
+"nicht vollständig kontrollieren können (verwenden Sie z. B. **nicht** die "
+"Patienten-ID aus Ihrem Krankenhausinformationssystem, den Patientennamen "
+"oder einen eindeutigen Identifikator, der anderswo verwendet wird)."
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
-msgstr "Für die Erstellung von Referenzdaten muss NeoIPC die einzelnen Patienten nicht nachverfolgen und die von Ihnen vergebenen IDs werden von NeoIPC in keiner Weise verwendet."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
+msgstr ""
+"Für die Erstellung von Referenzdaten muss NeoIPC die einzelnen Patienten "
+"nicht nachverfolgen und die von Ihnen vergebenen IDs werden von NeoIPC in "
+"keiner Weise verwendet."
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
-msgstr "Für die Erstellung einer Pseudonymisierungsliste können Sie die Vorlagen (Excel-Tabelle und Papierdatenblatt) verwenden, die Sie auf unserer Website im https://neoipc.org/surveillance/resources/[Abschnitt Ressourcen] finden."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
+msgstr ""
+"Für die Erstellung einer Pseudonymisierungsliste können Sie die Vorlagen "
+"(Excel-Tabelle und Papierdatenblatt) verwenden, die Sie auf unserer Website "
+"im https://neoipc.org/surveillance/resources/[Abschnitt Ressourcen] finden."
 
 #. type: Block title
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:219
@@ -568,13 +1152,40 @@ msgstr "Stammblatt zur Datenerfassung"
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
-msgstr "Sobald ein einzuschließender Patient in Ihrer neonatologischen Abteilung aufgenommen oder wieder aufgenommen wird, sollten Sie diesen erfassen, vorzugsweise direkt im Online-Erfassunsgsystem.  Nachdem Sie einen Patienten eingeschlossen haben, müssen Sie die Aufnahmedaten eingeben und die Verlaufsdaten mit Hilfe von Patientenakten weiter erfassen.  Wenn der Patient entlassen wird, in ein anderes Krankenhaus verlegt wird oder stirbt, müssen Sie die Nachbeobachtung für diesen Patienten beenden, die Summen der in den Patientenverlaufsbogen erfassten Daten bilden und diese ins Stammblatt übertragen oder direkt ins Online-Erfassungssystem eingeben."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
+msgstr ""
+"Sobald ein einzuschließender Patient in Ihrer neonatologischen Abteilung "
+"aufgenommen oder wieder aufgenommen wird, sollten Sie diesen erfassen, "
+"vorzugsweise direkt im Online-Erfassunsgsystem.  Nachdem Sie einen Patienten "
+"eingeschlossen haben, müssen Sie die Aufnahmedaten eingeben und die "
+"Verlaufsdaten mit Hilfe von Patientenakten weiter erfassen.  Wenn der "
+"Patient entlassen wird, in ein anderes Krankenhaus verlegt wird oder stirbt, "
+"müssen Sie die Nachbeobachtung für diesen Patienten beenden, die Summen der "
+"in den Patientenverlaufsbogen erfassten Daten bilden und diese ins "
+"Stammblatt übertragen oder direkt ins Online-Erfassungssystem eingeben."
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
-msgstr "Sie können das Stammblatt zur Datenerfassung verwenden, um die Daten zur Erfassung, Aufnahme und zum Ende der Surveillance lokal zu speichern.  Wenn Sie jedoch Daten an NeoIPC übermitteln, müssen die Informationen, die Sie auf dem Stammblatt zur Datenerfassung erfassen, letztendlich ins Online-Erfassungssystem eingegeben werden."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
+msgstr ""
+"Sie können das Stammblatt zur Datenerfassung verwenden, um die Daten zur "
+"Erfassung, Aufnahme und zum Ende der Surveillance lokal zu speichern.  Wenn "
+"Sie jedoch Daten an NeoIPC übermitteln, müssen die Informationen, die Sie "
+"auf dem Stammblatt zur Datenerfassung erfassen, letztendlich ins Online-"
+"Erfassungssystem eingegeben werden."
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -603,18 +1214,69 @@ msgstr "Patientenverlaufsbogen"
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
-msgstr "Eingeschlossene Patienten, die für das System in Frage kommen, müssen bis zu ihrem Tod, ihrer Verlegung oder ihrer Entlassung mit Hilfe von Patientenverlaufsbögen nachverfolgt werden.  Darin werden kumulative Risiko- und Schutzfaktoren wie Patiententage, Device-Tage und Antibiotika-Tage erfasst, und zwar möglichst täglich.  Dieser Bogen muss in Ihrer Einrichtung aufbewahrt werden, um die Datenerfassung und die Nachverfolgung der Patienten zu vereinfachen.  Sie müssen während des Surveillancezeitraums für jedes eingeschlossenen Kind einem oder mehrere Verlaufsbögen führen.  Es ist möglich, bis zu sechs verschiedene Antibiotika in einer Karte einzutragen.  Wenn Ihr Patient mehr als sechs verschiedene Antibiotika erhalten hat, dokumentieren Sie diese bitte auf einem zusätzlichen Bogen."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
+msgstr ""
+"Eingeschlossene Patienten, die für das System in Frage kommen, müssen bis zu "
+"ihrem Tod, ihrer Verlegung oder ihrer Entlassung mit Hilfe von "
+"Patientenverlaufsbögen nachverfolgt werden.  Darin werden kumulative Risiko- "
+"und Schutzfaktoren wie Patiententage, Device-Tage und Antibiotika-Tage "
+"erfasst, und zwar möglichst täglich.  Dieser Bogen muss in Ihrer Einrichtung "
+"aufbewahrt werden, um die Datenerfassung und die Nachverfolgung der "
+"Patienten zu vereinfachen.  Sie müssen während des Surveillancezeitraums für "
+"jedes eingeschlossenen Kind einem oder mehrere Verlaufsbögen führen.  Es ist "
+"möglich, bis zu sechs verschiedene Antibiotika in einer Karte einzutragen.  "
+"Wenn Ihr Patient mehr als sechs verschiedene Antibiotika erhalten hat, "
+"dokumentieren Sie diese bitte auf einem zusätzlichen Bogen."
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
-msgstr "Wenn ein Patient entlassen wird, in ein anderes Krankenhaus verlegt wird oder verstirbt, müssen Sie die Nachbeobachtung für diesen Patienten beenden, und die Summe der Daten in den Verlaufsbögen des Patienten wird zu den Enddaten der Surveillance des Patienten.  Diese Daten müssen schließlich unter dem Ereignis „Surveillance-Ende“ ins Online-Erfassungssystem eingegeben werden.  Sie können das Stammblatt zur Datenerfassung verwenden, um diese Daten lokal zu speichern."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
+msgstr ""
+"Wenn ein Patient entlassen wird, in ein anderes Krankenhaus verlegt wird "
+"oder verstirbt, müssen Sie die Nachbeobachtung für diesen Patienten beenden, "
+"und die Summe der Daten in den Verlaufsbögen des Patienten wird zu den "
+"Enddaten der Surveillance des Patienten.  Diese Daten müssen schließlich "
+"unter dem Ereignis „Surveillance-Ende“ ins Online-Erfassungssystem "
+"eingegeben werden.  Sie können das Stammblatt zur Datenerfassung verwenden, "
+"um diese Daten lokal zu speichern."
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
-msgstr "Der Einfachheit halber gelten Patienten, die ihre Abteilung für bis zu zwei Tage verlassen (z. B. für eine Operation), nicht als verlegt oder entlassen.  Sie sollten die Daten für die Tage, die nicht in der Abteilung verbracht wurden, bei der Wiederaufnahme erfassen.  Wenn zwischen Verlegung und Wiederaufnahme mehr als 48 Stunden liegen, müssen Sie die Datenerfassung für diesen Patienten beenden und „Verlegung“ als Grund für das Ende der Surveillance angeben.  In diesem Fall ist jede Wiederaufnahme als Neuaufnahme zu erfassen, und als Art der Aufnahme ist „Verlegung in Ihr Zentrum ≥ 24 Stunden nach der Geburt“ zu wählen."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgstr ""
+"Der Einfachheit halber gelten Patienten, die ihre Abteilung für bis zu zwei "
+"Tage verlassen (z. B. für eine Operation), nicht als verlegt oder "
+"entlassen.  Sie sollten die Daten für die Tage, die nicht in der Abteilung "
+"verbracht wurden, bei der Wiederaufnahme erfassen.  Wenn zwischen Verlegung "
+"und Wiederaufnahme mehr als 48 Stunden liegen, müssen Sie die Datenerfassung "
+"für diesen Patienten beenden und „Verlegung“ als Grund für das Ende der "
+"Surveillance angeben.  In diesem Fall ist jede Wiederaufnahme als "
+"Neuaufnahme zu erfassen, und als Art der Aufnahme ist „Verlegung in Ihr "
+"Zentrum ≥ 24 Stunden nach der Geburt“ zu wählen."
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -639,8 +1301,29 @@ msgstr "Datenerhebung zu chirurgischen Eingriffen"
 
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
-msgstr "Jeder chirurgische Eingriff bei Neugeborenen und insbesondere bei VLBW/VPT-Neugeborenen ist ein Indikator für einen komplizierten Verlauf und ein zusätzlicher Risikofaktor für nosokomiale Infektionen und das Auftreten von multiresistenten Erregern.  Aus diesem Grund wird jeder chirurgische Eingriff, der an einem eingeschlossenen Neugeborenen vorgenommen wird, in NeoIPC erfasst.  Für die Dokumentation vor Ort können Sie den Erfassungsbogen für chirurgische Eingriffe verwenden oder die entsprechenden Informationen direkt in das Online-Erfassungssystem eingeben.  Zusätzlich zur Erfassung des Eingriffs müssen Sie das betreffende Kind 30 oder 90 Tage lang auf Wundinfektionen überwachen, je nachdem, ob während des Eingriffs ein Implantat belassen wurde."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
+msgstr ""
+"Jeder chirurgische Eingriff bei Neugeborenen und insbesondere bei VLBW/VPT-"
+"Neugeborenen ist ein Indikator für einen komplizierten Verlauf und ein "
+"zusätzlicher Risikofaktor für nosokomiale Infektionen und das Auftreten von "
+"multiresistenten Erregern.  Aus diesem Grund wird jeder chirurgische "
+"Eingriff, der an einem eingeschlossenen Neugeborenen vorgenommen wird, in "
+"NeoIPC erfasst.  Für die Dokumentation vor Ort können Sie den "
+"Erfassungsbogen für chirurgische Eingriffe verwenden oder die entsprechenden "
+"Informationen direkt in das Online-Erfassungssystem eingeben.  Zusätzlich "
+"zur Erfassung des Eingriffs müssen Sie das betreffende Kind 30 oder 90 Tage "
+"lang auf Wundinfektionen überwachen, je nachdem, ob während des Eingriffs "
+"ein Implantat belassen wurde."
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -665,28 +1348,115 @@ msgstr "Erhebung von Infektionsdaten"
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
-msgstr "Im Krankenhaus erworbene Blutstrominfektionen, Pneumonieen, NEC-Fälle und postoperative Wundinfektionen sollten bei allen eingeschlossenen Patienten bis zum Ende des Surveillance-Zeitraums dokumentiert werden."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
+msgstr ""
+"Im Krankenhaus erworbene Blutstrominfektionen, Pneumonieen, NEC-Fälle und "
+"postoperative Wundinfektionen sollten bei allen eingeschlossenen Patienten "
+"bis zum Ende des Surveillance-Zeitraums dokumentiert werden."
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
-msgstr "Neugeboreneninfektionen lassen sich grob in Früh- und Spätinfektionen (early- und late-onset) unterteilen.  Die meisten Frühinfektionen sind auf schwangerschafts- und geburtsbedingte Risiken zurückzuführen, bei denen die verursachenden Erreger typischerweise die Mutter in Form einer mikrobiellen Kolonisation oder Infektion befallen, bevor sie eine Infektion beim Kind verursachen.  Die meisten Spätinfektionen sind dagegen auf nosokomiale Infektionen zurückzuführen, und die Erreger dieser Infektionen stammen in der Regel von Personen oder unbelebten Oberflächen, die während der Neugeborenenversorgung in engen Kontakt mit dem Kind kommen.  Da nur letztere für das auf neonatologischen Stationen tätige Gesundheitspersonal unmittelbar handlungsrelevant sind, legt NeoIPC den Schwerpunkt auf diese „nosokomialen“ Spätinfektionen, versucht aber auch, Sie bei der Surveillance von Frühinfektionen zu unterstützen.  Obwohl ein fester zeitbasierter Cut-off-Wert nicht genau erfasst, ob eine Infektion auf der Neugeborenen-Intensivstation erworben wurde, besteht ein relativ breiter internationaler Konsens darüber, dass ein 72-Stunden-Cut-off-Wert als guter Schätzer für nosokomiale Infektionen in der Neonatologie dient.  Aus diesem Grund sollten Infektionen, bei denen die ersten Symptome innerhalb eines 72-Stunden-Fensters nach der Geburt auftreten, nicht als nosokomiale Infektionen gelten und daher nicht im NeoIPC-Kernmodul erfasst werden.  Es ist jedoch möglich, sie separat als Frühinfektionen zu erfassen, wenn Sie sich für das NeoIPC-Modul für Frühinfektionen entscheiden.  Wenn eine Infektion vor 72 Stunden beginnt und eindeutig im Krankenhaus erworben wurde (z. B. weil es deutliche Anzeichen einer Infektion an der Kathetereintrittsstelle gibt) oder nach 72 Stunden beginnt und eindeutig vertikal ist (z. B. alle transplazentaren Infektionen, die bei der Geburt nicht erkennbar sind, wie Toxoplasmose, CMV, HIV, Röteln und Syphilis), kann dieser Cut-off-Wert ignoriert werden."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
+msgstr ""
+"Neugeboreneninfektionen lassen sich grob in Früh- und Spätinfektionen "
+"(early- und late-onset) unterteilen.  Die meisten Frühinfektionen sind auf "
+"schwangerschafts- und geburtsbedingte Risiken zurückzuführen, bei denen die "
+"verursachenden Erreger typischerweise die Mutter in Form einer mikrobiellen "
+"Kolonisation oder Infektion befallen, bevor sie eine Infektion beim Kind "
+"verursachen.  Die meisten Spätinfektionen sind dagegen auf nosokomiale "
+"Infektionen zurückzuführen, und die Erreger dieser Infektionen stammen in "
+"der Regel von Personen oder unbelebten Oberflächen, die während der "
+"Neugeborenenversorgung in engen Kontakt mit dem Kind kommen.  Da nur "
+"letztere für das auf neonatologischen Stationen tätige Gesundheitspersonal "
+"unmittelbar handlungsrelevant sind, legt NeoIPC den Schwerpunkt auf diese "
+"„nosokomialen“ Spätinfektionen, versucht aber auch, Sie bei der Surveillance "
+"von Frühinfektionen zu unterstützen.  Obwohl ein fester zeitbasierter Cut-"
+"off-Wert nicht genau erfasst, ob eine Infektion auf der Neugeborenen-"
+"Intensivstation erworben wurde, besteht ein relativ breiter internationaler "
+"Konsens darüber, dass ein 72-Stunden-Cut-off-Wert als guter Schätzer für "
+"nosokomiale Infektionen in der Neonatologie dient.  Aus diesem Grund sollten "
+"Infektionen, bei denen die ersten Symptome innerhalb eines 72-Stunden-"
+"Fensters nach der Geburt auftreten, nicht als nosokomiale Infektionen gelten "
+"und daher nicht im NeoIPC-Kernmodul erfasst werden.  Es ist jedoch möglich, "
+"sie separat als Frühinfektionen zu erfassen, wenn Sie sich für das NeoIPC-"
+"Modul für Frühinfektionen entscheiden.  Wenn eine Infektion vor 72 Stunden "
+"beginnt und eindeutig im Krankenhaus erworben wurde (z. B. weil es deutliche "
+"Anzeichen einer Infektion an der Kathetereintrittsstelle gibt) oder nach 72 "
+"Stunden beginnt und eindeutig vertikal ist (z. B. alle transplazentaren "
+"Infektionen, die bei der Geburt nicht erkennbar sind, wie Toxoplasmose, CMV, "
+"HIV, Röteln und Syphilis), kann dieser Cut-off-Wert ignoriert werden."
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
-msgstr "Für Patienten, die auf eine Station in Ihrer neonatologischen Abteilung verlegt oder wieder aufgenommen werden, muss ein zusätzlicher Grenzwert angewendet werden.  In diesem Fall gilt eine Infektion nur dann als nosokomiale Infektion, wenn der Tag des Symptombeginns größer oder gleich dem dritten Tag des Krankenhausaufenthalts des Patienten ist, wobei der Tag der Aufnahme als Tag 1 gilt."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgstr ""
+"Für Patienten, die auf eine Station in Ihrer neonatologischen Abteilung "
+"verlegt oder wieder aufgenommen werden, muss ein zusätzlicher Grenzwert "
+"angewendet werden.  In diesem Fall gilt eine Infektion nur dann als "
+"nosokomiale Infektion, wenn der Tag des Symptombeginns größer oder gleich "
+"dem dritten Tag des Krankenhausaufenthalts des Patienten ist, wobei der Tag "
+"der Aufnahme als Tag 1 gilt."
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
-msgstr "Die NeoIPC Surveillance sieht keinen strikten Zeitrahmen für das Auftreten von Elementen der Definitionen vor, aber in der Regel treten alle Elemente, die zur Erfüllung einer Infektionsdefinition erforderlich sind, innerhalb eines Zeitrahmens von 7-10 Tagen auf, wobei typischerweise nicht mehr als 2-3 Tage zwischen den einzelnen Elementen liegen."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
+msgstr ""
+"Die NeoIPC Surveillance sieht keinen strikten Zeitrahmen für das Auftreten "
+"von Elementen der Definitionen vor, aber in der Regel treten alle Elemente, "
+"die zur Erfüllung einer Infektionsdefinition erforderlich sind, innerhalb "
+"eines Zeitrahmens von 7-10 Tagen auf, wobei typischerweise nicht mehr als "
+"2-3 Tage zwischen den einzelnen Elementen liegen."
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
-msgstr "Wenn ein neuer Erreger in demselben Organsystem isoliert wird, obwohl bereits eine Infektion festgestellt wurde, kann dies nicht als neue Infektion erfasst werden.  Es sind mindestens 14 Tage und ein Zeitraum ohne relevante Infektionssymptome erforderlich, um die gleiche Art von Infektion erneut zu erfassen."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
+msgstr ""
+"Wenn ein neuer Erreger in demselben Organsystem isoliert wird, obwohl "
+"bereits eine Infektion festgestellt wurde, kann dies nicht als neue "
+"Infektion erfasst werden.  Es sind mindestens 14 Tage und ein Zeitraum ohne "
+"relevante Infektionssymptome erforderlich, um die gleiche Art von Infektion "
+"erneut zu erfassen."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:302
@@ -696,8 +1466,19 @@ msgstr "Primäre Sepsis/BSI"
 
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
-msgstr "Wenn bei einem eingeschlossenen Kind während des Surveillance-Zeitraums eine im Krankenhaus erworbene primäre Sepsis/Blutstrominfektion gemäß den NeoIPC-Surveillance-Kriterien (siehe Infektionsdefinitionen: Primäre Sepsis/Blutstrominfektion) auftritt, sind die erforderlichen Daten mit dem nachstehenden Datenerfassungsbogen zu erfassen und/oder über die Online-Erfassungsplattform übermitteln."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
+msgstr ""
+"Wenn bei einem eingeschlossenen Kind während des Surveillance-Zeitraums eine "
+"im Krankenhaus erworbene primäre Sepsis/Blutstrominfektion gemäß den NeoIPC-"
+"Surveillance-Kriterien (siehe Infektionsdefinitionen: Primäre Sepsis/"
+"Blutstrominfektion) auftritt, sind die erforderlichen Daten mit dem "
+"nachstehenden Datenerfassungsbogen zu erfassen und/oder über die Online-"
+"Erfassungsplattform übermitteln."
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -723,8 +1504,18 @@ msgstr "Nekrotisierende Enterokolitis"
 
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
-msgstr "Wenn bei einem eingeschlossenen Kind während des Surveillance-Zeitraums eine nekrotisierende Enterokolitis (NEC) gemäß den NeoIPC-Surveillance-Kriterien (siehe Infektionsdefinitionen: NEC) auftritt, sind die erforderlichen Daten mit dem nachstehenden Datenerfassungsbogen zu erfassen und/oder über die Online-Erfassungsplattform übermitteln."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
+msgstr ""
+"Wenn bei einem eingeschlossenen Kind während des Surveillance-Zeitraums eine "
+"nekrotisierende Enterokolitis (NEC) gemäß den NeoIPC-Surveillance-Kriterien "
+"(siehe Infektionsdefinitionen: NEC) auftritt, sind die erforderlichen Daten "
+"mit dem nachstehenden Datenerfassungsbogen zu erfassen und/oder über die "
+"Online-Erfassungsplattform übermitteln."
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -743,8 +1534,18 @@ msgstr "NeoIPC-Core-NEC-Reporting-Sheet-Image.png"
 
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
-msgstr "Wenn bei einem eingeschlossenen Kind während des Surveillance-Zeitraums eine im Krankenhaus erworbene Pneumonie gemäß den NeoIPC-Surveillance-Kriterien (siehe Infektionsdefinitionen: Pneumonie) auftritt, sind die erforderlichen Daten mit dem nachstehenden Datenerfassungsbogen zu erfassen und/oder über die Online-Erfassungsplattform übermitteln."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
+msgstr ""
+"Wenn bei einem eingeschlossenen Kind während des Surveillance-Zeitraums eine "
+"im Krankenhaus erworbene Pneumonie gemäß den NeoIPC-Surveillance-Kriterien "
+"(siehe Infektionsdefinitionen: Pneumonie) auftritt, sind die erforderlichen "
+"Daten mit dem nachstehenden Datenerfassungsbogen zu erfassen und/oder über "
+"die Online-Erfassungsplattform übermitteln."
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -774,8 +1575,18 @@ msgstr "Postoperative Wundinfektionen"
 
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
-msgstr "Wenn bei einem eingeschlossenen Kind während des Surveillance-Zeitraums eine postoperative Wundinfektion gemäß den NeoIPC-Surveillance-Kriterien (siehe Infektionsdefinitionen: Postoperative Wundinfektion) auftritt, sind die erforderlichen Daten mit dem nachstehenden Datenerfassungsbogen zu erfassen und/oder über die Online-Erfassungsplattform übermitteln."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
+msgstr ""
+"Wenn bei einem eingeschlossenen Kind während des Surveillance-Zeitraums eine "
+"postoperative Wundinfektion gemäß den NeoIPC-Surveillance-Kriterien (siehe "
+"Infektionsdefinitionen: Postoperative Wundinfektion) auftritt, sind die "
+"erforderlichen Daten mit dem nachstehenden Datenerfassungsbogen zu erfassen "
+"und/oder über die Online-Erfassungsplattform übermitteln."
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -800,8 +1611,17 @@ msgstr "Device-assoziierte Infektionen"
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
-msgstr "Intravenöse Therapie und mechanische Beatmung sind etablierte Risikofaktoren für nosokomiale Infektionen in der Neonatologie.  Diese Arten von Infektionen werden typischerweise als Device-assoziierte Infektionen bezeichnet und in Verbindung mit der Anwenung invasiver medizinischer Verfahren wie Gefäßkathetern oder Intubation erfasst."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
+msgstr ""
+"Intravenöse Therapie und mechanische Beatmung sind etablierte Risikofaktoren "
+"für nosokomiale Infektionen in der Neonatologie.  Diese Arten von "
+"Infektionen werden typischerweise als Device-assoziierte Infektionen "
+"bezeichnet und in Verbindung mit der Anwenung invasiver medizinischer "
+"Verfahren wie Gefäßkathetern oder Intubation erfasst."
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:343
@@ -830,8 +1650,19 @@ msgstr "Infektionen im Zusammenhang mit peripheren Venenkathetern (PVK)"
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
-msgstr "Da die Feststellung eines ursächlichen Zusammenhangs zwischen einem Device und einer nosokomialen Infektion in vielen neonatologischen Einrichtungen schwierig und undurchführbar ist, konzentriert sich NeoIPC ausschließlich auf einen zeitlichen Zusammenhang.  Um einen Zusammenhang zwischen einem Device und einer Infektion herzustellen, muss das Device über einen bestimmten Zeitraum vor der Infektion in Gebrauch gewesen sein."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
+msgstr ""
+"Da die Feststellung eines ursächlichen Zusammenhangs zwischen einem Device "
+"und einer nosokomialen Infektion in vielen neonatologischen Einrichtungen "
+"schwierig und undurchführbar ist, konzentriert sich NeoIPC ausschließlich "
+"auf einen zeitlichen Zusammenhang.  Um einen Zusammenhang zwischen einem "
+"Device und einer Infektion herzustellen, muss das Device über einen "
+"bestimmten Zeitraum vor der Infektion in Gebrauch gewesen sein."
 
 #. type: Block title
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:352
@@ -863,13 +1694,25 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
-msgstr "Erfüllt ein Patient, bei dem eine Blutstrominfektion auftritt, die Kriterien sowohl für eine PVK- als auch für eine ZVK-Assoziation, wird der ZVK als das Device mit dem relativ höheren Infektionsrisiko betrachtet und die BSI wird als ZVK-assoziierte BSI erfasst."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
+msgstr ""
+"Erfüllt ein Patient, bei dem eine Blutstrominfektion auftritt, die Kriterien "
+"sowohl für eine PVK- als auch für eine ZVK-Assoziation, wird der ZVK als das "
+"Device mit dem relativ höheren Infektionsrisiko betrachtet und die BSI wird "
+"als ZVK-assoziierte BSI erfasst."
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
-msgstr "Wenn sowohl invasive als auch nicht-invasive Beatmung intermittierend eingesetzt wurden, wird die Pneumonie als INV-assoziierte Pneumonie erfasst."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
+msgstr ""
+"Wenn sowohl invasive als auch nicht-invasive Beatmung intermittierend "
+"eingesetzt wurden, wird die Pneumonie als INV-assoziierte Pneumonie erfasst."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:371
@@ -879,18 +1722,37 @@ msgstr "Sekundäre Blutstrominfektion"
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
-msgstr "Im Rahmen der NeoIPC-Surveillance ist es möglich, Blutstrominfektionen sekundär zu Pneumonie, NEC und SSI zu erfassen.  Die Erfassung von Daten zu sekundären BSI ist optional; daher ist es möglich, **„Keine Nachverfolgung“** auszuwählen, wenn Sie Patienten nicht auf sekundäre BSI überwachen."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
+msgstr ""
+"Im Rahmen der NeoIPC-Surveillance ist es möglich, Blutstrominfektionen "
+"sekundär zu Pneumonie, NEC und SSI zu erfassen.  Die Erfassung von Daten zu "
+"sekundären BSI ist optional; daher ist es möglich, **„Keine "
+"Nachverfolgung“** auszuwählen, wenn Sie Patienten nicht auf sekundäre BSI "
+"überwachen."
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
-msgstr "Um eine sekundäre Blutstrominfektion einer Pneumonie, einem NEC oder einer SSI zuzuordnen, müssen die folgenden Kriterien erfüllt sein:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
+msgstr ""
+"Um eine sekundäre Blutstrominfektion einer Pneumonie, einem NEC oder einer "
+"SSI zuzuordnen, müssen die folgenden Kriterien erfüllt sein:"
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
-msgstr "Die Blutprobe wird in einem Zeitraum zwischen 3 Tagen vor und 13 Tagen nach dem Tag der Primärinfektion entnommen (Tag der Primärinfektion = erste Symptome oder erste positive Kultur am Ort der Primärinfektion)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
+msgstr ""
+"Die Blutprobe wird in einem Zeitraum zwischen 3 Tagen vor und 13 Tagen nach "
+"dem Tag der Primärinfektion entnommen (Tag der Primärinfektion = erste "
+"Symptome oder erste positive Kultur am Ort der Primärinfektion)."
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:380
@@ -918,8 +1780,12 @@ msgstr "**UND**"
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
-msgstr "Mindestens ein Organismus aus der Blutprobe stimmt mit einem Organismus überein, der an der Stelle der Primärinfektion identifiziert wurde."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
+msgstr ""
+"Mindestens ein Organismus aus der Blutprobe stimmt mit einem Organismus "
+"überein, der an der Stelle der Primärinfektion identifiziert wurde."
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -950,18 +1816,45 @@ msgstr "Primäre Sepsis/Blutstrominfektion"
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
-msgstr "Infektionen, die durch Mikroorganismen verursacht werden, die von einer primären Infektionsstelle in die Blutbahn gelangen (mit Ausnahme von Katheter-assoziierten Infektionen), werden in diesem Abschnitt nicht berücksichtigt.  Ausführliche Informationen finden Sie unter xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
+msgstr ""
+"Infektionen, die durch Mikroorganismen verursacht werden, die von einer "
+"primären Infektionsstelle in die Blutbahn gelangen (mit Ausnahme von "
+"Katheter-assoziierten Infektionen), werden in diesem Abschnitt nicht "
+"berücksichtigt.  Ausführliche Informationen finden Sie unter xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:401
@@ -985,8 +1878,12 @@ msgstr "LCBSI, verursacht durch einen gewöhnlichen Kommensalen*"
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
-msgstr "*Siehe xref:appendix-list-of-list-of-infectious-agents[Liste der Infektionserreger]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
+msgstr ""
+"*Siehe xref:appendix-list-of-list-of-infectious-agents[Liste der "
+"Infektionserreger]"
 
 #. type: Block title
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:409
@@ -1009,33 +1906,106 @@ msgstr "LCBSI verursacht durch gewöhnliche Kommensalen"
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
-msgstr "Wenn in Blutkulturen ein oder mehrere gewöhnliche Kommensalen (z. B. koagulasenegative Staphylokokken) nachgewiesen werden, ist in vielen Fällen unklar, ob die nachgewiesenen Bakterien der Erreger einer vermuteten Infektion sind oder ob eine Kontamination zu einer falschen Diagnose führt.  Es gibt mehrere Ansätze, dieses Problem durch Anpassung der Surveillance-Definitionen an diese Tatsache zu lösen.  Leider sind all diese Ansätze durch diagnostische Gewohnheiten und die Verfügbarkeit von Ressourcen limitiert, was den Vergleich von Daten aus verschiedenen Umgebungen nahezu unmöglich macht."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
+msgstr ""
+"Wenn in Blutkulturen ein oder mehrere gewöhnliche Kommensalen (z. B. "
+"koagulasenegative Staphylokokken) nachgewiesen werden, ist in vielen Fällen "
+"unklar, ob die nachgewiesenen Bakterien der Erreger einer vermuteten "
+"Infektion sind oder ob eine Kontamination zu einer falschen Diagnose führt.  "
+"Es gibt mehrere Ansätze, dieses Problem durch Anpassung der Surveillance-"
+"Definitionen an diese Tatsache zu lösen.  Leider sind all diese Ansätze "
+"durch diagnostische Gewohnheiten und die Verfügbarkeit von Ressourcen "
+"limitiert, was den Vergleich von Daten aus verschiedenen Umgebungen nahezu "
+"unmöglich macht."
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
-msgstr "Da NeoIPC darauf abzielt, Instrumente und Definitionen bereitzustellen, die in einem breiten Spektrum unterschiedlicher Umgebungen funktionieren, bieten wir drei verschiedene Definitionen für durch gewöhnliche Kommensalen verursachte LCBSI an, die in einem breiten Spektrum von Umgebungen verwendet werden können.  Da die Instrumente die Rohdaten sammeln, die zur Diagnose einer Infektion führen, ist es möglich, die Anwendung der verschiedenen Definitionen in verschiedenen Umfeldern zu bewerten und möglicherweise die Auswirkungen auf die berechnete Inzidenz zu beurteilen."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
+msgstr ""
+"Da NeoIPC darauf abzielt, Instrumente und Definitionen bereitzustellen, die "
+"in einem breiten Spektrum unterschiedlicher Umgebungen funktionieren, bieten "
+"wir drei verschiedene Definitionen für durch gewöhnliche Kommensalen "
+"verursachte LCBSI an, die in einem breiten Spektrum von Umgebungen verwendet "
+"werden können.  Da die Instrumente die Rohdaten sammeln, die zur Diagnose "
+"einer Infektion führen, ist es möglich, die Anwendung der verschiedenen "
+"Definitionen in verschiedenen Umfeldern zu bewerten und möglicherweise die "
+"Auswirkungen auf die berechnete Inzidenz zu beurteilen."
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
-msgstr "In jedem Fall sollten Sie aufgrund dieser Tatsache sehr vorsichtig sein, wenn Sie die Raten von LCBSI, die durch gewöhnliche Kommensalen verursacht werden, in verschiedenen Einrichtungen vergleichen."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
+msgstr ""
+"In jedem Fall sollten Sie aufgrund dieser Tatsache sehr vorsichtig sein, "
+"wenn Sie die Raten von LCBSI, die durch gewöhnliche Kommensalen verursacht "
+"werden, in verschiedenen Einrichtungen vergleichen."
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
-msgstr "Die Surveillance-Kriterien für nekrotisierende Enterokolitis (NEC) bestehen entweder aus einer Kombination von radiologischen Befunden und klinischen Zeichen oder einer Diagnose, die auf chirurgischen und/oder pathologischen Befunden beruht.  Der NEC-Datensatz enthält Informationen darüber, ob der Patient eine Darmperforation aufweist.  Dies gehört jedoch nicht zu den Kriterien der Surveillance-Definition.  Das bedeutet, dass Sie Fälle, bei denen Sie einen chirurgischen Nachweis einer Darmperforation ohne Nachweis einer primären Nekrose oder Pneumatosis intestinalis (z. B. spontane Darmperforation) haben, nicht als NEC melden sollten."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
+msgstr ""
+"Die Surveillance-Kriterien für nekrotisierende Enterokolitis (NEC) bestehen "
+"entweder aus einer Kombination von radiologischen Befunden und klinischen "
+"Zeichen oder einer Diagnose, die auf chirurgischen und/oder pathologischen "
+"Befunden beruht.  Der NEC-Datensatz enthält Informationen darüber, ob der "
+"Patient eine Darmperforation aufweist.  Dies gehört jedoch nicht zu den "
+"Kriterien der Surveillance-Definition.  Das bedeutet, dass Sie Fälle, bei "
+"denen Sie einen chirurgischen Nachweis einer Darmperforation ohne Nachweis "
+"einer primären Nekrose oder Pneumatosis intestinalis (z. B. spontane "
+"Darmperforation) haben, nicht als NEC melden sollten."
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
-msgstr "Pneumonie bei Neugeborenen ist eine Entität, die für Surveillancezwecke sehr schwer zu definieren ist, wie man aus der Tatsache schließen kann, dass viele Surveillance-Systeme sie überhaupt nicht erfassen, während andere beatmungsassoziierte Ereignisse erfassen, bei denen die Surveillance auf beatmete Patienten beschränkt ist und Pneumonie nur eine der Entitäten ist, die von der Definition erfasst werden."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
+msgstr ""
+"Pneumonie bei Neugeborenen ist eine Entität, die für Surveillancezwecke sehr "
+"schwer zu definieren ist, wie man aus der Tatsache schließen kann, dass "
+"viele Surveillance-Systeme sie überhaupt nicht erfassen, während andere "
+"beatmungsassoziierte Ereignisse erfassen, bei denen die Surveillance auf "
+"beatmete Patienten beschränkt ist und Pneumonie nur eine der Entitäten ist, "
+"die von der Definition erfasst werden."
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
-msgstr "Um die Kriterien einer Device-assoziierten, im Krankenhaus erworbenen Pneumonie zu erfüllen, müssen die Patienten mindestens 4 Kalendertage lang beatmet werden (Tag 1 ist der Tag, an dem die invasive/nicht-invasive Beatmung beginnt).  Das früheste Datum des Ereignisses ist Tag 3 der Beatmung."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
+msgstr ""
+"Um die Kriterien einer Device-assoziierten, im Krankenhaus erworbenen "
+"Pneumonie zu erfüllen, müssen die Patienten mindestens 4 Kalendertage lang "
+"beatmet werden (Tag 1 ist der Tag, an dem die invasive/nicht-invasive "
+"Beatmung beginnt).  Das früheste Datum des Ereignisses ist Tag 3 der "
+"Beatmung."
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:449
@@ -1105,18 +2075,37 @@ msgstr "Postoperative Wundinfektion"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
-msgstr "Eine Wundinfektion (WI), die an der Inzisions- oder Operationsstelle auftritt, wird als postoperative Wundinfektion („surgical site infection“ – SSI) erfasst, wenn sie in einem bestimmten Zeitfenster nach einem operativen Eingriff auftritt, der ebenfalls im NeoIPC-Surveillance-System erfasst wurde."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
+msgstr ""
+"Eine Wundinfektion (WI), die an der Inzisions- oder Operationsstelle "
+"auftritt, wird als postoperative Wundinfektion („surgical site infection“ – "
+"SSI) erfasst, wenn sie in einem bestimmten Zeitfenster nach einem operativen "
+"Eingriff auftritt, der ebenfalls im NeoIPC-Surveillance-System erfasst wurde."
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
-msgstr "SSIs, die bei Patienten auftreten, für die kein chirurgischer Eingriff im NeoIPC-Surveillance-System erfasst wurde (z. B. ein Patient, der nach einem chirurgischen Eingriff in einem anderen Zentrum in Ihr Zentrum verlegt wurde), werden nicht erfasst."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
+msgstr ""
+"SSIs, die bei Patienten auftreten, für die kein chirurgischer Eingriff im "
+"NeoIPC-Surveillance-System erfasst wurde (z. B. ein Patient, der nach einem "
+"chirurgischen Eingriff in einem anderen Zentrum in Ihr Zentrum verlegt "
+"wurde), werden nicht erfasst."
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
-msgstr "Im Einzelnen gelten die folgenden Surveillancezeiten (Tag 1 = das Datum des Eingriffs):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
+msgstr ""
+"Im Einzelnen gelten die folgenden Surveillancezeiten (Tag 1 = das Datum des "
+"Eingriffs):"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:484
@@ -1125,18 +2114,28 @@ msgstr "Oberflächliche Wundinfektion: 30 Tage"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
-msgstr "Tiefe Wundinfektion: 30 Tage oder 90 Tage, wenn ein Implantat an Ort und Stelle belassen wurde"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgstr ""
+"Tiefe Wundinfektion: 30 Tage oder 90 Tage, wenn ein Implantat an Ort und "
+"Stelle belassen wurde"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
-msgstr "Wundinfektion an Organen oder in Körperhöhlen: 30 Tage bzw. 90 Tage, wenn ein Implantat belassen wurde"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgstr ""
+"Wundinfektion an Organen oder in Körperhöhlen: 30 Tage bzw. 90 Tage, wenn "
+"ein Implantat belassen wurde"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
-msgstr "Die Nachverfolgung von SSI nach einem chirurgischen Eingriff kannaus zwei Gründen vorzeitig abgebrochen werden:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
+msgstr ""
+"Die Nachverfolgung von SSI nach einem chirurgischen Eingriff kannaus zwei "
+"Gründen vorzeitig abgebrochen werden:"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:490
@@ -1155,8 +2154,15 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
-msgstr "Kleinere Eingriffe wie einfache Punktionen von Hämatomen/Seromen gelten nicht als Revisionseingriffe.  Die Surveillance kann durch solche kleineren Eingriffe nicht beendet werden, und es beginnt kein neuer Nachbeobachtungszeitraum."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
+msgstr ""
+"Kleinere Eingriffe wie einfache Punktionen von Hämatomen/Seromen gelten "
+"nicht als Revisionseingriffe.  Die Surveillance kann durch solche kleineren "
+"Eingriffe nicht beendet werden, und es beginnt kein neuer "
+"Nachbeobachtungszeitraum."
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:497
@@ -1185,8 +2191,12 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
-msgstr "Der Patient darf nicht verstorben sein (z. B. ist eine postmortale Organentnahme zum Zweck der Organspende ausgeschlossen)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
+msgstr ""
+"Der Patient darf nicht verstorben sein (z. B. ist eine postmortale "
+"Organentnahme zum Zweck der Organspende ausgeschlossen)."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:508
@@ -1196,8 +2206,12 @@ msgstr "Oberflächliche postoperative Wundinfektion"
 
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
-msgstr "Zu dieser Kategorie gehören Infektionen an der Operationsstelle, die nur die Haut und das subkutane Gewebe betreffen."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
+msgstr ""
+"Zu dieser Kategorie gehören Infektionen an der Operationsstelle, die nur die "
+"Haut und das subkutane Gewebe betreffen."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:514
@@ -1207,8 +2221,12 @@ msgstr "Tiefe postoperative Wundinfektion"
 
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
-msgstr "Zu dieser Kategorie gehören Infektionen an der Operationsstelle, die tiefe Weichteile der Inzision (z. B. Faszien- und Muskelschichten) betreffen."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
+msgstr ""
+"Zu dieser Kategorie gehören Infektionen an der Operationsstelle, die tiefe "
+"Weichteile der Inzision (z. B. Faszien- und Muskelschichten) betreffen."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:520
@@ -1218,8 +2236,14 @@ msgstr "Postoperative Wundinfektion an Organen oder in Körperhöhlen"
 
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
-msgstr "Zu dieser Kategorie gehören Infektionen an der Operationsstelle, die einen Teil des Körpers betreffen, der tiefer als die Faszien-/Muskelschichten liegt und während des operativen Eingriffs geöffnet oder manipuliert wurde."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
+msgstr ""
+"Zu dieser Kategorie gehören Infektionen an der Operationsstelle, die einen "
+"Teil des Körpers betreffen, der tiefer als die Faszien-/Muskelschichten "
+"liegt und während des operativen Eingriffs geöffnet oder manipuliert wurde."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:526
@@ -1229,12 +2253,26 @@ msgstr "Datenverzeichnis"
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
-msgstr "Die folgenden Datenelemente erscheinen in den NeoIPC-Erfassungsbögen oder in der Online-Erfassungsplattform.  Einige von ihnen (z. B. Patienten-ID und Patientenname) werden nur für Ihre lokale Dokumentation und nicht in den zentralen NeoIPC-Softwaretools verwendet."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
+msgstr ""
+"Die folgenden Datenelemente erscheinen in den NeoIPC-Erfassungsbögen oder in "
+"der Online-Erfassungsplattform.  Einige von ihnen (z. B. Patienten-ID und "
+"Patientenname) werden nur für Ihre lokale Dokumentation und nicht in den "
+"zentralen NeoIPC-Softwaretools verwendet."
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1268,13 +2306,33 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-neoipc-id]]NeoIPC-ID (Ne
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
-msgstr "Die eindeutige Kennung, die Sie dem Patienten zur Nachverfolgung in der Online-Datenerfassungsplatform zuweisen.  Wir empfehlen Ihnen, diese Information in einer Pseudonymisierungsliste zu speichern."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
+msgstr ""
+"Die eindeutige Kennung, die Sie dem Patienten zur Nachverfolgung in der "
+"Online-Datenerfassungsplatform zuweisen.  Wir empfehlen Ihnen, diese "
+"Information in einer Pseudonymisierungsliste zu speichern."
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
-msgstr "Verwenden Sie diese Kennung zur eindeutigen Identifizierung eines Patienten im System.  Idealerweise verwenden Sie eine eindeutige zufällige Zeichenfolge.  Wenn Sie die Anforderung haben, einen hier eingegebenen Patienten zu identifizieren, können Sie diese Kennung als NeoIPC-Schlüssel für die Pseudonymisierung verwenden.  Verwenden Sie NIEMALS einen Identifikator, der bereits an anderer Stelle verwendet wird und den Sie nicht vollständig kontrollieren können (verwenden Sie z. B. NICHT die Patienten-ID aus Ihrem Krankenhausinformationssystem)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
+msgstr ""
+"Verwenden Sie diese Kennung zur eindeutigen Identifizierung eines Patienten "
+"im System.  Idealerweise verwenden Sie eine eindeutige zufällige "
+"Zeichenfolge.  Wenn Sie die Anforderung haben, einen hier eingegebenen "
+"Patienten zu identifizieren, können Sie diese Kennung als NeoIPC-Schlüssel "
+"für die Pseudonymisierung verwenden.  Verwenden Sie NIEMALS einen "
+"Identifikator, der bereits an anderer Stelle verwendet wird und den Sie "
+"nicht vollständig kontrollieren können (verwenden Sie z. B. NICHT die "
+"Patienten-ID aus Ihrem Krankenhausinformationssystem)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:545
@@ -1284,8 +2342,14 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-patient-id]]Patienten-ID
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
-msgstr "Die eindeutige Kennung des Patienten im Krankenhaus, die in den meisten Fällen aus dem Krankenhausinformationssystem (KIS) oder dem Patientendatenmanagementsystem (PDMS) stammt."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
+msgstr ""
+"Die eindeutige Kennung des Patienten im Krankenhaus, die in den meisten "
+"Fällen aus dem Krankenhausinformationssystem (KIS) oder dem "
+"Patientendatenmanagementsystem (PDMS) stammt."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
@@ -1300,8 +2364,19 @@ msgstr "Der Name des Patienten (z. B. Vorname, gefolgt von Familienname)."
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
-msgstr "Die Patienten-ID und der Patientenname sind nicht Teil des NeoIPC-Datensatzes und dürfen nicht an die Datenerfassungsplattform übermittelt werden (z. B. dürfen sie NICHT als NeoIPC-ID verwendet werden).  Sie sind auf den Datenerfassungsbögen verfügbar, damit Sie den Patienten innerhalb des Krankenhauses identifizieren und die Datei im Krankenhausinformationssystem nachschlagen können."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
+msgstr ""
+"Die Patienten-ID und der Patientenname sind nicht Teil des NeoIPC-"
+"Datensatzes und dürfen nicht an die Datenerfassungsplattform übermittelt "
+"werden (z. B. dürfen sie NICHT als NeoIPC-ID verwendet werden).  Sie sind "
+"auf den Datenerfassungsbögen verfügbar, damit Sie den Patienten innerhalb "
+"des Krankenhauses identifizieren und die Datei im "
+"Krankenhausinformationssystem nachschlagen können."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:551
@@ -1311,8 +2386,20 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-gestational-age]]Gestati
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
-msgstr "Das Gestationsalter, ausgedrückt in vollen Wochen und Tagen (z. B. 25 Wochen und 4 Tage: 25+4) zum Zeitpunkt der Geburt.  In der Regel handelt es sich dabei um das vom Geburtshelfer der Mutter berechnete oder geschätzte Gestationsalter, doch wenn dieses nicht verfügbar ist (z. B. bei unbeobachteten Schwangerschaften), kann das vom behandelnden Arzt (z. B. anhand des Ballard-Scores) geschätzte Gestationsalter angegeben werden."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
+msgstr ""
+"Das Gestationsalter, ausgedrückt in vollen Wochen und Tagen (z. B. 25 Wochen "
+"und 4 Tage: 25+4) zum Zeitpunkt der Geburt.  In der Regel handelt es sich "
+"dabei um das vom Geburtshelfer der Mutter berechnete oder geschätzte "
+"Gestationsalter, doch wenn dieses nicht verfügbar ist (z. B. bei "
+"unbeobachteten Schwangerschaften), kann das vom behandelnden Arzt (z. B. "
+"anhand des Ballard-Scores) geschätzte Gestationsalter angegeben werden."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
@@ -1322,8 +2409,18 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-birthweight]]Geburtsgewi
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
-msgstr "Das Gewicht des Kindes unmittelbar nach der Geburt in Gramm.  In der Regel basiert dieser Wert auf einer Messung, aber wenn das Geburtsgewicht unbekannt ist oder einen hochgradig pathologischen Wert hat, der nicht die Reife des Kindes widerspiegelt (z. B. Hydrops fetalis), können Sie das vom behandelnden Arzt geschätzte Geburtsgewicht eingeben."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
+msgstr ""
+"Das Gewicht des Kindes unmittelbar nach der Geburt in Gramm.  In der Regel "
+"basiert dieser Wert auf einer Messung, aber wenn das Geburtsgewicht "
+"unbekannt ist oder einen hochgradig pathologischen Wert hat, der nicht die "
+"Reife des Kindes widerspiegelt (z. B. Hydrops fetalis), können Sie das vom "
+"behandelnden Arzt geschätzte Geburtsgewicht eingeben."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
@@ -1333,8 +2430,15 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-sex]]Geschlecht"
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
-msgstr "In der Regel das phänotypische Geschlecht des Patienten.  Wenn das Geschlecht nicht anhand des Phänotyps oder Genotyps des Patienten bestimmt werden kann oder wenn der Genotyp weder XX noch XY ist, gilt es für die Zwecke der Surveillance als unbestimmt."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
+msgstr ""
+"In der Regel das phänotypische Geschlecht des Patienten.  Wenn das "
+"Geschlecht nicht anhand des Phänotyps oder Genotyps des Patienten bestimmt "
+"werden kann oder wenn der Genotyp weder XX noch XY ist, gilt es für die "
+"Zwecke der Surveillance als unbestimmt."
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:559
@@ -1360,7 +2464,9 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-delivery-mode]]Geburtsmo
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:563
 msgid "The mode of the infant's delivery.  This can be one of the following:"
-msgstr "Die Art der Entbindung des Kindes.  Dies kann eine der folgenden Angaben sein:"
+msgstr ""
+"Die Art der Entbindung des Kindes.  Dies kann eine der folgenden Angaben "
+"sein:"
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:565
@@ -1386,7 +2492,8 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-multiple-birth]]Mehrling
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:568
 msgid "Check this field if the infant is part of a multiple birth."
-msgstr "Kreuzen Sie dieses Feld an, wenn das Kind Teil einer Mehrlingsgeburt ist."
+msgstr ""
+"Kreuzen Sie dieses Feld an, wenn das Kind Teil einer Mehrlingsgeburt ist."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:568
@@ -1396,8 +2503,14 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-number-of-infants]]Anzah
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
-msgstr "Die Anzahl der Kinder, die in der (Mehrlings-)Schwangerschaft, zu der dieses Kind gehört, geboren wurden.  Bitte geben Sie die Gesamtzahl der Kinder an, einschließlich des Kindes, den Sie hier erfassen."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
+msgstr ""
+"Die Anzahl der Kinder, die in der (Mehrlings-)Schwangerschaft, zu der dieses "
+"Kind gehört, geboren wurden.  Bitte geben Sie die Gesamtzahl der Kinder an, "
+"einschließlich des Kindes, den Sie hier erfassen."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:572
@@ -1413,8 +2526,12 @@ msgstr "[[data-dictionary-patient-master-data-admission-information-admission-da
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
-msgstr "Der Tag, an dem der Patient in das Krankenhaus aufgenommen wurde.  Bei Kindern, die in Ihrem Krankenhaus geboren wurden, ist dies das Geburtsdatum."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
+msgstr ""
+"Der Tag, an dem der Patient in das Krankenhaus aufgenommen wurde.  Bei "
+"Kindern, die in Ihrem Krankenhaus geboren wurden, ist dies das Geburtsdatum."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
@@ -1424,13 +2541,21 @@ msgstr "[[data-dictionary-patient-master-data-admission-information-admission-ty
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
-msgstr "Beschreibt, ob das Kind in Ihrem Krankenhaus geboren wurde oder ob er nach der Geburt aufgenommen wurde und wenn ja, wie lange nach der Geburt:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
+msgstr ""
+"Beschreibt, ob das Kind in Ihrem Krankenhaus geboren wurde oder ob er nach "
+"der Geburt aufgenommen wurde und wenn ja, wie lange nach der Geburt:"
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
-msgstr "Aufgenommen aus dem Kreißsaal (Erstaufnahme für Kinder, die in Ihrem Krankenhaus entbunden wurden)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
+msgstr ""
+"Aufgenommen aus dem Kreißsaal (Erstaufnahme für Kinder, die in Ihrem "
+"Krankenhaus entbunden wurden)"
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:579
@@ -1440,7 +2565,9 @@ msgstr "Verlegung/Wiederaufnahme in Ihr Krankenhaus am Tag der Geburt"
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:580
 msgid "Transferred/readmitted to your hospital the day after birth or later"
-msgstr "Verlegung/Wiederaufnahme in Ihr Krankenhaus am Tag nach der Geburt oder später"
+msgstr ""
+"Verlegung/Wiederaufnahme in Ihr Krankenhaus am Tag nach der Geburt oder "
+"später"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:580
@@ -1450,8 +2577,15 @@ msgstr "[[data-dictionary-patient-master-data-admission-information-admission-da
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
-msgstr "Bei Kindern, die nicht in Ihrem eigenen Krankenhaus entbunden wurden, erfassen Sie den Lebenstag des Kindes am Tag der Aufnahme (Tag der Geburt = Lebenstag 1.  Der nächste Tag, beginnend um 00:00 Uhr, ist der zweite Lebenstag)."
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
+msgstr ""
+"Bei Kindern, die nicht in Ihrem eigenen Krankenhaus entbunden wurden, "
+"erfassen Sie den Lebenstag des Kindes am Tag der Aufnahme (Tag der Geburt = "
+"Lebenstag 1.  Der nächste Tag, beginnend um 00:00 Uhr, ist der zweite "
+"Lebenstag)."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:584
@@ -1467,8 +2601,11 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-date]]Surveillanc
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
-msgid "The day the data collection and follow-up for the patient has been stopped."
-msgstr "Der Tag, an dem die Datenerfassung und die Nachverfolgung für den Patienten beendet wurden."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
+msgstr ""
+"Der Tag, an dem die Datenerfassung und die Nachverfolgung für den Patienten "
+"beendet wurden."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
@@ -1479,7 +2616,8 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-reason]]Grund fü
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:588
 msgid "The reason for ending data collection.  One of the following:"
-msgstr "Der Grund für die Beendigung der Datenerfassung.  Einer der folgenden Gründe:"
+msgstr ""
+"Der Grund für die Beendigung der Datenerfassung.  Einer der folgenden Gründe:"
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:590
@@ -1499,8 +2637,14 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-patient-days]]Pat
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
-msgstr "Die kumulative Anzahl der Tage, die der Patient in der Abteilung verbracht hat, einschließlich des Tages der Aufnahme und des Tages der Entlassung/Verlegung/des Todes (keine Mindestaufenthaltsdauer)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
+msgstr ""
+"Die kumulative Anzahl der Tage, die der Patient in der Abteilung verbracht "
+"hat, einschließlich des Tages der Aufnahme und des Tages der Entlassung/"
+"Verlegung/des Todes (keine Mindestaufenthaltsdauer)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
@@ -1510,8 +2654,12 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-cvc-days]]ZVK-Tag
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
-msgstr "Die kumulative Anzahl der Tage, an denen ein zentraler Venenkatheter für mindestens 12 Stunden/Tag gelegt war."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
+msgstr ""
+"Die kumulative Anzahl der Tage, an denen ein zentraler Venenkatheter für "
+"mindestens 12 Stunden/Tag gelegt war."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
@@ -1521,8 +2669,12 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-pvc-days]]PVC-Tag
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
-msgstr "Die kumulative Anzahl der Tage, an denen ein peripherer Gefäßkatheter für mindestens 12 Stunden/Tag gelegt war."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
+msgstr ""
+"Die kumulative Anzahl der Tage, an denen ein peripherer Gefäßkatheter für "
+"mindestens 12 Stunden/Tag gelegt war."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
@@ -1532,8 +2684,12 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-inv-days]]INV-Tag
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
-msgstr "Die kumulative Anzahl der Tage, an denen das Kind mindestens 12 Stunden/Tag invasiv beatmet (intubiert) wurde."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
+msgstr ""
+"Die kumulative Anzahl der Tage, an denen das Kind mindestens 12 Stunden/Tag "
+"invasiv beatmet (intubiert) wurde."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
@@ -1543,8 +2699,14 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-niv-days]]NIV-Tag
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
-msgstr "Die kumulative Anzahl der Tage, an denen das Kind mindestens 12 Stunden/Tag nicht-invasiv beatmet wurde (nicht intubiert; z. B. mit High-Flow-Nasenkanülen oder CPAP)."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
+msgstr ""
+"Die kumulative Anzahl der Tage, an denen das Kind mindestens 12 Stunden/Tag "
+"nicht-invasiv beatmet wurde (nicht intubiert; z. B. mit High-Flow-"
+"Nasenkanülen oder CPAP)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
@@ -1554,8 +2716,15 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-human-milk-days]]
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
-msgstr "Die kumulative Anzahl der Tage, an denen die enterale Ernährung des Patienten ausschließlich aus Muttermilch (der eigenen Mutter oder einer Spenderin) besteht.  Angereicherte Muttermilch wird als Muttermilch betrachtet."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
+msgstr ""
+"Die kumulative Anzahl der Tage, an denen die enterale Ernährung des "
+"Patienten ausschließlich aus Muttermilch (der eigenen Mutter oder einer "
+"Spenderin) besteht.  Angereicherte Muttermilch wird als Muttermilch "
+"betrachtet."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
@@ -1565,8 +2734,12 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-kangaroo-care-day
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
-msgstr "Die kumulative Anzahl der Tage, an denen der Patient Känguru-Pflege (intensiver Haut-zu-Haut-Kontakt) für mindestens 2 Stunden erhielt."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
+msgstr ""
+"Die kumulative Anzahl der Tage, an denen der Patient Känguru-Pflege "
+"(intensiver Haut-zu-Haut-Kontakt) für mindestens 2 Stunden erhielt."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
@@ -1576,8 +2749,14 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-probiotic-days]]P
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
-msgstr "Die kumulative Anzahl der Tage, an denen der Patient ein orales Probiotikum erhält, das mindestens eines von Lactobacillus spp. oder Bifidobacterium spp. enthält, unabhängig von der Menge."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
+msgstr ""
+"Die kumulative Anzahl der Tage, an denen der Patient ein orales Probiotikum "
+"erhält, das mindestens eines von Lactobacillus spp. oder Bifidobacterium "
+"spp. enthält, unabhängig von der Menge."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
@@ -1587,8 +2766,29 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-total-antibiotic-
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
-msgstr "Die kumulative Anzahl der Tagefootnote:ab-days-comment[Gezählt werden der Tag der ersten Dosis und der Tag der letzten Dosis einer Antibiotikatherapie sowie alle Tage dazwischen.  Tage, an denen zwischen der ersten und der letzten Dosis keine Dosis verabreicht wurde (z. B. ausgelassene Dosen aufgrund hoher Arzneimittelspiegel in der therapeutischen Arzneimittelüberwachung), werden gezählt, als ob eine Dosis verabreicht worden wäre.  Tage nach der letzten Dosis werden nicht gezählt, unabhängig vom gemessenen oder angenommenen Medikamentenspiegel im Patienten.] wenn das Kind (irgendwelche) systemischen Antibiotika erhalten hat.  Pro Tag kann nur ein Antibiotikatag erfasst werden, d. h. ein Tag, an dem der Patient mehrere Antibiotika erhalten hat, wird trotzdem als ein Antibiotikatag gezählt."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
+msgstr ""
+"Die kumulative Anzahl der Tagefootnote:ab-days-comment[Gezählt werden der "
+"Tag der ersten Dosis und der Tag der letzten Dosis einer Antibiotikatherapie "
+"sowie alle Tage dazwischen.  Tage, an denen zwischen der ersten und der "
+"letzten Dosis keine Dosis verabreicht wurde (z. B. ausgelassene Dosen "
+"aufgrund hoher Arzneimittelspiegel in der therapeutischen "
+"Arzneimittelüberwachung), werden gezählt, als ob eine Dosis verabreicht "
+"worden wäre.  Tage nach der letzten Dosis werden nicht gezählt, unabhängig "
+"vom gemessenen oder angenommenen Medikamentenspiegel im Patienten.] wenn das "
+"Kind (irgendwelche) systemischen Antibiotika erhalten hat.  Pro Tag kann nur "
+"ein Antibiotikatag erfasst werden, d. h. ein Tag, an dem der Patient mehrere "
+"Antibiotika erhalten hat, wird trotzdem als ein Antibiotikatag gezählt."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
@@ -1598,8 +2798,13 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-antibiotic-substa
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
-msgstr "Die kumulative Anzahl der Tagefootnote:ab-days-comment[] an denen das Kind eine bestimmte systemische antibiotische Substanz erhalten hat.  Exp.: Gentamicin-Tage"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgstr ""
+"Die kumulative Anzahl der Tagefootnote:ab-days-comment[] an denen das Kind "
+"eine bestimmte systemische antibiotische Substanz erhalten hat.  Exp.: "
+"Gentamicin-Tage"
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:608
@@ -1626,8 +2831,14 @@ msgstr "[[data-dictionary-surgical-procedure-description]]Beschreibung des Eingr
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
-msgstr "Ein von Menschen lesbarer Name oder eine Beschreibung des chirurgischen Eingriffs, wie er von Chirurgen in Ihrer Einrichtung üblicherweise genannt wird (z. B. Ligatur eines offenen Arterienkanals)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
+msgstr ""
+"Ein von Menschen lesbarer Name oder eine Beschreibung des chirurgischen "
+"Eingriffs, wie er von Chirurgen in Ihrer Einrichtung üblicherweise genannt "
+"wird (z. B. Ligatur eines offenen Arterienkanals)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
@@ -1637,8 +2848,19 @@ msgstr "[[data-dictionary-surgical-procedure-main-procedure-code]]Main procedure
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
-msgstr "Der Code der Internationalen Klassifikation der Gesundheitsinterventionen (ICHI) für das durchgeführte Hauptverfahren.  Werden während einer Operation mehrere verschiedene Verfahren durchgeführt, entscheidet der Chirurg, welches Verfahren das Hauptverfahren ist (in der Regel das komplexeste Verfahren oder das Verfahren mit dem höchsten Infektionsrisiko).  Bitte besuchen Sie https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgstr ""
+"Der Code der Internationalen Klassifikation der Gesundheitsinterventionen "
+"(ICHI) für das durchgeführte Hauptverfahren.  Werden während einer Operation "
+"mehrere verschiedene Verfahren durchgeführt, entscheidet der Chirurg, "
+"welches Verfahren das Hauptverfahren ist (in der Regel das komplexeste "
+"Verfahren oder das Verfahren mit dem höchsten Infektionsrisiko).  Bitte "
+"besuchen Sie https://icd.who.int/dev11/l-ichi/en"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
@@ -1648,8 +2870,14 @@ msgstr "[[data-dictionary-surgical-procedure-side-procedure-code]]Side procedure
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
-msgstr "Der Code der Internationalen Klassifikation der Gesundheitsinterventionen (ICHI) für das/die durchgeführte(n) Nebenverfahren.  Es ist möglich, bis zu zwei Nebenverfahren zu erfassen."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
+msgstr ""
+"Der Code der Internationalen Klassifikation der Gesundheitsinterventionen "
+"(ICHI) für das/die durchgeführte(n) Nebenverfahren.  Es ist möglich, bis zu "
+"zwei Nebenverfahren zu erfassen."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
@@ -1659,8 +2887,12 @@ msgstr "[[data-dictionary-surgical-procedure-duration]]Dauer"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
-msgstr "Die Dauer des chirurgischen Eingriffs in Minuten (Zeit von der Inzision bis zur Naht, falls verfügbar)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
+msgstr ""
+"Die Dauer des chirurgischen Eingriffs in Minuten (Zeit von der Inzision bis "
+"zur Naht, falls verfügbar)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
@@ -1670,8 +2902,16 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class]]Wundklasse"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
-msgstr "Eine Bewertung des Kontaminationsgrads einer chirurgischen Wunde zum Zeitpunkt des chirurgischen Eingriffs gemäß den CDC-Richtlinien.  Sie wird von einer an dem chirurgischen Eingriff beteiligten Person (z. B. Chirurg, OP-Schwester usw.) vergeben.  Die vier Wundklassifizierungen sind:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
+msgstr ""
+"Eine Bewertung des Kontaminationsgrads einer chirurgischen Wunde zum "
+"Zeitpunkt des chirurgischen Eingriffs gemäß den CDC-Richtlinien.  Sie wird "
+"von einer an dem chirurgischen Eingriff beteiligten Person (z. B. Chirurg, "
+"OP-Schwester usw.) vergeben.  Die vier Wundklassifizierungen sind:"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
@@ -1681,8 +2921,21 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class-i]]Klasse I/Sauber"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
-msgstr "Eine nicht infizierte Operationswunde, bei der keine Entzündung vorliegt und die Atemwege, der Verdauungstrakt, der Genitaltrakt oder der nicht infizierte Harntrakt nicht betroffen sind.  Außerdem sind saubere Wunden in erster Linie geschlossen und werden, falls erforderlich, mit einer geschlossenen Drainage abgeleitet.  Operative Schnittwunden, die keinem penetrierenden (stumpfen) Trauma folgen, sollten in diese Kategorie aufgenommen werden, wenn sie die Kriterien erfüllen."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
+msgstr ""
+"Eine nicht infizierte Operationswunde, bei der keine Entzündung vorliegt und "
+"die Atemwege, der Verdauungstrakt, der Genitaltrakt oder der nicht "
+"infizierte Harntrakt nicht betroffen sind.  Außerdem sind saubere Wunden in "
+"erster Linie geschlossen und werden, falls erforderlich, mit einer "
+"geschlossenen Drainage abgeleitet.  Operative Schnittwunden, die keinem "
+"penetrierenden (stumpfen) Trauma folgen, sollten in diese Kategorie "
+"aufgenommen werden, wenn sie die Kriterien erfüllen."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
@@ -1692,8 +2945,19 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class-ii]]Klasse II/Sauber-Ko
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
-msgstr "Eine Operationswunde, bei der die Atemwege, der Verdauungstrakt, der Genitaltrakt oder die Harnwege unter kontrollierten Bedingungen und ohne ungewöhnliche Kontamination erreicht werden.  Insbesondere Operationen, die den Gallengang, den Blinddarm, die Vagina und den Oropharynx betreffen, fallen in diese Kategorie, sofern keine Anzeichen für eine Infektion oder eine wesentliche Unterbrechung der sterilen Technik zu verzeichnen sind."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
+msgstr ""
+"Eine Operationswunde, bei der die Atemwege, der Verdauungstrakt, der "
+"Genitaltrakt oder die Harnwege unter kontrollierten Bedingungen und ohne "
+"ungewöhnliche Kontamination erreicht werden.  Insbesondere Operationen, die "
+"den Gallengang, den Blinddarm, die Vagina und den Oropharynx betreffen, "
+"fallen in diese Kategorie, sofern keine Anzeichen für eine Infektion oder "
+"eine wesentliche Unterbrechung der sterilen Technik zu verzeichnen sind."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
@@ -1703,8 +2967,16 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class-iii]]Klasse III/Kontami
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
-msgstr "Offene, frische, zufällige Wunden.  Außerdem gehören zu dieser Kategorie Operationen mit größeren Unterbrechungen der sterilen Technik (z. B. offene Herzmassage) oder grobe Verschüttungen aus dem Magen-Darm-Trakt sowie Schnitte, bei denen eine akute oder keine eitrige Entzündung auftritt."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
+msgstr ""
+"Offene, frische, zufällige Wunden.  Außerdem gehören zu dieser Kategorie "
+"Operationen mit größeren Unterbrechungen der sterilen Technik (z. B. offene "
+"Herzmassage) oder grobe Verschüttungen aus dem Magen-Darm-Trakt sowie "
+"Schnitte, bei denen eine akute oder keine eitrige Entzündung auftritt."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
@@ -1714,8 +2986,17 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class-iv]]Klasse IV/schmutzig
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
-msgstr "Alte traumatische Wunden mit zurückgebliebenem devitalisiertem Gewebe und solche, die eine bestehende klinische Infektion oder perforierte Eingeweide aufweisen.  Diese Definition legt nahe, dass die Organismen, die eine postoperative Infektion verursachen, bereits vor der Operation im Operationsfeld vorhanden waren."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
+msgstr ""
+"Alte traumatische Wunden mit zurückgebliebenem devitalisiertem Gewebe und "
+"solche, die eine bestehende klinische Infektion oder perforierte Eingeweide "
+"aufweisen.  Diese Definition legt nahe, dass die Organismen, die eine "
+"postoperative Infektion verursachen, bereits vor der Operation im "
+"Operationsfeld vorhanden waren."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:630
@@ -1725,8 +3006,14 @@ msgstr "[[data-dictionary-surgical-procedure-asa-score]]ASA-Score"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
-msgstr "Das Klassifizierungssystem für den körperlichen Zustand der American Society of Anesthesiologists (ASA) zur Bewertung und Mitteilung der medizinischen Komorbiditäten eines Patienten vor der Anästhesie:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
+msgstr ""
+"Das Klassifizierungssystem für den körperlichen Zustand der American Society "
+"of Anesthesiologists (ASA) zur Bewertung und Mitteilung der medizinischen "
+"Komorbiditäten eines Patienten vor der Anästhesie:"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:633
@@ -1769,8 +3056,12 @@ msgstr "[[data-dictionary-surgical-procedure-asa-score-iv]]ASA IV"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
-msgid "A patient with severe systemic disease that is a constant threat to life"
-msgstr "Ein Patient mit einer schweren Systemerkrankung: Ein Patient mit einer schweren systemischen Erkrankung, die eine ständige Bedrohung für das Leben darstellt"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
+msgstr ""
+"Ein Patient mit einer schweren Systemerkrankung: Ein Patient mit einer "
+"schweren systemischen Erkrankung, die eine ständige Bedrohung für das Leben "
+"darstellt"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
@@ -1781,12 +3072,18 @@ msgstr "[[data-dictionary-surgical-procedure-asa-score-v]]ASA V"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:638
 msgid "A moribund patient who is not expected to survive without the operation"
-msgstr "Ein todkranker Patient, der ohne die Operation voraussichtlich nicht überleben wird"
+msgstr ""
+"Ein todkranker Patient, der ohne die Operation voraussichtlich nicht "
+"überleben wird"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
-msgstr "Besuchen Sie https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
+msgstr ""
+"Besuchen Sie https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
@@ -1817,8 +3114,13 @@ msgstr "Nein"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
-msgstr "Der Eingriff wurde offen oder endoskopisch assistiert durchgeführt, oder es wurde während eines endoskopischen Eingriffs zu einer offenen Technik gewechselt."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
+msgstr ""
+"Der Eingriff wurde offen oder endoskopisch assistiert durchgeführt, oder es "
+"wurde während eines endoskopischen Eingriffs zu einer offenen Technik "
+"gewechselt."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
@@ -1828,8 +3130,12 @@ msgstr "[[data-dictionary-surgical-procedure-emergency]]Notfalleingriff"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
-msgstr "Ein Verfahren, das gemäß dem Protokoll der Einrichtung als Notfall- oder Dringlichkeitsverfahren dokumentiert ist."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
+msgstr ""
+"Ein Verfahren, das gemäß dem Protokoll der Einrichtung als Notfall- oder "
+"Dringlichkeitsverfahren dokumentiert ist."
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:647
@@ -1855,13 +3161,32 @@ msgstr "[[data-dictionary-surgical-procedure-primary-closure]]Primärer Verschlu
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
-msgstr "Der Verschluss des Hautniveaus während des ursprünglichen Eingriffs, unabhängig vom Vorhandensein von Drähten, Dochten, Drainagen oder anderen Vorrichtungen oder Gegenständen, die durch den Einschnitt herausragen.  Diese Kategorie umfasst Operationen, bei denen die Haut auf irgendeine Weise verschlossen wird.  Wenn also ein Teil der Inzision auf Hautniveau auf irgendeine Weise verschlossen wird, sollte die Operation als Primärverschluss bezeichnet werden."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
+msgstr ""
+"Der Verschluss des Hautniveaus während des ursprünglichen Eingriffs, "
+"unabhängig vom Vorhandensein von Drähten, Dochten, Drainagen oder anderen "
+"Vorrichtungen oder Gegenständen, die durch den Einschnitt herausragen.  "
+"Diese Kategorie umfasst Operationen, bei denen die Haut auf irgendeine Weise "
+"verschlossen wird.  Wenn also ein Teil der Inzision auf Hautniveau auf "
+"irgendeine Weise verschlossen wird, sollte die Operation als "
+"Primärverschluss bezeichnet werden."
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
-msgstr "Wenn ein Verfahren mehrere Inzisionen/laparoskopische Trokarstellen hat und eine der Inzisionen primär verschlossen wird, dann wird die Verfahrenstechnik als primär verschlossen erfasst."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
+msgstr ""
+"Wenn ein Verfahren mehrere Inzisionen/laparoskopische Trokarstellen hat und "
+"eine der Inzisionen primär verschlossen wird, dann wird die "
+"Verfahrenstechnik als primär verschlossen erfasst."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:654
@@ -1871,8 +3196,14 @@ msgstr "[[data-dictionary-surgical-procedure-revision-procedure]]Revisionsverfah
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
-msgstr "Revisionseingriffe sind Folge-, Ersatz- oder Korrektureingriffe nach einem Ersteingriff.  Mit einem Revisionseingriff wird die Nachsorge für den Primäreingriff beendet und ein neuer Nachsorgezeitraum begonnen."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
+msgstr ""
+"Revisionseingriffe sind Folge-, Ersatz- oder Korrektureingriffe nach einem "
+"Ersteingriff.  Mit einem Revisionseingriff wird die Nachsorge für den "
+"Primäreingriff beendet und ein neuer Nachsorgezeitraum begonnen."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
@@ -1882,8 +3213,16 @@ msgstr "[[data-dictionary-surgical-procedure-implant]]Implantat"
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
-msgstr "Ein Implantat ist ein Fremdkörper nicht-menschlichen Ursprungs, der einem Patienten während einer Operation dauerhaft eingesetzt wird und nicht routinemäßig zu diagnostischen oder therapeutischen Zwecken manipuliert wird (z. B. Gefäßprothesen, Schrauben, Drähte, Netze)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
+msgstr ""
+"Ein Implantat ist ein Fremdkörper nicht-menschlichen Ursprungs, der einem "
+"Patienten während einer Operation dauerhaft eingesetzt wird und nicht "
+"routinemäßig zu diagnostischen oder therapeutischen Zwecken manipuliert wird "
+"(z. B. Gefäßprothesen, Schrauben, Drähte, Netze)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
@@ -1893,8 +3232,22 @@ msgstr "[[data-dictionary-surgical-procedure-signs-of-infetion]]Anzeichen einer 
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
-msgstr "Dieses Feld ist auszufüllen, wenn während des chirurgischen Eingriffs Anzeichen einer Infektion festgestellt wurden.  Die Anzeichen einer Infektion müssen intraoperativ festgestellt und im narrativen Teil der Operationsnotiz oder des Operationsberichts dokumentiert werden.  Wenn eine Infektion der Operationsstelle auftritt, werden diese Informationen verwendet, um festzustellen, ob die in diesem Abschnitt aufgeführten Anzeichen als „Infektion zum Zeitpunkt der Operation vorhanden“ interpretiert werden können."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
+msgstr ""
+"Dieses Feld ist auszufüllen, wenn während des chirurgischen Eingriffs "
+"Anzeichen einer Infektion festgestellt wurden.  Die Anzeichen einer "
+"Infektion müssen intraoperativ festgestellt und im narrativen Teil der "
+"Operationsnotiz oder des Operationsberichts dokumentiert werden.  Wenn eine "
+"Infektion der Operationsstelle auftritt, werden diese Informationen "
+"verwendet, um festzustellen, ob die in diesem Abschnitt aufgeführten "
+"Anzeichen als „Infektion zum Zeitpunkt der Operation vorhanden“ "
+"interpretiert werden können."
 
 #. type: Block title
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:661
@@ -1904,43 +3257,94 @@ msgstr "Anzeichen einer Infektion zum Zeitpunkt der Operation"
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
-msgstr "Beispiele, die auf eine Infektion hinweisen, sind unter anderem: Abszess, Infektion, Eiter, Phlegma oder „fäkale Peritonitis“.  Ein durchgebrochener/perforierter Blinddarm ist ein Hinweis auf eine Infektion auf der Ebene des Organs/Raums."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
+msgstr ""
+"Beispiele, die auf eine Infektion hinweisen, sind unter anderem: Abszess, "
+"Infektion, Eiter, Phlegma oder „fäkale Peritonitis“.  Ein durchgebrochener/"
+"perforierter Blinddarm ist ein Hinweis auf eine Infektion auf der Ebene des "
+"Organs/Raums."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
-msgstr "Beispiele für Formulierungen, die nicht als Beweis für eine Infektion gelten, sind u. a.: Dickdarmperforation, Kontamination, Nekrose, Gangrän, Verschütten von Fäkalien, während des Eingriffs eingekerbter Darm, trübe Flüssigkeit oder Dokumentation einer Entzündung."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
+msgstr ""
+"Beispiele für Formulierungen, die nicht als Beweis für eine Infektion "
+"gelten, sind u. a.: Dickdarmperforation, Kontamination, Nekrose, Gangrän, "
+"Verschütten von Fäkalien, während des Eingriffs eingekerbter Darm, trübe "
+"Flüssigkeit oder Dokumentation einer Entzündung."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
-msgstr "Die Verwendung der Endung „itis“ in einer Operationsnotiz/einem Operationsbericht gilt nicht automatisch als Beweis für eine Infektion, da sie nur eine Entzündung widerspiegeln kann, die nicht infektiöser Natur ist (z. B. Divertikulitis, Peritonitis und Appendizitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
+msgstr ""
+"Die Verwendung der Endung „itis“ in einer Operationsnotiz/einem "
+"Operationsbericht gilt nicht automatisch als Beweis für eine Infektion, da "
+"sie nur eine Entzündung widerspiegeln kann, die nicht infektiöser Natur ist "
+"(z. B. Divertikulitis, Peritonitis und Appendizitis)."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
-msgstr "Befunde aus Pathologieberichten und bildgebenden Verfahren können nicht als Nachweis für eine Infektion herangezogen werden."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
+msgstr ""
+"Befunde aus Pathologieberichten und bildgebenden Verfahren können nicht als "
+"Nachweis für eine Infektion herangezogen werden."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
-msgstr "Die Identifizierung eines Organismus mit Hilfe einer Kultur oder einer nicht kulturbasierten mikrobiologischen Testmethode oder in einem Pathologiebericht einer chirurgischen Probe kann nicht als Nachweis für eine Infektion herangezogen werden."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
+msgstr ""
+"Die Identifizierung eines Organismus mit Hilfe einer Kultur oder einer nicht "
+"kulturbasierten mikrobiologischen Testmethode oder in einem "
+"Pathologiebericht einer chirurgischen Probe kann nicht als Nachweis für eine "
+"Infektion herangezogen werden."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:670
 msgid "Wound class cannot be used as evidence of infection."
-msgstr "Die Klasse der Wunde kann nicht als Beweis für eine Infektion herangezogen werden."
+msgstr ""
+"Die Klasse der Wunde kann nicht als Beweis für eine Infektion herangezogen "
+"werden."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
-msgstr "Ein Trauma, das zu einem kontaminierten Fall führt, gilt nicht automatisch als Nachweis einer Infektion.  Zum Beispiel kann eine frische Schusswunde im Bauch ein Trauma mit einer hohen Wundklasse sein, aber es wäre nicht genug Zeit, um eine Infektion zu entwickeln."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
+msgstr ""
+"Ein Trauma, das zu einem kontaminierten Fall führt, gilt nicht automatisch "
+"als Nachweis einer Infektion.  Zum Beispiel kann eine frische Schusswunde im "
+"Bauch ein Trauma mit einer hohen Wundklasse sein, aber es wäre nicht genug "
+"Zeit, um eine Infektion zu entwickeln."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
-msgstr "Verfahrensbedingte Komplikationen wie eine Darmperforation während einer Operation können nicht als Beweis für eine Infektion gelten, da zum Zeitpunkt der Operation keine Infektion vorlag."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
+msgstr ""
+"Verfahrensbedingte Komplikationen wie eine Darmperforation während einer "
+"Operation können nicht als Beweis für eine Infektion gelten, da zum "
+"Zeitpunkt der Operation keine Infektion vorlag."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:676
@@ -1962,8 +3366,13 @@ msgstr "[[data-dictionary-general-infection-data-infection-date]]Infektionsdatum
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
-msgstr "Der Tag, an dem die ersten Infektionssymptome auftraten.  Wenn keine Symptome auftreten, der Tag der ersten positiven Kultur am Ort der Primärinfektion."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
+msgstr ""
+"Der Tag, an dem die ersten Infektionssymptome auftraten.  Wenn keine "
+"Symptome auftreten, der Tag der ersten positiven Kultur am Ort der "
+"Primärinfektion."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:682
@@ -1973,8 +3382,18 @@ msgstr "[[data-dictionary-general-infection-data-common-commensal]]Common commen
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
-msgstr "Eine Art von Mikroorganismen (z. B. koagulasenegative Staphylokokken), die häufig auf epithelbedeckten Körperoberflächen (z. B. der Haut) vorkommen.  Wenn eine oder mehrere dieser Arten in einer Blutkultur wachsen, ist eine Kontamination wahrscheinlicher, als wenn ein anerkannter Erreger wächst.  Siehe Master Organism List auf https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
+msgstr ""
+"Eine Art von Mikroorganismen (z. B. koagulasenegative Staphylokokken), die "
+"häufig auf epithelbedeckten Körperoberflächen (z. B. der Haut) vorkommen.  "
+"Wenn eine oder mehrere dieser Arten in einer Blutkultur wachsen, ist eine "
+"Kontamination wahrscheinlicher, als wenn ein anerkannter Erreger wächst.  "
+"Siehe Master Organism List auf https://neoipc.org/surveillance/resources/"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:686
@@ -1985,12 +3404,15 @@ msgstr "[[data-dictionary-general-infection-data-mdros]]Multiresistente Organism
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:687
 msgid "Select the one(s) applicable to the isolated organism;"
-msgstr "Wählen Sie die für den isolierten Organismus zutreffende(n) Bezeichnung(en) aus;"
+msgstr ""
+"Wählen Sie die für den isolierten Organismus zutreffende(n) Bezeichnung(en) "
+"aus;"
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:688
 msgid "MRSA/VRE/3GCR: Choose if one of the following applies:"
-msgstr "MRSA/VRE/3GCR: Wählen Sie aus, ob eine der folgenden Bedingungen zutrifft:"
+msgstr ""
+"MRSA/VRE/3GCR: Wählen Sie aus, ob eine der folgenden Bedingungen zutrifft:"
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:689
@@ -2004,18 +3426,35 @@ msgstr "VRE: Vancomycin-resistente Enterokokken"
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
-msgstr "3GCR: Multiresistente gramnegative Erreger, die nach den Cut-off-Werten des eigenen Labors gegen Cephalosporine der 3. Generation resistent sind (bezieht sich auf phänotypische Resistenz oder ESBL-produzierende Organismen)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
+msgstr ""
+"3GCR: Multiresistente gramnegative Erreger, die nach den Cut-off-Werten des "
+"eigenen Labors gegen Cephalosporine der 3. Generation resistent sind "
+"(bezieht sich auf phänotypische Resistenz oder ESBL-produzierende Organismen)"
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
-msgstr "Carbapenem-resistent: Resistent gegen mindestens eine der folgenden Substanzen (Imipenem, Meropenem, Ertapenem) gemäß den Cut-off-Werten des eigenen Labors (bezieht sich auf phänotypische Resistenz oder Carbapenemase-produzierende Organismen)."
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
+msgstr ""
+"Carbapenem-resistent: Resistent gegen mindestens eine der folgenden "
+"Substanzen (Imipenem, Meropenem, Ertapenem) gemäß den Cut-off-Werten des "
+"eigenen Labors (bezieht sich auf phänotypische Resistenz oder Carbapenemase-"
+"produzierende Organismen)."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
-msgstr "Colistin-resistent: Resistent gegen Colistin gemäß den Cut-off-Werten des eigenen Labors."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
+msgstr ""
+"Colistin-resistent: Resistent gegen Colistin gemäß den Cut-off-Werten des "
+"eigenen Labors."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:695
@@ -2024,18 +3463,29 @@ msgstr "Optionen für jede Gruppe:"
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
-msgstr "Ja: Der isolierte Organismus ist gegen die angegebene(n) Antibiotikagruppe(n) resistent."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgstr ""
+"Ja: Der isolierte Organismus ist gegen die angegebene(n) "
+"Antibiotikagruppe(n) resistent."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
-msgstr "Nein: Der isolierte Organismus ist nicht resistent gegen die angegebene(n) Antibiotikagruppe(n)."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
+msgstr ""
+"Nein: Der isolierte Organismus ist nicht resistent gegen die angegebene(n) "
+"Antibiotikagruppe(n)."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
-msgstr "Nicht getestet: Der isolierte Organismus wurde nicht auf Resistenz gegen die angegebene(n) Antibiotikagruppe(n) getestet."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
+msgstr ""
+"Nicht getestet: Der isolierte Organismus wurde nicht auf Resistenz gegen die "
+"angegebene(n) Antibiotikagruppe(n) getestet."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:700
@@ -2046,29 +3496,66 @@ msgstr "[[data-dictionary-general-infection-data-secondary-bsi]]Sekundäre Bluts
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
 #, fuzzy
-#| msgid "A BSI that is thought to be seeded from a site-specific infection at another body site (except for catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
-msgstr "Eine BSI, von der man annimmt, dass sie von einer ortsspezifischen Infektion an einer anderen Körperstelle ausgeht (außer bei katheterassoziierten Infektionen).  Eine BSI kann auf eine ortsspezifische Infektion (NEC, PN oder SSI) zurückgeführt werden, wenn sie in einem Zeitraum von 17 Tagen auftritt, der den Tag der Infektion (=erste Symptome der ortsspezifischen Infektion), 3 Tage davor und 13 Tage danach umfasst."
+#| msgid ""
+#| "A BSI that is thought to be seeded from a site-specific infection at "
+#| "another body site (except for catheter-associated infections).  A BSI can "
+#| "be attributed to a site-specific infection (NEC, PN or SSI) if it occurs "
+#| "in a 17-day period that includes the day of infection (=first symptoms of "
+#| "site-specific infection), 3 days prior, and 13 days after."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
+msgstr ""
+"Eine BSI, von der man annimmt, dass sie von einer ortsspezifischen Infektion "
+"an einer anderen Körperstelle ausgeht (außer bei katheterassoziierten "
+"Infektionen).  Eine BSI kann auf eine ortsspezifische Infektion (NEC, PN "
+"oder SSI) zurückgeführt werden, wenn sie in einem Zeitraum von 17 Tagen "
+"auftritt, der den Tag der Infektion (=erste Symptome der ortsspezifischen "
+"Infektion), 3 Tage davor und 13 Tage danach umfasst."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
-msgstr "Die Erfassung von Daten über sekundäre BSI ist fakultativ; daher ist es möglich, „No follow-up“ auszuwählen, wenn Sie die Patienten nicht auf sekundäre BSI hin verfolgen.  Ausführliche Informationen finden Sie unter Sekundäre Blutstrominfektion."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
+msgstr ""
+"Die Erfassung von Daten über sekundäre BSI ist fakultativ; daher ist es "
+"möglich, „No follow-up“ auszuwählen, wenn Sie die Patienten nicht auf "
+"sekundäre BSI hin verfolgen.  Ausführliche Informationen finden Sie unter "
+"Sekundäre Blutstrominfektion."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
-msgstr "Ja: wenn Sie Patienten wegen sekundärer BSI verfolgen und der Patient eine sekundäre Sepsis entwickelt hat, die der Definition von NeoIPC entspricht (aktiviert ein Feld unten, in das Sie identifizierte Organismen eingeben können)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
+msgstr ""
+"Ja: wenn Sie Patienten wegen sekundärer BSI verfolgen und der Patient eine "
+"sekundäre Sepsis entwickelt hat, die der Definition von NeoIPC entspricht "
+"(aktiviert ein Feld unten, in das Sie identifizierte Organismen eingeben "
+"können)"
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
-msgstr "Nein: wenn Sie Patienten wegen sekundärer BSI verfolgen und der Patient keine sekundäre Sepsis entwickelt hat, die der Definition von NeoIPC entspricht"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
+msgstr ""
+"Nein: wenn Sie Patienten wegen sekundärer BSI verfolgen und der Patient "
+"keine sekundäre Sepsis entwickelt hat, die der Definition von NeoIPC "
+"entspricht"
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:709
 msgid "No follow-up: if you are not following patients for secondary BSI."
-msgstr "Kein Follow-up: wenn Sie die Patienten nicht auf sekundäre BSI hin verfolgen."
+msgstr ""
+"Kein Follow-up: wenn Sie die Patienten nicht auf sekundäre BSI hin verfolgen."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:711
@@ -2084,13 +3571,23 @@ msgstr "[[data-dictionary-bsi-specific-data-cvc]]Zentraler Gefäßkatheter (ZVK)
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
-msgstr "Ein intravaskulärer Katheter, der am oder in der Nähe des Herzens oder in einem der großen Gefäße endet und für Infusionen, Blutentnahmen oder hämodynamisches Monitoring verwendet wird."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
+msgstr ""
+"Ein intravaskulärer Katheter, der am oder in der Nähe des Herzens oder in "
+"einem der großen Gefäße endet und für Infusionen, Blutentnahmen oder "
+"hämodynamisches Monitoring verwendet wird."
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
-msgstr "Zentraler Venenkatheter (ZVK), einschließlich nicht getunnelter, getunnelter und implantierter zentraler Venenkatheter."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
+msgstr ""
+"Zentraler Venenkatheter (ZVK), einschließlich nicht getunnelter, getunnelter "
+"und implantierter zentraler Venenkatheter."
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:717
@@ -2104,13 +3601,19 @@ msgstr "Nabelarterienkatheter (UAC) oder Nabelvenenkatheter (UVC)"
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
-msgstr "Extrakorporale Membranoxygenierung (ECMO) und arterielle Katheter (außer Pulmonalarterie, Aorta oder Nabelarterie) gelten NICHT als ZVK."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgstr ""
+"Extrakorporale Membranoxygenierung (ECMO) und arterielle Katheter (außer "
+"Pulmonalarterie, Aorta oder Nabelarterie) gelten NICHT als ZVK."
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
-msgstr "Die folgenden Gefäße gelten als große Gefäße zum Zweck der Meldung von ZVKs:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
+msgstr ""
+"Die folgenden Gefäße gelten als große Gefäße zum Zweck der Meldung von ZVKs:"
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:724
@@ -2175,8 +3678,16 @@ msgstr "[[data-dictionary-bsi-specific-data-cvc-associated-bsi]]ZVK-associated B
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
-msgstr "Eine primäre Blutstrominfektion gilt als <<bsi-specific-data_cvc,ZVK>>-associated, wenn der ZVK am Tag der Infektion (=erste Symptome oder erster positiver diagnostischer Test; z. B. Kultur) oder am Tag davor mindestens drei aufeinanderfolgende Tage lang angelegt war."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
+msgstr ""
+"Eine primäre Blutstrominfektion gilt als <<bsi-specific-data_cvc,ZVK>>-"
+"associated, wenn der ZVK am Tag der Infektion (=erste Symptome oder erster "
+"positiver diagnostischer Test; z. B. Kultur) oder am Tag davor mindestens "
+"drei aufeinanderfolgende Tage lang angelegt war."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:738
@@ -2186,8 +3697,12 @@ msgstr "[[data-dictionary-bsi-specific-data-cvc-day]]ZVK-Tag"
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
-msgstr "Ein Tag, an dem der Patient einen <<bsi-spezifischen Daten_cvc,ZVK>> für mindestens 12 Stunden kumulativ platziert hatte."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
+msgstr ""
+"Ein Tag, an dem der Patient einen <<bsi-spezifischen Daten_cvc,ZVK>> für "
+"mindestens 12 Stunden kumulativ platziert hatte."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:740
@@ -2197,8 +3712,12 @@ msgstr "[[data-dictionary-bsi-specific-data-pvc]]Peripherer Gefäßkatheter (PVC
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
-msgstr "Ein PVC ist ein Katheter, der in eine periphere Vene gelegt wird und nicht in eines der unter ZVK genannten großen Gefäße reicht."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
+msgstr ""
+"Ein PVC ist ein Katheter, der in eine periphere Vene gelegt wird und nicht "
+"in eines der unter ZVK genannten großen Gefäße reicht."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:742
@@ -2208,8 +3727,25 @@ msgstr "[[data-dictionary-bsi-specific-data-pvc-associated-bsi]]PVC-assoziierte 
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
-msgstr "Eine primäre Blutstrominfektion gilt als <<bsi-spezifische-daten_pvc,PVC>>-assoziiert, wenn der PVC am Tag der Infektion (=erste Symptome oder erster positiver diagnostischer Test; z. B. Kultur) oder am Tag davor mindestens drei aufeinanderfolgende Tage lang vorhanden war und nicht die Kriterien für ZVK-assoziierte BSI erfüllt.  Das heißt, wenn ein Patient, bei dem eine Blutstrominfektion auftritt, sowohl die Kriterien für eine PVC- als auch für eine ZVK-Assoziation erfüllt, wird der ZVK als das Device mit dem relativ höheren Infektionsrisiko betrachtet, und die BSI sollte als ZVK-assoziierte BSI erfasst werden."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
+msgstr ""
+"Eine primäre Blutstrominfektion gilt als <<bsi-spezifische-daten_pvc,PVC>>-"
+"assoziiert, wenn der PVC am Tag der Infektion (=erste Symptome oder erster "
+"positiver diagnostischer Test; z. B. Kultur) oder am Tag davor mindestens "
+"drei aufeinanderfolgende Tage lang vorhanden war und nicht die Kriterien für "
+"ZVK-assoziierte BSI erfüllt.  Das heißt, wenn ein Patient, bei dem eine "
+"Blutstrominfektion auftritt, sowohl die Kriterien für eine PVC- als auch für "
+"eine ZVK-Assoziation erfüllt, wird der ZVK als das Device mit dem relativ "
+"höheren Infektionsrisiko betrachtet, und die BSI sollte als ZVK-assoziierte "
+"BSI erfasst werden."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:745
@@ -2219,8 +3755,12 @@ msgstr "[[data-dictionary-bsi-specific-data-pvc-day]]PVC-Tag"
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
-msgstr "Ein Tag, an dem der Patient einen <<bsi-spezifischen Daten_pvc,PVC>> für mindestens 12 Stunden kumulativ platziert hatte."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
+msgstr ""
+"Ein Tag, an dem der Patient einen <<bsi-spezifischen Daten_pvc,PVC>> für "
+"mindestens 12 Stunden kumulativ platziert hatte."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:747
@@ -2230,8 +3770,28 @@ msgstr "[[data-dictionary-bsi-specific-data-iv-ab-therapy-initiated]]Intravenös
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
-msgstr "Es wurde eine Antibiotikabehandlung für mindestens fünf Tage eingeleitet.  Gezählt werden der Tag der ersten und der Tag der letzten Dosis.  Tage, an denen zwischen der ersten und der letzten Dosis keine Dosis verabreicht wurde (z. B. ausgelassene Dosen wegen hoher Wirkstoffspiegel in der therapeutischen Arzneimittelüberwachung), werden gezählt, als ob eine Dosis verabreicht worden wäre.  Tage nach der letzten Dosis werden nicht gezählt, unabhängig vom gemessenen oder angenommenen Medikamentenspiegel des Patienten.  Wenn das Kind vor dem Ende der fünftägigen Behandlung mit intravenösen Antibiotika gestorben ist, entlassen oder verlegt wurde, ist diese Bedingung erfüllt, wenn die Behandlung für fünf oder mehr Tage geplant war."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
+msgstr ""
+"Es wurde eine Antibiotikabehandlung für mindestens fünf Tage eingeleitet.  "
+"Gezählt werden der Tag der ersten und der Tag der letzten Dosis.  Tage, an "
+"denen zwischen der ersten und der letzten Dosis keine Dosis verabreicht "
+"wurde (z. B. ausgelassene Dosen wegen hoher Wirkstoffspiegel in der "
+"therapeutischen Arzneimittelüberwachung), werden gezählt, als ob eine Dosis "
+"verabreicht worden wäre.  Tage nach der letzten Dosis werden nicht gezählt, "
+"unabhängig vom gemessenen oder angenommenen Medikamentenspiegel des "
+"Patienten.  Wenn das Kind vor dem Ende der fünftägigen Behandlung mit "
+"intravenösen Antibiotika gestorben ist, entlassen oder verlegt wurde, ist "
+"diese Bedingung erfüllt, wenn die Behandlung für fünf oder mehr Tage geplant "
+"war."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:753
@@ -2241,8 +3801,17 @@ msgstr "[[data-dictionary-bsi-specific-data-increased-oxygen-demand-or-ventilato
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
-msgstr "Neue oder häufigere Apnoe-Episoden, die länger als 20 Sekunden dauern, oder ein Anstieg der Sauerstoffmenge, die zur Aufrechterhaltung einer angemessenen Sauerstoffversorgung erforderlich ist, oder eine Eskalation der Beatmungsunterstützung, wie z. B. ein erhöhter Flow bei der High-Flow-Therapie oder eine Intubation zur invasiven Beatmung."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
+msgstr ""
+"Neue oder häufigere Apnoe-Episoden, die länger als 20 Sekunden dauern, oder "
+"ein Anstieg der Sauerstoffmenge, die zur Aufrechterhaltung einer "
+"angemessenen Sauerstoffversorgung erforderlich ist, oder eine Eskalation der "
+"Beatmungsunterstützung, wie z. B. ein erhöhter Flow bei der High-Flow-"
+"Therapie oder eine Intubation zur invasiven Beatmung."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:755
@@ -2252,8 +3821,14 @@ msgstr "[[data-dictionary-bsi-specific-data-enteral-feeding-intolerance]]Intoler
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
-msgstr "Intoleranz der enteralen Ernährung, abdominale Distension oder Ileus ohne bildgebende oder chirurgische Befunde, die sonst auf eine nekrotisierende Entrokolitis oder eine spontane Darmperforation hindeuten würden."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
+msgstr ""
+"Intoleranz der enteralen Ernährung, abdominale Distension oder Ileus ohne "
+"bildgebende oder chirurgische Befunde, die sonst auf eine nekrotisierende "
+"Entrokolitis oder eine spontane Darmperforation hindeuten würden."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:757
@@ -2263,8 +3838,12 @@ msgstr "[[data-dictionary-bsi-specific-data-unexplained-metabolic-acidosis]]Unge
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
-msgstr "Ungeklärte metabolische Azidose mit einem Basendefizit größer (negativer) als 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
+msgstr ""
+"Ungeklärte metabolische Azidose mit einem Basendefizit größer (negativer) "
+"als 10 mmol/L (10 mEq/L)."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:760
@@ -2281,7 +3860,8 @@ msgstr "[[data-dictionary-nec-specific-data-portal-veinous-gas]]Portalvenöses G
 #. type: #data-dictionary-nec-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:762
 msgid "Accumulation of gas (-bubbles) in the portal vein and its branches."
-msgstr "Ansammlung von Gas (-bläschen) in der Pfortader und ihren Verzweigungen."
+msgstr ""
+"Ansammlung von Gas (-bläschen) in der Pfortader und ihren Verzweigungen."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:764
@@ -2303,8 +3883,12 @@ msgstr "Neuaufnahme der Beatmungsunterstützung oder Erhöhung des bestehenden N
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
-msgstr "Anstieg des Bedarfs an FiO2 ≥ 0,25 (25 Punkte) innerhalb von 24 Stunden (tägliche Mindest-FiO2-Werte müssen hier berücksichtigt werden)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
+msgstr ""
+"Anstieg des Bedarfs an FiO2 ≥ 0,25 (25 Punkte) innerhalb von 24 Stunden "
+"(tägliche Mindest-FiO2-Werte müssen hier berücksichtigt werden)"
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:773
@@ -2318,14 +3902,22 @@ msgstr "ODER"
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
-msgstr "Beginn der nicht-invasiven Beatmungsunterstützung (ausgenommen Umstellung von invasiver Beatmung)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
+msgstr ""
+"Beginn der nicht-invasiven Beatmungsunterstützung (ausgenommen Umstellung "
+"von invasiver Beatmung)"
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
-msgstr "Beginn der invasiven mechanischen Beatmung (einschließlich Umstellung von nicht-invasiver Beatmungsunterstützung)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
+msgstr ""
+"Beginn der invasiven mechanischen Beatmung (einschließlich Umstellung von "
+"nicht-invasiver Beatmungsunterstützung)"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:778
@@ -2336,7 +3928,9 @@ msgstr "… der sich nicht innerhalb von weniger als 2 Tagen bessert"
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:779
 msgid "The above-mentioned condition should not improve within two days."
-msgstr "Der oben erwähnte Zustand sollte sich nicht innerhalb von zwei Tagen verbessern."
+msgstr ""
+"Der oben erwähnte Zustand sollte sich nicht innerhalb von zwei Tagen "
+"verbessern."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:780
@@ -2346,13 +3940,25 @@ msgstr "… nach mindestens 2 Tagen der Stabilität oder Verbesserung"
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
-msgstr "Eine stabile oder sich verbessernde Ausgangssituation von mindestens zwei Tagen ist erforderlich, bevor die oben genannte Bedingung eintritt."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
+msgstr ""
+"Eine stabile oder sich verbessernde Ausgangssituation von mindestens zwei "
+"Tagen ist erforderlich, bevor die oben genannte Bedingung eintritt."
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
-msgstr "Um das Kriterium der Device-assoziierten, im Krankenhaus erworbenen Pneumonie zu erfüllen, müssen die Patienten mindestens 4 Kalendertage lang beatmet werden (Tag 1 ist der Tag, an dem die invasive/nicht-invasive Beatmung beginnt). Das früheste Datum des Ereignisses ist Tag 3 der Beatmung."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
+msgstr ""
+"Um das Kriterium der Device-assoziierten, im Krankenhaus erworbenen "
+"Pneumonie zu erfüllen, müssen die Patienten mindestens 4 Kalendertage lang "
+"beatmet werden (Tag 1 ist der Tag, an dem die invasive/nicht-invasive "
+"Beatmung beginnt). Das früheste Datum des Ereignisses ist Tag 3 der Beatmung."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:785
@@ -2373,8 +3979,16 @@ msgstr "[[data-dictionary-pneumonia-specific-data-inv-associated-pneumonia]]INV-
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
-msgstr "Eine Pneumonie ist mit <<pneumonie-spezifischen-daten_inv,INV>> assoziiert, wenn der Patient am Tag der Infektion (=erste Symptome oder erste positive Kultur) oder am Tag davor an mindestens 3 aufeinander folgenden Tagen einen Endotracheal- oder Tracheostomietubus hatte."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
+msgstr ""
+"Eine Pneumonie ist mit <<pneumonie-spezifischen-daten_inv,INV>> assoziiert, "
+"wenn der Patient am Tag der Infektion (=erste Symptome oder erste positive "
+"Kultur) oder am Tag davor an mindestens 3 aufeinander folgenden Tagen einen "
+"Endotracheal- oder Tracheostomietubus hatte."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:789
@@ -2384,8 +3998,12 @@ msgstr "[[data-dictionary-pneumonia-specific-data-inv-day]]INV-Day"
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
-msgstr "Ein Tag, an dem der Patient mindestens 12 Stunden lang kumulativ invasiv über einen Endotracheal- oder Tracheostomietubus beatmet wurde."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
+msgstr ""
+"Ein Tag, an dem der Patient mindestens 12 Stunden lang kumulativ invasiv "
+"über einen Endotracheal- oder Tracheostomietubus beatmet wurde."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:791
@@ -2406,8 +4024,17 @@ msgstr "[[data-dictionary-pneumonia-specific-data-niv-associated-pneumonia]]NIV-
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
-msgstr "Eine Pneumonie ist <<pneumonie-spezifische-daten_niv,NIV>>-assoziiert, wenn der Patient am Tag der Infektion (=erste Symptome oder erste positive Kultur) oder am Tag davor an mindestens 3 aufeinanderfolgenden Tagen nicht-invasive Beatmungsunterstützung (z. B. CPAP oder High-Flow-Nasenkanüle) erhalten hat."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
+msgstr ""
+"Eine Pneumonie ist <<pneumonie-spezifische-daten_niv,NIV>>-assoziiert, wenn "
+"der Patient am Tag der Infektion (=erste Symptome oder erste positive "
+"Kultur) oder am Tag davor an mindestens 3 aufeinanderfolgenden Tagen nicht-"
+"invasive Beatmungsunterstützung (z. B. CPAP oder High-Flow-Nasenkanüle) "
+"erhalten hat."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:795
@@ -2417,8 +4044,13 @@ msgstr "NIV-Tag: [[data-dictionary-pneumonia-specific-data-niv-day]]NIV-Tag"
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
-msgstr "Ein Tag, an dem der Patient mindestens 12 Stunden lang kumulativ eine nicht-invasive Beatmungsunterstützung mittels CPAP oder High-Flow-Nasenkanüle erhielt."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgstr ""
+"Ein Tag, an dem der Patient mindestens 12 Stunden lang kumulativ eine nicht-"
+"invasive Beatmungsunterstützung mittels CPAP oder High-Flow-Nasenkanüle "
+"erhielt."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:797
@@ -2428,8 +4060,16 @@ msgstr "[[data-dictionary-pneumonia-specific-data-organisms-rt]]Identifizierte O
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
-msgstr "Mindestens ein Organismus wurde in den Atemwegen durch eine Kultur oder ein nicht kulturbasiertes mikrobiologisches Testverfahren identifiziert, das zu Zwecken der klinischen Diagnose oder Behandlung durchgeführt wird (z. B. NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
+msgstr ""
+"Mindestens ein Organismus wurde in den Atemwegen durch eine Kultur oder ein "
+"nicht kulturbasiertes mikrobiologisches Testverfahren identifiziert, das zu "
+"Zwecken der klinischen Diagnose oder Behandlung durchgeführt wird (z. B. NOT "
+"Active Surveillance Culture/Testing (ASC/AST))."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:799
@@ -2439,8 +4079,14 @@ msgstr "[[data-dictionary-pneumonia-specific-data-organisms-lrt]]Wiedergewonnen 
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
-msgstr "Wählen Sie aus, ob pilzliche, bakterielle oder virale Erreger (virales Gen, Antigen oder Antikörper, z. B. mittels EIA, FAMA, Shell Vial Assay, PCR) in den unteren Atemwegen nachgewiesen wurden."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
+msgstr ""
+"Wählen Sie aus, ob pilzliche, bakterielle oder virale Erreger (virales Gen, "
+"Antigen oder Antikörper, z. B. mittels EIA, FAMA, Shell Vial Assay, PCR) in "
+"den unteren Atemwegen nachgewiesen wurden."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
@@ -2451,7 +4097,9 @@ msgstr "[[data-dictionary-pneumonia-specific-data-organisms-urt]]Aus den oberen 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:801
 msgid "Select only if viral pathogens are detected in upper respiratory tract."
-msgstr "Nur auswählen, wenn virale Erreger in den oberen Atemwegen nachgewiesen werden."
+msgstr ""
+"Nur auswählen, wenn virale Erreger in den oberen Atemwegen nachgewiesen "
+"werden."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:803
@@ -2467,8 +4115,14 @@ msgstr "[[data-dictionary-ssi-specific-data-infection-present]]Infektion zum Zei
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
-msgstr "Wählen Sie JA, nur wenn das während des chirurgischen Eingriffs festgestellte Infektionszeichen auf die Tiefe der SSI zutrifft, die dem Eingriff zugeschrieben wird."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
+msgstr ""
+"Wählen Sie JA, nur wenn das während des chirurgischen Eingriffs "
+"festgestellte Infektionszeichen auf die Tiefe der SSI zutrifft, die dem "
+"Eingriff zugeschrieben wird."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:807
@@ -2479,13 +4133,24 @@ msgstr "Beispiel"
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
-msgstr "Wenn bei einem Patienten zum Zeitpunkt der Operation eine intraabdominale Infektion dokumentiert ist und er später mit einer Organ-/Raum-SSI zurückkehrt = JA."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
+msgstr ""
+"Wenn bei einem Patienten zum Zeitpunkt der Operation eine intraabdominale "
+"Infektion dokumentiert ist und er später mit einer Organ-/Raum-SSI "
+"zurückkehrt = JA."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
-msgstr "Wenn bei einem Patienten zum Zeitpunkt der Operation eine intraabdominale Infektion dokumentiert ist und er später mit einer oberflächlichen oder tiefen Inzisions-SSI zurückkehrt = NEIN."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
+msgstr ""
+"Wenn bei einem Patienten zum Zeitpunkt der Operation eine intraabdominale "
+"Infektion dokumentiert ist und er später mit einer oberflächlichen oder "
+"tiefen Inzisions-SSI zurückkehrt = NEIN."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:812
@@ -2495,28 +4160,64 @@ msgstr "[[data-dictionary-ssi-specific-data-ssi-type]]SSI-Typ"
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
-msgstr "Eine oberflächliche Inzisions-SSI betrifft nur die Haut und das Unterhautgewebe der Inzision, und die ersten Symptome treten innerhalb von 30 Tagen nach der Operation auf."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
+msgstr ""
+"Eine oberflächliche Inzisions-SSI betrifft nur die Haut und das "
+"Unterhautgewebe der Inzision, und die ersten Symptome treten innerhalb von "
+"30 Tagen nach der Operation auf."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
-msgstr "Eine tiefe Inzisions-SSI betrifft tiefe Weichteile der Inzision (z. B. Faszien- und Muskelschichten), und die ersten Symptome treten innerhalb von 30 Tagen nach der Operation oder 90 Tagen nach der Operation auf, wenn ein Implantat belassen wurde."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
+msgstr ""
+"Eine tiefe Inzisions-SSI betrifft tiefe Weichteile der Inzision (z. B. "
+"Faszien- und Muskelschichten), und die ersten Symptome treten innerhalb von "
+"30 Tagen nach der Operation oder 90 Tagen nach der Operation auf, wenn ein "
+"Implantat belassen wurde."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
-msgstr "Eine Organ-/Raum-SSI betrifft jeden Körperteil, der tiefer als die Faszien-/Muskelschichten liegt und während des operativen Eingriffs geöffnet oder manipuliert wurde, und erste Symptome treten innerhalb von 30 Tagen nach der Operation oder 90 Tagen nach der Operation auf, wenn ein Implantat an Ort und Stelle belassen wurde."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
+msgstr ""
+"Eine Organ-/Raum-SSI betrifft jeden Körperteil, der tiefer als die Faszien-/"
+"Muskelschichten liegt und während des operativen Eingriffs geöffnet oder "
+"manipuliert wurde, und erste Symptome treten innerhalb von 30 Tagen nach der "
+"Operation oder 90 Tagen nach der Operation auf, wenn ein Implantat an Ort "
+"und Stelle belassen wurde."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
-msgstr "Die gemeldete SSI muss die tiefste Gewebeebene widerspiegeln, in der die SSI-Kriterien während des Surveillancezeitraums erfüllt sind."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
+msgstr ""
+"Die gemeldete SSI muss die tiefste Gewebeebene widerspiegeln, in der die SSI-"
+"Kriterien während des Surveillancezeitraums erfüllt sind."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
-msgstr "Wenn eine SSI am Tag 10 des SSI-Surveillancezeitraums als tiefe Inzisions-SSI begann und dann eine Woche später (Tag 17) die Kriterien für eine Organ-/Raum-SSI erfüllt.  Sie müssen sie als Organ-/Raum-SSI melden, unabhängig davon, ob oberflächliches oder tiefes Gewebe betroffen ist.  Der Tag der Infektion wäre in diesem Fall der „Tag 17“."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
+msgstr ""
+"Wenn eine SSI am Tag 10 des SSI-Surveillancezeitraums als tiefe Inzisions-"
+"SSI begann und dann eine Woche später (Tag 17) die Kriterien für eine Organ-/"
+"Raum-SSI erfüllt.  Sie müssen sie als Organ-/Raum-SSI melden, unabhängig "
+"davon, ob oberflächliches oder tiefes Gewebe betroffen ist.  Der Tag der "
+"Infektion wäre in diesem Fall der „Tag 17“."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:827
@@ -2526,8 +4227,16 @@ msgstr "[[data-dictionary-ssi-specific-data-organism-identified]]An der Operatio
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
-msgstr "Mindestens ein Organismus wurde an der Operationsstelle durch eine Kultur oder ein nicht kulturbasiertes mikrobiologisches Testverfahren identifiziert, das zu Zwecken der klinischen Diagnose oder Behandlung durchgeführt wird (z. B. NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
+msgstr ""
+"Mindestens ein Organismus wurde an der Operationsstelle durch eine Kultur "
+"oder ein nicht kulturbasiertes mikrobiologisches Testverfahren "
+"identifiziert, das zu Zwecken der klinischen Diagnose oder Behandlung "
+"durchgeführt wird (z. B. NOT Active Surveillance Culture/Testing (ASC/AST))."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:830
@@ -2537,13 +4246,23 @@ msgstr "Datenanalyse"
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
-msgstr "Die folgenden Raten werden sowohl für die Berichte der Abteilungen als auch für die Referenzberichte berechnet und können als Ausgangspunkt für weitere Analysen und Diskussionen in Ihrer Abteilung dienen."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
+msgstr ""
+"Die folgenden Raten werden sowohl für die Berichte der Abteilungen als auch "
+"für die Referenzberichte berechnet und können als Ausgangspunkt für weitere "
+"Analysen und Diskussionen in Ihrer Abteilung dienen."
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
-msgstr "Für das Kernmodul werden die Raten im Allgemeinen nach dem Geburtsgewicht der Kinder in 4 Gruppen stratifiziert:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
+msgstr ""
+"Für das Kernmodul werden die Raten im Allgemeinen nach dem Geburtsgewicht "
+"der Kinder in 4 Gruppen stratifiziert:"
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:836
@@ -2579,28 +4298,51 @@ msgstr "Devie-Anwendung"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
-msgstr "Eine Devie-Anwendungsrate beschreibt den Prozentsatz der Patiententage, an denen ein bestimmtes Device verwendet wurde.  Sie wird berechnet, indem die Anzahl der Devicetage durch die Anzahl der Patiententage dividiert und das Ergebnis mit 100 multipliziert wird."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
+msgstr ""
+"Eine Devie-Anwendungsrate beschreibt den Prozentsatz der Patiententage, an "
+"denen ein bestimmtes Device verwendet wurde.  Sie wird berechnet, indem die "
+"Anzahl der Devicetage durch die Anzahl der Patiententage dividiert und das "
+"Ergebnis mit 100 multipliziert wird."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
-msgstr "stem:[\"ZVK Utilisation Rate\" = \"Total ZVK Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
+msgstr ""
+"stem:[\"ZVK Utilisation Rate\" = \"Total ZVK Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
-msgstr "stem:[\"PVC-Nutzungsrate\" = \"PVC-Tage gesamt\" / \"Patiententage gesamt\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
+msgstr ""
+"stem:[\"PVC-Nutzungsrate\" = \"PVC-Tage gesamt\" / \"Patiententage gesamt\" "
+"xx 100 ]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
-msgstr "stem:[\"INV-Nutzungsrate\" = \"INV-Tage gesamt\" / \"Patiententage gesamt\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
+msgstr ""
+"stem:[\"INV-Nutzungsrate\" = \"INV-Tage gesamt\" / \"Patiententage gesamt\" "
+"xx 100 ]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"NIV-Nutzungsrate\" = \"NIV-Tage gesamt\" / \"Patiententage gesamt\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
+msgstr ""
+"stem:[\"NIV-Nutzungsrate\" = \"NIV-Tage gesamt\" / \"Patiententage gesamt\" "
+"xx 100]"
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:856
@@ -2610,48 +4352,108 @@ msgstr "Antibiotika-Einsatz"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
-msgstr "Die Antibiotikagebrauchsrate beschreibt den Prozentsatz der Patiententage, an denen systemische Antibiotika eingesetzt wurden, im Verhältnis zu den gesamten Patiententagen.  Sie wird berechnet, indem die Anzahl der Antibiotikatage durch die Anzahl der Patiententage dividiert und das Ergebnis mit 100 multipliziert wird."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
+msgstr ""
+"Die Antibiotikagebrauchsrate beschreibt den Prozentsatz der Patiententage, "
+"an denen systemische Antibiotika eingesetzt wurden, im Verhältnis zu den "
+"gesamten Patiententagen.  Sie wird berechnet, indem die Anzahl der "
+"Antibiotikatage durch die Anzahl der Patiententage dividiert und das "
+"Ergebnis mit 100 multipliziert wird."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Antibiotikaeinsatzrate\" = \"Antibiotikatage insgesamt\" / \"Patiententage insgesamt\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
+msgstr ""
+"stem:[\"Antibiotikaeinsatzrate\" = \"Antibiotikatage insgesamt\" / "
+"\"Patiententage insgesamt\" xx 100]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
-msgstr "Neben der Gesamt-Antibiotika-Verbrauchsrate werden Antibiotika-Verbrauchsraten und Anteile der Patienten, die eine Substanz erhalten, für einzelne Substanzen und Substanzgruppen berechnet."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
+msgstr ""
+"Neben der Gesamt-Antibiotika-Verbrauchsrate werden Antibiotika-"
+"Verbrauchsraten und Anteile der Patienten, die eine Substanz erhalten, für "
+"einzelne Substanzen und Substanzgruppen berechnet."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
-msgstr "Die Substanzen und Gruppen werden aus der Anatomisch-Therapeutisch-Chemischen Klassifikation (ATC) Fußnote:[Anatomisch-Therapeutisch-Chemische Klassifikationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification], wie sie im neuesten ATC/DDD-Index veröffentlicht sindFußnote:[ATC/DDD-Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgstr ""
+"Die Substanzen und Gruppen werden aus der Anatomisch-Therapeutisch-"
+"Chemischen Klassifikation (ATC) Fußnote:[Anatomisch-Therapeutisch-Chemische "
+"Klassifikationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification], wie sie im neuesten ATC/DDD-Index veröffentlicht "
+"sindFußnote:[ATC/DDD-Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
-msgstr "Derzeit werden die ATC-Stufen 1, 2, 4 und 5 für die Gruppierung der Stoffe verwendet."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
+msgstr ""
+"Derzeit werden die ATC-Stufen 1, 2, 4 und 5 für die Gruppierung der Stoffe "
+"verwendet."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
-msgstr "Da die Zahlen in den einzelnen Gruppen in der Regel sehr klein werden, werden die substanz- und gruppenspezifischen Konsumraten berechnet, indem die Anzahl der Substanz(gruppen)tage durch die Anzahl der Patiententage dividiert und das Ergebnis mit 1000 multipliziert wird."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
+msgstr ""
+"Da die Zahlen in den einzelnen Gruppen in der Regel sehr klein werden, "
+"werden die substanz- und gruppenspezifischen Konsumraten berechnet, indem "
+"die Anzahl der Substanz(gruppen)tage durch die Anzahl der Patiententage "
+"dividiert und das Ergebnis mit 1000 multipliziert wird."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Substanzgruppen-Konsumrate\" = \"Gesamte Therapietage für Substanzgruppe\" / \"Gesamte Patiententage\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
+msgstr ""
+"stem:[\"Substanzgruppen-Konsumrate\" = \"Gesamte Therapietage für "
+"Substanzgruppe\" / \"Gesamte Patiententage\" xx 100]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
-msgstr "Der Anteil der Patienten, die eine bestimmte Substanz(en) einer Substanzgruppe erhalten, wird berechnet als Verhältnis zwischen der Gesamtzahl der Patienten, die eine bestimmte Substanz oder Gruppe von Antibiotika erhalten, und der Gesamtzahl der Patienten, die alle Arten von Antibiotika erhalten, multipliziert mit 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
+msgstr ""
+"Der Anteil der Patienten, die eine bestimmte Substanz(en) einer "
+"Substanzgruppe erhalten, wird berechnet als Verhältnis zwischen der "
+"Gesamtzahl der Patienten, die eine bestimmte Substanz oder Gruppe von "
+"Antibiotika erhalten, und der Gesamtzahl der Patienten, die alle Arten von "
+"Antibiotika erhalten, multipliziert mit 100."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Anteil der Patienten, die eine AB-Substanz oder -Gruppe erhalten\" = \"Gesamte Therapietage für diese Substanz oder Gruppe\" / \"Gesamte Patiententage\" xx 100]"
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
+msgstr ""
+"stem:[\"Anteil der Patienten, die eine AB-Substanz oder -Gruppe erhalten\" = "
+"\"Gesamte Therapietage für diese Substanz oder Gruppe\" / \"Gesamte "
+"Patiententage\" xx 100]"
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:879
@@ -2661,23 +4463,45 @@ msgstr "Umsetzung des Schutzfaktors"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
-msgstr "Eine Schutzfaktor-Umsetzungsrate beschreibt den prozentualen Anteil der Patiententage, an denen ein Patient einen bestimmten Schutzfaktor erhalten hat, wie z. B. Muttermilch, Probiotika oder Känguru-Mutter-Pflege.  Sie wird berechnet, indem die Anzahl der Schutzfaktortage durch die Anzahl der Patiententage dividiert und das Ergebnis mit 100 multipliziert wird."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
+msgstr ""
+"Eine Schutzfaktor-Umsetzungsrate beschreibt den prozentualen Anteil der "
+"Patiententage, an denen ein Patient einen bestimmten Schutzfaktor erhalten "
+"hat, wie z. B. Muttermilch, Probiotika oder Känguru-Mutter-Pflege.  Sie wird "
+"berechnet, indem die Anzahl der Schutzfaktortage durch die Anzahl der "
+"Patiententage dividiert und das Ergebnis mit 100 multipliziert wird."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
+msgstr ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
+msgstr ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Känguru-Pflege-Umsetzungsrate\" = \"Känguru-Pflege-Tage insgesamt\" / \"Patiententage insgesamt\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
+msgstr ""
+"stem:[\"Känguru-Pflege-Umsetzungsrate\" = \"Känguru-Pflege-Tage "
+"insgesamt\" / \"Patiententage insgesamt\" xx 100]"
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:890
@@ -2693,23 +4517,44 @@ msgstr "Inzidenzdichten"
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
-msgstr "Da ein erheblicher Anteil der Infektionen nicht mit einem spezifischen Risikofaktor in Verbindung gebracht werden kann, werden Inzidenzdichten für Blutstrominfektionen, Pneumonie und NEC berechnet.  Der Risikofaktor stellt hier die kumulative Anzahl von Patiententagen dar und ist auf 1000 Patiententage normiert."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
+msgstr ""
+"Da ein erheblicher Anteil der Infektionen nicht mit einem spezifischen "
+"Risikofaktor in Verbindung gebracht werden kann, werden Inzidenzdichten für "
+"Blutstrominfektionen, Pneumonie und NEC berechnet.  Der Risikofaktor stellt "
+"hier die kumulative Anzahl von Patiententagen dar und ist auf 1000 "
+"Patiententage normiert."
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
-msgstr "stem:[\"BSI-Inzidenzdichte\" = \"BSI-Fälle insgesamt\" / \"Patiententage insgesamt\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
+msgstr ""
+"stem:[\"BSI-Inzidenzdichte\" = \"BSI-Fälle insgesamt\" / \"Patiententage "
+"insgesamt\" xx 1000]"
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
-msgstr "stem:[\"Pneumonie-Inzidenzdichte\" = \"Pneumonie-Fälle insgesamt\" / \"Patiententage insgesamt\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
+msgstr ""
+"stem:[\"Pneumonie-Inzidenzdichte\" = \"Pneumonie-Fälle insgesamt\" / "
+"\"Patiententage insgesamt\" xx 1000]"
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
-msgstr "stem:[\"NEC-Inzidenzdichte\" = \"NEC-Fälle insgesamt\" / \"Patiententage insgesamt\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
+msgstr ""
+"stem:[\"NEC-Inzidenzdichte\" = \"NEC-Fälle insgesamt\" / \"Patiententage "
+"insgesamt\" xx 1000]"
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:903
@@ -2719,43 +4564,102 @@ msgstr "Device-assoziierte Infektionen"
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
-msgstr "Eine Device-assoziierte Infektionsrate ist eine wichtige Kennzahl für das Qualitätsmanagement und beschreibt, wie viele Device-assoziierte Infektionen pro 1000 Devicetage auftreten.  Bei diesem als Standardisierung bezeichneten Prozess werden Infektionen (z. B. BSI), die bei Vorhandensein eines bestimmten Risikofaktors (z. B. ZVK) auftreten, mit der Gesamtzahl der Risikotage (z. B. ZVK-Tage) in Beziehung gesetzt, und das Ergebnis wird mit 1000 multipliziert."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
+msgstr ""
+"Eine Device-assoziierte Infektionsrate ist eine wichtige Kennzahl für das "
+"Qualitätsmanagement und beschreibt, wie viele Device-assoziierte Infektionen "
+"pro 1000 Devicetage auftreten.  Bei diesem als Standardisierung bezeichneten "
+"Prozess werden Infektionen (z. B. BSI), die bei Vorhandensein eines "
+"bestimmten Risikofaktors (z. B. ZVK) auftreten, mit der Gesamtzahl der "
+"Risikotage (z. B. ZVK-Tage) in Beziehung gesetzt, und das Ergebnis wird mit "
+"1000 multipliziert."
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
-msgstr "stem:[\"ZVK-associated BSI Rate\" = \"Total BSI Cases in Patients With ZVK\" / \"Total ZVK Days\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
+msgstr ""
+"stem:[\"ZVK-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"ZVK\" / \"Total ZVK Days\" xx 1000]"
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
-msgstr "stem:[\"PVC-assoziierte BSI-Rate\" = \"Gesamte BSI-Fälle bei Patienten mit PVC\" / \"Gesamte PVC-Tage\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
+msgstr ""
+"stem:[\"PVC-assoziierte BSI-Rate\" = \"Gesamte BSI-Fälle bei Patienten mit "
+"PVC\" / \"Gesamte PVC-Tage\" xx 1000]"
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
-msgstr "stem:[\"INV-assoziierte Pneumonie-Rate\" = \"Summe der Pneumonie-Fälle bei Patienten mit INV\" / \"Summe der INV-Tage\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgstr ""
+"stem:[\"INV-assoziierte Pneumonie-Rate\" = \"Summe der Pneumonie-Fälle bei "
+"Patienten mit INV\" / \"Summe der INV-Tage\" xx 1000]"
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
-msgstr "stem:[\"NIV-assoziierte Pneumonie-Rate\" = \"Summe der Pneumonie-Fälle bei Patienten mit NIV\" / \"Summe der NIV-Tage\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgstr ""
+"stem:[\"NIV-assoziierte Pneumonie-Rate\" = \"Summe der Pneumonie-Fälle bei "
+"Patienten mit NIV\" / \"Summe der NIV-Tage\" xx 1000]"
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
-msgstr "Die Rate der Infektionen an der Operationsstelle (SSI) gibt den Prozentsatz der SSI an, die während des Beobachtungszeitraums nach einem operativen Eingriff auftreten.  Sie wird berechnet, indem die Anzahl der nach einem chirurgischen Eingriff aufgetretenen SSI durch die Anzahl der chirurgischen Eingriffe dividiert und das Ergebnis mit 100 multipliziert wird.  Da das Risiko, eine SSI zu entwickeln, von der Art des chirurgischen Eingriffs abhängt, werden mehrere SSI-Raten für Gruppen ähnlicher Eingriffe berechnet.  Dennoch wird eine Gesamt-SSI-Rate berechnet, um der Tatsache Rechnung zu tragen, dass Operationen bei VLBW/VPT-Neugeborenen seltener sind als bei Erwachsenen und die Gruppierung von Verfahren zu einer sehr geringen Anzahl von Verfahren pro Gruppe führen kann."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
+msgstr ""
+"Die Rate der Infektionen an der Operationsstelle (SSI) gibt den Prozentsatz "
+"der SSI an, die während des Beobachtungszeitraums nach einem operativen "
+"Eingriff auftreten.  Sie wird berechnet, indem die Anzahl der nach einem "
+"chirurgischen Eingriff aufgetretenen SSI durch die Anzahl der chirurgischen "
+"Eingriffe dividiert und das Ergebnis mit 100 multipliziert wird.  Da das "
+"Risiko, eine SSI zu entwickeln, von der Art des chirurgischen Eingriffs "
+"abhängt, werden mehrere SSI-Raten für Gruppen ähnlicher Eingriffe "
+"berechnet.  Dennoch wird eine Gesamt-SSI-Rate berechnet, um der Tatsache "
+"Rechnung zu tragen, dass Operationen bei VLBW/VPT-Neugeborenen seltener sind "
+"als bei Erwachsenen und die Gruppierung von Verfahren zu einer sehr geringen "
+"Anzahl von Verfahren pro Gruppe führen kann."
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
-msgstr "stem:[\"SSI-Gesamtrate\" = \"SSI-Fälle insgesamt\" / \"Gesamtzahl der Operationen\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
+msgstr ""
+"stem:[\"SSI-Gesamtrate\" = \"SSI-Fälle insgesamt\" / \"Gesamtzahl der "
+"Operationen\" xx 100]"
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
-msgstr "stem:[\"Gruppierte SSI-Rate\" = \"Summe der SSI-Fälle, die nach den Eingriffen in dieser Gruppe beobachtet wurden\" / \"Gesamtzahl der Eingriffe in dieser Gruppe\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgstr ""
+"stem:[\"Gruppierte SSI-Rate\" = \"Summe der SSI-Fälle, die nach den "
+"Eingriffen in dieser Gruppe beobachtet wurden\" / \"Gesamtzahl der Eingriffe "
+"in dieser Gruppe\" xx 100]"
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:927
@@ -2765,13 +4669,39 @@ msgstr "Standardisierte Infektionsrate"
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
-msgstr "Mit den oben beschriebenen Infektionsraten ist es möglich, Risikofaktoren und Infektionen für die 3 Geburtsgewichtsklassen im Detail zu betrachten.  Allerdings ist das Geburtsgewicht von 500 g eine relativ grobe Stratifizierung für das neonatale Infektionsrisiko, und es berücksichtigt auch nicht die Tatsache, dass Kinder lange vor ihrer normalen Entlassung in andere Abteilungen verlegt werden können (z. B. zur Operation oder in eine Abteilung, die näher am Wohnort der Eltern liegt) und dass sich die Hochrisikotage der Stabilisierungsphase in einigen neonatologischen Abteilungen häufen, während andere die Niedrigrisikotage bereits stabilisierter Kinder kumulieren würden.  Um dies zu berücksichtigen, berechnet NeoIPC eine standardisierte Infektionsrate (SIR), die die Infektionshäufigkeit zwischen den Abteilungen auf der Grundlage der Zusammensetzung ihrer Patientenpopulation vergleicht."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
+msgstr ""
+"Mit den oben beschriebenen Infektionsraten ist es möglich, Risikofaktoren "
+"und Infektionen für die 3 Geburtsgewichtsklassen im Detail zu betrachten.  "
+"Allerdings ist das Geburtsgewicht von 500 g eine relativ grobe "
+"Stratifizierung für das neonatale Infektionsrisiko, und es berücksichtigt "
+"auch nicht die Tatsache, dass Kinder lange vor ihrer normalen Entlassung in "
+"andere Abteilungen verlegt werden können (z. B. zur Operation oder in eine "
+"Abteilung, die näher am Wohnort der Eltern liegt) und dass sich die "
+"Hochrisikotage der Stabilisierungsphase in einigen neonatologischen "
+"Abteilungen häufen, während andere die Niedrigrisikotage bereits "
+"stabilisierter Kinder kumulieren würden.  Um dies zu berücksichtigen, "
+"berechnet NeoIPC eine standardisierte Infektionsrate (SIR), die die "
+"Infektionshäufigkeit zwischen den Abteilungen auf der Grundlage der "
+"Zusammensetzung ihrer Patientenpopulation vergleicht."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:933
 msgid "Standardized infection rates are calculated based on two factors:"
-msgstr "Standardisierte Infektionsraten werden auf der Grundlage von zwei Faktoren berechnet:"
+msgstr ""
+"Standardisierte Infektionsraten werden auf der Grundlage von zwei Faktoren "
+"berechnet:"
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:935
@@ -2785,33 +4715,72 @@ msgstr "Infektionsrisiko für einen bestimmten Tag des Lebens"
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
-msgstr "Aus der Referenzdatenbank wird das durchschnittliche Risiko für BSI oder Pneumonie für einen bestimmten Lebenstag eines Kindes mit einem bestimmten Geburtsgewicht berechnet."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
+msgstr ""
+"Aus der Referenzdatenbank wird das durchschnittliche Risiko für BSI oder "
+"Pneumonie für einen bestimmten Lebenstag eines Kindes mit einem bestimmten "
+"Geburtsgewicht berechnet."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
-msgstr "Anschließend wird die Anzahl der erwarteten Infektionen (kumuliertes Risiko) für eine Abteilung berechnet, indem die durchschnittlichen Risiken der Kinder und die jeweiligen Tage, die sie in der Abteilung verbracht haben, addiert werden."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
+msgstr ""
+"Anschließend wird die Anzahl der erwarteten Infektionen (kumuliertes Risiko) "
+"für eine Abteilung berechnet, indem die durchschnittlichen Risiken der "
+"Kinder und die jeweiligen Tage, die sie in der Abteilung verbracht haben, "
+"addiert werden."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
-msgstr "Der SIR stellt das Verhältnis von beobachteten Infektionen zu erwarteten Infektionen in einer Abteilung dar und kann einen allgemeinen Überblick über das Infektionsrisiko in einer Abteilung geben."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
+msgstr ""
+"Der SIR stellt das Verhältnis von beobachteten Infektionen zu erwarteten "
+"Infektionen in einer Abteilung dar und kann einen allgemeinen Überblick über "
+"das Infektionsrisiko in einer Abteilung geben."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
-msgstr "stem:[\"Standardisierte Infektionsrate\" = \"Beobachtete Infektionen insgesamt\" / \"Erwartete Infektionen insgesamt\"] Wenn die standardisierte Infektionsrate größer als eins ist, haben Sie mehr Infektionen beobachtet, als Sie bei Ihrer Patientenzusammensetzung im Vergleich zu den Referenzdaten erwarten würden."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
+msgstr ""
+"stem:[\"Standardisierte Infektionsrate\" = \"Beobachtete Infektionen "
+"insgesamt\" / \"Erwartete Infektionen insgesamt\"] Wenn die standardisierte "
+"Infektionsrate größer als eins ist, haben Sie mehr Infektionen beobachtet, "
+"als Sie bei Ihrer Patientenzusammensetzung im Vergleich zu den Referenzdaten "
+"erwarten würden."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
-msgstr "Wenn die standardisierte Infektionsrate gleich eins ist, haben Sie im Vergleich zu den Referenzdaten die gleiche Anzahl von Infektionen beobachtet, die Sie aufgrund Ihrer Patientenzusammensetzung erwarten würden."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
+msgstr ""
+"Wenn die standardisierte Infektionsrate gleich eins ist, haben Sie im "
+"Vergleich zu den Referenzdaten die gleiche Anzahl von Infektionen "
+"beobachtet, die Sie aufgrund Ihrer Patientenzusammensetzung erwarten würden."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
-msgstr "Wenn die standardisierte Infektionsrate kleiner als eins ist, haben Sie im Vergleich zu den Referenzdaten weniger Infektionen beobachtet, als Sie aufgrund Ihrer Patientenzusammensetzung erwarten würden."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
+msgstr ""
+"Wenn die standardisierte Infektionsrate kleiner als eins ist, haben Sie im "
+"Vergleich zu den Referenzdaten weniger Infektionen beobachtet, als Sie "
+"aufgrund Ihrer Patientenzusammensetzung erwarten würden."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:951
@@ -2827,8 +4796,12 @@ msgstr "3GCR"
 
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
-msgstr "Multiresistente gramnegative Erreger, die gegen Cephalosporine der 3^. Generation resistent sind"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
+msgstr ""
+"Multiresistente gramnegative Erreger, die gegen Cephalosporine der 3^. "
+"Generation resistent sind"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
@@ -2850,7 +4823,9 @@ msgstr "ASA"
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:956
 msgid "American Society of Anaesthesiologists"
-msgstr "Amerikanische Gesellschaft der Anästhesisten (American Society of Anaesthesiologists)"
+msgstr ""
+"Amerikanische Gesellschaft der Anästhesisten (American Society of "
+"Anaesthesiologists)"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:956
@@ -3318,8 +5293,12 @@ msgstr "communication@pentafoundation.org"
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
-msgstr "Um mehr über die NeoDeco-Studie und das Clinical Practice Network zu erfahren, schreiben Sie bitte an:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
+msgstr ""
+"Um mehr über die NeoDeco-Studie und das Clinical Practice Network zu "
+"erfahren, schreiben Sie bitte an:"
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1014
@@ -3344,7 +5323,9 @@ msgstr "Antibiotikaliste"
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3355,26 +5336,39 @@ msgstr "Liste der Infektionserreger"
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
-msgstr "**Fehlen einer positiven mikrobiologischen Blut- und/oder Liquorkultur**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
+msgstr ""
+"**Fehlen einer positiven mikrobiologischen Blut- und/oder Liquorkultur**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
-msgstr "**Eine Behandlung mit intravenösen Antibiotika über FÜNF oder mehr Tage wurde eingeleitet$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
+msgstr ""
+"**Eine Behandlung mit intravenösen Antibiotika über FÜNF oder mehr Tage "
+"wurde eingeleitet$$*$$**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:8
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
-msgstr "**Der Patient weist mindestens ZWEI der folgenden klinischen oder Labormerkmale einer generalisierten Infektion auf:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
+msgstr ""
+"**Der Patient weist mindestens ZWEI der folgenden klinischen oder "
+"Labormerkmale einer generalisierten Infektion auf:**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:12
@@ -3390,24 +5384,36 @@ msgstr "Temperaturinstabilität, Fieber (> 38 °C) oder Hypothermie (< 36,5
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:42
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
-msgstr "Neue/häufigere Bradykardie-Episoden (< 80/min) oder ungeklärte Tachykardie (> 200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
+msgstr ""
+"Neue/häufigere Bradykardie-Episoden (< 80/min) oder ungeklärte Tachykardie "
+"(> 200/min)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:14
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
-msgstr "Beeinträchtigte periphere Durchblutung (Rekapillarisierungszeit von > 3 s oder marmorierte Haut oder Kern-/Peripherietemperaturunterschied > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
+msgstr ""
+"Beeinträchtigte periphere Durchblutung (Rekapillarisierungszeit von > 3 s "
+"oder marmorierte Haut oder Kern-/Peripherietemperaturunterschied > 2 °C)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:15
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:12
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
-msgstr "Neue/häufigere Episoden von Apnoe (> 20 s) oder Anstieg des Sauerstoffbedarfs oder der Beatmungsunterstützung"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
+msgstr ""
+"Neue/häufigere Episoden von Apnoe (> 20 s) oder Anstieg des "
+"Sauerstoffbedarfs oder der Beatmungsunterstützung"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:16
@@ -3415,7 +5421,8 @@ msgstr "Neue/häufigere Episoden von Apnoe (> 20 s) oder Anstieg des Sauersto
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:45
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:66
 msgid "Enteral feeding intolerance, abdominal distension or ileus"
-msgstr "Intoleranz gegenüber enteraler Ernährung, aufgeblähtes Abdomen oder Ileus"
+msgstr ""
+"Intoleranz gegenüber enteraler Ernährung, aufgeblähtes Abdomen oder Ileus"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:17
@@ -3431,15 +5438,20 @@ msgstr "Irritabilität, Lethargie, Apathie oder instabiler Allgemenzustand"
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:47
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:68
 msgid "Unexplained metabolic acidosis (base excess < −10 mmol/L; <−10 mEq/L)"
-msgstr "Ungeklärte metabolische Azidose (Basenüberschuss < -10 mmol/l; (< -10 mEq/l)"
+msgstr ""
+"Ungeklärte metabolische Azidose (Basenüberschuss < -10 mmol/l; (< -10 mEq/l)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:19
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:16
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
-msgstr "Neue und ungeklärte Hyperglykämie (> 140 mg/dl; > 7,8 mmol/l) oder Hypoglykämie (< 40 mg/dl; < 2,2 mmol/l)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgstr ""
+"Neue und ungeklärte Hyperglykämie (> 140 mg/dl; > 7,8 mmol/l) oder "
+"Hypoglykämie (< 40 mg/dl; < 2,2 mmol/l)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:20
@@ -3462,7 +5474,8 @@ msgstr "Thrombozytenzahl von < 100 × 10⁹/l (< 100 × 10³/μl)"
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:33
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:72
 msgid "WBC < 4 × 10^9^/L or > 20 × 10^9^/L (< 4 × 10^3^/μL or > 20 × 10^3^/μL)"
-msgstr "Leukozyten < 4 × 10⁹/l oder > 20 × 10⁹/l (< 4 × 10³/μl oder > 20 × 10³/μl)"
+msgstr ""
+"Leukozyten < 4 × 10⁹/l oder > 20 × 10⁹/l (< 4 × 10³/μl oder > 20 × 10³/μl)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:23
@@ -3486,7 +5499,9 @@ msgstr "Procalcitonin ≥ 2 μg/l (≥ 2 ng/ml oder ≥ 200 ng/dl)"
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:36
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:75
 msgid "I/T-Ratio > 0.2 (ratio of immature granulocytes to total granulocytes)"
-msgstr "I/T-Ratio > 0,2 (Verhältnis von unreifen Granulozyten zu den gesamten Granulozyten)"
+msgstr ""
+"I/T-Ratio > 0,2 (Verhältnis von unreifen Granulozyten zu den gesamten "
+"Granulozyten)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:26
@@ -3498,8 +5513,28 @@ msgstr "Erhöhte Werte von Interleukin (IL) 6 oder 8"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
-msgstr "Es wurde eine Antibiotikabehandlung für mindestens fünf Tage eingeleitet.  Gezählt werden der Tag der ersten und der Tag der letzten Dosis.  Tage, an denen zwischen der ersten und der letzten Dosis keine Dosis verabreicht wurde (z. B. ausgelassene Dosen wegen hoher Wirkstoffspiegel in der therapeutischen Arzneimittelüberwachung), werden gezählt, als ob eine Dosis verabreicht worden wäre.  Tage nach der letzten Dosis werden nicht gezählt, unabhängig vom gemessenen oder angenommenen Medikamentenspiegel des Patienten.  Wenn das Kind vor dem Ende der fünftägigen Behandlung mit intravenösen Antibiotika gestorben ist, entlassen oder verlegt wurde, ist diese Bedingung erfüllt, wenn die Behandlung für fünf oder mehr Tage geplant war."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
+msgstr ""
+"Es wurde eine Antibiotikabehandlung für mindestens fünf Tage eingeleitet.  "
+"Gezählt werden der Tag der ersten und der Tag der letzten Dosis.  Tage, an "
+"denen zwischen der ersten und der letzten Dosis keine Dosis verabreicht "
+"wurde (z. B. ausgelassene Dosen wegen hoher Wirkstoffspiegel in der "
+"therapeutischen Arzneimittelüberwachung), werden gezählt, als ob eine Dosis "
+"verabreicht worden wäre.  Tage nach der letzten Dosis werden nicht gezählt, "
+"unabhängig vom gemessenen oder angenommenen Medikamentenspiegel des "
+"Patienten.  Wenn das Kind vor dem Ende der fünftägigen Behandlung mit "
+"intravenösen Antibiotika gestorben ist, entlassen oder verlegt wurde, ist "
+"diese Bedingung erfüllt, wenn die Behandlung für fünf oder mehr Tage geplant "
+"war."
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:1
@@ -3511,12 +5546,18 @@ msgstr "Tiefe postoperative Wundinfektion"
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:5
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:5
 msgid "**First symptoms occur within 30 or 90^#^ days after the operation**"
-msgstr "**Erste Symptome treten innerhalb von 30 oder 90^#^ Tagen nach der Operation auf**"
+msgstr ""
+"**Erste Symptome treten innerhalb von 30 oder 90^#^ Tagen nach der Operation "
+"auf**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
-msgstr "**Die Infektion betrifft tiefe Weichteile der Inzision (z. B. Faszien- und Muskelschichten)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
+msgstr ""
+"**Die Infektion betrifft tiefe Weichteile der Inzision (z. B. Faszien- und "
+"Muskelschichten)**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:11
@@ -3532,34 +5573,76 @@ msgstr "Eitrige Drainage aus der tiefen Inzision."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
-msgstr "Eine tiefe Inzision, die sich spontan öffnet oder absichtlich von einem Chirurgen, Arzt* oder einer von diesen beauftragten Person eröffnet oder aspiriert wird"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
+msgstr ""
+"Eine tiefe Inzision, die sich spontan öffnet oder absichtlich von einem "
+"Chirurgen, Arzt* oder einer von diesen beauftragten Person eröffnet oder "
+"aspiriert wird"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
-msgstr "Erreger, die aus den tiefen Weichteilen der Inzision durch eine Kultur oder ein nicht auf Kultur basierendes mikrobiologisches Testverfahren identifiziert wurden, das zu Zwecken der klinischen Diagnose oder Behandlung durchgeführt wurde (z. B. keine Befunde aus Diagnostik zum Zweck des mikrobiologischen Screenings) oder eine Kultur oder ein nicht auf Kultur basierendes mikrobiologisches Testverfahren ist nicht durchgeführt worden. Eine Kultur oder ein nicht auf Kultur basierender Test aus den tiefen Weichteilen der Inzision, der einen negativen Befund aufweist, erfüllt dieses Kriterium nicht."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
+msgstr ""
+"Erreger, die aus den tiefen Weichteilen der Inzision durch eine Kultur oder "
+"ein nicht auf Kultur basierendes mikrobiologisches Testverfahren "
+"identifiziert wurden, das zu Zwecken der klinischen Diagnose oder Behandlung "
+"durchgeführt wurde (z. B. keine Befunde aus Diagnostik zum Zweck des "
+"mikrobiologischen Screenings) oder eine Kultur oder ein nicht auf Kultur "
+"basierendes mikrobiologisches Testverfahren ist nicht durchgeführt worden. "
+"Eine Kultur oder ein nicht auf Kultur basierender Test aus den tiefen "
+"Weichteilen der Inzision, der einen negativen Befund aufweist, erfüllt "
+"dieses Kriterium nicht."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
-msgstr "Der Patient weist mindestens eine der folgenden Beschwerden oder Symptome auf: Temperaturinstabilität, Fieber (> 38 °C) oder Hypothermie (< 36,5 °C); örtlich begrenzte Schmerzen oder Spannungsgefühl."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
+msgstr ""
+"Der Patient weist mindestens eine der folgenden Beschwerden oder Symptome "
+"auf: Temperaturinstabilität, Fieber (> 38 °C) oder Hypothermie (< 36,5 °C); "
+"örtlich begrenzte Schmerzen oder Spannungsgefühl."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
-msgstr "Ein Abszess oder andere Anzeichen einer Infektion im Bereich der tiefen Inzision, die bei einer körperlichen oder histopathologischen Untersuchung oder bei einer bildgebenden Untersuchung festgestellt werden."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
+msgstr ""
+"Ein Abszess oder andere Anzeichen einer Infektion im Bereich der tiefen "
+"Inzision, die bei einer körperlichen oder histopathologischen Untersuchung "
+"oder bei einer bildgebenden Untersuchung festgestellt werden."
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:25
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:16
 msgid "^#^Follow-up of 90 days applies when an implant was left in place."
-msgstr "^#^Eine Nachverfolgungszeit von 90 Tagen gilt, wenn ein Implantat an Ort und Stelle belassen wurde."
+msgstr ""
+"^#^Eine Nachverfolgungszeit von 90 Tagen gilt, wenn ein Implantat an Ort und "
+"Stelle belassen wurde."
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
-msgstr "*Der Begriff \"Arzt\" für die Anwendung der NeoIPC-SSI-Kriterien kann so ausgelegt werden, dass er einen Chirurgen, einen Infektionsmediziner, einen Notfallmediziner, einen anderen an dem Fall beteiligten Arzt oder eine von dem Arzt benannte Person (Krankenpfleger oder Arzthelfer) umfasst."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
+msgstr ""
+"*Der Begriff \"Arzt\" für die Anwendung der NeoIPC-SSI-Kriterien kann so "
+"ausgelegt werden, dass er einen Chirurgen, einen Infektionsmediziner, einen "
+"Notfallmediziner, einen anderen an dem Fall beteiligten Arzt oder eine von "
+"dem Arzt benannte Person (Krankenpfleger oder Arzthelfer) umfasst."
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:1
@@ -3569,8 +5652,13 @@ msgstr "Zweifach im Labor bestätigte Blutstrominfektion mit gewöhnlichen Komme
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
-msgstr "**Derselbe gewöhnliche Kommensale wird in mindestens ZWEI Blut- und/oder Liquorkulturproben nachgewiesen, die bei verschiedenen Gelegenheiten entnommen wurden**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
+msgstr ""
+"**Derselbe gewöhnliche Kommensale wird in mindestens ZWEI Blut- und/oder "
+"Liquorkulturproben nachgewiesen, die bei verschiedenen Gelegenheiten "
+"entnommen wurden**"
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:25
@@ -3581,8 +5669,12 @@ msgstr "Im Labor bestätigte Blutstrominfektion mit gewöhnlichen Kommensalen un
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
-msgstr "**Ein gewöhnlicher Kommensale wird aus EINER Blutkultur und/oder Liquorkulturprobe gewonnen**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
+msgstr ""
+"**Ein gewöhnlicher Kommensale wird aus EINER Blutkultur und/oder "
+"Liquorkulturprobe gewonnen**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:32
@@ -3597,13 +5689,35 @@ msgstr "Im Labor bestätigte Blutstrominfektion mit gewöhnlichen Kommensalen un
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
-msgstr "**Eine Behandlung mit intravenösen Antibiotika über fünf oder mehr Tage wurde eingeleitet$$*$$**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
+msgstr ""
+"**Eine Behandlung mit intravenösen Antibiotika über fünf oder mehr Tage "
+"wurde eingeleitet$$*$$**"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
-msgstr "*Gezählt werden der Tag der ersten Dosis und der Tag der letzten Dosis.  Tage, an denen zwischen der ersten und der letzten Dosis keine Dosis verabreicht wurde (z. B. ausgelassene Dosen aufgrund hoher Arzneimittelspiegel in der therapeutischen Arzneimittelüberwachung), werden gezählt, als ob eine Dosis verabreicht worden wäre.  Tage nach der letzten Dosis werden nicht gezählt, unabhängig vom gemessenen oder angenommenen Medikamentenspiegel des Patienten.  Wenn das Kind vor dem Ende der fünftägigen Behandlung mit intravenösen Antibiotika verstirbt, entlassen oder verlegt wird, ist diese Bedingung erfüllt, wenn die Behandlung für fünf oder mehr Tage geplant war."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
+msgstr ""
+"*Gezählt werden der Tag der ersten Dosis und der Tag der letzten Dosis.  "
+"Tage, an denen zwischen der ersten und der letzten Dosis keine Dosis "
+"verabreicht wurde (z. B. ausgelassene Dosen aufgrund hoher "
+"Arzneimittelspiegel in der therapeutischen Arzneimittelüberwachung), werden "
+"gezählt, als ob eine Dosis verabreicht worden wäre.  Tage nach der letzten "
+"Dosis werden nicht gezählt, unabhängig vom gemessenen oder angenommenen "
+"Medikamentenspiegel des Patienten.  Wenn das Kind vor dem Ende der "
+"fünftägigen Behandlung mit intravenösen Antibiotika verstirbt, entlassen "
+"oder verlegt wird, ist diese Bedingung erfüllt, wenn die Behandlung für fünf "
+"oder mehr Tage geplant war."
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:1
@@ -3613,8 +5727,12 @@ msgstr "Mikrobiologisch bestätigte Blutbahninfektion mit anerkanntem Infektions
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
-msgstr "**Anerkannter Infektionserreger wurde aus einer Blut- und/oder Liquorkultur gewonnen**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
+msgstr ""
+"**Anerkannter Infektionserreger wurde aus einer Blut- und/oder Liquorkultur "
+"gewonnen**"
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:1
@@ -3624,8 +5742,12 @@ msgstr "Symptombasierte NEC"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
-msgstr "**Mindestens EINES der folgenden radiologischen Zeichen (bildgebende Verfahren: Röntgen, CT, MRT, Ultraschall):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
+msgstr ""
+"**Mindestens EINES der folgenden radiologischen Zeichen (bildgebende "
+"Verfahren: Röntgen, CT, MRT, Ultraschall):**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:8
@@ -3665,8 +5787,11 @@ msgstr "Verfärbung des Abdomens oder glänzende/rötliche Hautfarbe"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
-msgstr "Wiederholtes okkultes (Guajak-Test) oder sichtbares Blut im Stuhl (keine Analfissur)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgstr ""
+"Wiederholtes okkultes (Guajak-Test) oder sichtbares Blut im Stuhl (keine "
+"Analfissur)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:18
@@ -3697,7 +5822,8 @@ msgstr "Chirurgische NEC"
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:28
 msgid "**At least of ONE the following surgical or pathological findings:**"
-msgstr "**Mindestens EINER der folgenden chirurgischen oder pathologischen Befunde:**"
+msgstr ""
+"**Mindestens EINER der folgenden chirurgischen oder pathologischen Befunde:**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:30
@@ -3712,33 +5838,75 @@ msgstr "Infektion von Organen und Körperhöhlen im Operationsgebiet"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
-msgstr "**Die Infektion betrifft irgendeinen Teil des Körpers, der tiefer als die Faszien-/Muskelschichten liegt und während des operativen Eingriffs geöffnet oder manipuliert wurde.**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
+msgstr ""
+"**Die Infektion betrifft irgendeinen Teil des Körpers, der tiefer als die "
+"Faszien-/Muskelschichten liegt und während des operativen Eingriffs geöffnet "
+"oder manipuliert wurde.**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
-msgstr "Eitrige Drainage aus einer in das Organ/die Körperhöhle eingebrachten Drainage (z. B. geschlossenes Saugdrainagesystem, offene Drainage, T-Drainage, CT-gestützte Drainage)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
+msgstr ""
+"Eitrige Drainage aus einer in das Organ/die Körperhöhle eingebrachten "
+"Drainage (z. B. geschlossenes Saugdrainagesystem, offene Drainage, T-"
+"Drainage, CT-gestützte Drainage)."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
-msgstr "Erreger, die aus der Flüssigkeit oder dem Gewebe des Organs/der Körperhöhle durch eine Kultur oder eine nicht auf Kulturen basierende mikrobiologische Testmethode identifiziert wurden, die zu Zwecken der klinischen Diagnose oder Behandlung durchgeführt wird (z. B. keine Befunde aus Diagnostik zum Zweck des mikrobiologischen Screenings)."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
+msgstr ""
+"Erreger, die aus der Flüssigkeit oder dem Gewebe des Organs/der Körperhöhle "
+"durch eine Kultur oder eine nicht auf Kulturen basierende mikrobiologische "
+"Testmethode identifiziert wurden, die zu Zwecken der klinischen Diagnose "
+"oder Behandlung durchgeführt wird (z. B. keine Befunde aus Diagnostik zum "
+"Zweck des mikrobiologischen Screenings)."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
-msgstr "Ein Abszess oder andere Anzeichen einer Infektion des Organs/der Körperhöhle, die bei einer körperlichen oder histopathologischen Untersuchung festgestellt werden, oder bildgebende Tests, die auf eine Infektion hindeuten."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
+msgstr ""
+"Ein Abszess oder andere Anzeichen einer Infektion des Organs/der "
+"Körperhöhle, die bei einer körperlichen oder histopathologischen "
+"Untersuchung festgestellt werden, oder bildgebende Tests, die auf eine "
+"Infektion hindeuten."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
-msgstr "**Mindestens EINER der folgenden bildgebenden Befunde (bildgebende Verfahren: Röntgen, CT, MRT, Ultraschall) zeigt neue Veränderungen, die auf eine Pneumonie hindeuten, wie z. B. Infiltrate, Verschattungen, Eintrübungen, erhöhte Dichte, Flüssigkeit in der Pleurahöhle oder in der Interlobarfissur**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
+msgstr ""
+"**Mindestens EINER der folgenden bildgebenden Befunde (bildgebende "
+"Verfahren: Röntgen, CT, MRT, Ultraschall) zeigt neue Veränderungen, die auf "
+"eine Pneumonie hindeuten, wie z. B. Infiltrate, Verschattungen, "
+"Eintrübungen, erhöhte Dichte, Flüssigkeit in der Pleurahöhle oder in der "
+"Interlobarfissur**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
-msgstr "**Neueinleitung von Atemunterstützung oder Eskalation der bestehenden Stufe der Atemunterstützung für ≥ 2 Tage$$*$$ nach mindestens 2 Tagen der Stabilität oder Verbesserung**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
+msgstr ""
+"**Neueinleitung von Atemunterstützung oder Eskalation der bestehenden Stufe "
+"der Atemunterstützung für ≥ 2 Tage$$*$$ nach mindestens 2 Tagen der "
+"Stabilität oder Verbesserung**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:11
@@ -3752,8 +5920,12 @@ msgstr "Erreger aus den Atemwegen identifiziert^+^"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
-msgstr "Neue oder vermehrte Tachypnoe (>60/min) oder neue oder vermehrte Apnoe (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
+msgstr ""
+"Neue oder vermehrte Tachypnoe (>60/min) oder neue oder vermehrte Apnoe (> 20 "
+"s)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:15
@@ -3762,23 +5934,34 @@ msgstr "Eitriges Trachealaspirat"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
-msgstr "Neue oder vermehrte Symptome von Atemnot (Einziehungen, Nasenflügel, Stöhnen, eingezogener Brustkorb)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
+msgstr ""
+"Neue oder vermehrte Symptome von Atemnot (Einziehungen, Nasenflügel, "
+"Stöhnen, eingezogener Brustkorb)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:17
 msgid "Temperature instability or fever (>38 °C) or hypothermia (<36.5 °C)"
-msgstr "Temperaturinstabilität oder Fieber (>38 °C) oder Hypothermie (<36,5 °C)"
+msgstr ""
+"Temperaturinstabilität oder Fieber (>38 °C) oder Hypothermie (<36,5 °C)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
-msgstr "Vermehrte Sekretion der Atemwege ( häufigeres endotracheales Absaugen erforderlich)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
+msgstr ""
+"Vermehrte Sekretion der Atemwege ( häufigeres endotracheales Absaugen "
+"erforderlich)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
-msgstr "CRP > 10 mg/L (> 1 mg/dL) oder erhöhte Werte von Interleukin (IL) 6 oder 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgstr ""
+"CRP > 10 mg/L (> 1 mg/dL) oder erhöhte Werte von Interleukin (IL) 6 oder 8^#^"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:20
@@ -3787,28 +5970,56 @@ msgstr "I/T-Ratio > 0,2"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
-msgstr "*Neueinleitung einer Atemunterstützung oder Erhöhung des bestehenden Niveaus der Atemunterstützung, die sich nicht innerhalb von weniger als zwei Tagen verbessert:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
+msgstr ""
+"*Neueinleitung einer Atemunterstützung oder Erhöhung des bestehenden Niveaus "
+"der Atemunterstützung, die sich nicht innerhalb von weniger als zwei Tagen "
+"verbessert:"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
-msgstr "Anstieg des Bedarfs an FiO~2~ ≥ 0,25 (25 Punkte) innerhalb von 24 Stunden (tägliche Mindestwerte für FiO~2~ müssen berücksichtigt werden)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
+msgstr ""
+"Anstieg des Bedarfs an FiO~2~ ≥ 0,25 (25 Punkte) innerhalb von 24 Stunden "
+"(tägliche Mindestwerte für FiO~2~ müssen berücksichtigt werden)"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
-msgstr "…die sich nicht innerhalb von weniger als 2 Tagen bessert: Der oben beschriebene Zustand sollte sich nicht innerhalb von zwei Tagen bessern."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
+msgstr ""
+"…die sich nicht innerhalb von weniger als 2 Tagen bessert: Der oben "
+"beschriebene Zustand sollte sich nicht innerhalb von zwei Tagen bessern."
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
-msgstr "…nach mindestens 2 Tagen der Stabilität oder Verbesserung: Eine stabile oder verbesserte Ausgangssituation von mindestens zwei Tagen ist erforderlich, bevor die oben genannte Bedingung eintritt."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
+msgstr ""
+"…nach mindestens 2 Tagen der Stabilität oder Verbesserung: Eine stabile oder "
+"verbesserte Ausgangssituation von mindestens zwei Tagen ist erforderlich, "
+"bevor die oben genannte Bedingung eintritt."
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
-msgstr "^+^Mindestens ein Krankheitserreger (siehe unten) wurde in den Atemwegen durch eine Kultur oder ein nicht auf Kulturen basierendes mikrobiologisches Testverfahren identifiziert, das zum Zweck der klinischen Diagnose oder Behandlung durchgeführt wird (z. B. keine Befunde aus Diagnostik zum Zweck des mikrobiologischen Screenings):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgstr ""
+"^+^Mindestens ein Krankheitserreger (siehe unten) wurde in den Atemwegen "
+"durch eine Kultur oder ein nicht auf Kulturen basierendes mikrobiologisches "
+"Testverfahren identifiziert, das zum Zweck der klinischen Diagnose oder "
+"Behandlung durchgeführt wird (z. B. keine Befunde aus Diagnostik zum Zweck "
+"des mikrobiologischen Screenings):"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:41
@@ -3817,13 +6028,21 @@ msgstr "Pilz- oder bakterielle Erreger aus Sekreten der unteren Atemwege"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
-msgstr "Virales Gen, Antigen oder Antikörper aus Sekreten der oberen oder unteren Atemwege (z. B. EIA, FAMA, Shell Vial Assay, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgstr ""
+"Virales Gen, Antigen oder Antikörper aus Sekreten der oberen oder unteren "
+"Atemwege (z. B. EIA, FAMA, Shell Vial Assay, PCR)"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
-msgstr "^#^Interleukin sollte als Parameter verwendet werden, wenn die Laborspezifikationen für einen pathologischen Wert erfüllt sind."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
+msgstr ""
+"^#^Interleukin sollte als Parameter verwendet werden, wenn die "
+"Laborspezifikationen für einen pathologischen Wert erfüllt sind."
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:1
@@ -3834,12 +6053,16 @@ msgstr "Superficial incisional SSI"
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:5
 msgid "**First symptoms occur within 30 days after the operation**"
-msgstr "**Erste Symptome treten innerhalb von 30 Tagen nach der Operation auf**"
+msgstr ""
+"**Erste Symptome treten innerhalb von 30 Tagen nach der Operation auf**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
-msgstr "**Die Infektion betrifft nur die Haut und das subkutane Gewebe der Inzision.**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
+msgstr ""
+"**Die Infektion betrifft nur die Haut und das subkutane Gewebe der "
+"Inzision.**"
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:13
@@ -3848,48 +6071,107 @@ msgstr "Eitrige Drainage aus der tiefen Inzision."
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
-msgstr "Organismus(en), der/die aus einer aseptisch entnommenen Probe aus der oberflächlichen Inzision oder dem subkutanen Gewebe mittels einer kulturbasierten oder nicht kulturbasierten mikrobiologischen Testmethode identifiziert wurde(n), die zum Zwecke der klinischen Diagnose oder Behandlung durchgeführt wird (z. B. keine aktive Überwachungskultur/Aktiver Überwachungstest (ASC/AST))."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
+msgstr ""
+"Organismus(en), der/die aus einer aseptisch entnommenen Probe aus der "
+"oberflächlichen Inzision oder dem subkutanen Gewebe mittels einer "
+"kulturbasierten oder nicht kulturbasierten mikrobiologischen Testmethode "
+"identifiziert wurde(n), die zum Zwecke der klinischen Diagnose oder "
+"Behandlung durchgeführt wird (z. B. keine aktive Überwachungskultur/Aktiver "
+"Überwachungstest (ASC/AST))."
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
-msgstr "Oberflächliche Inzision, die absichtlich von einem Chirurgen, Arzt* oder einem vom Arzt Beauftragten geöffnet wird, ohne dass eine Kultur- oder nicht kulturbasierte Untersuchung der oberflächlichen Inzision oder des subkutanen Gewebes durchgeführt wird. Eine Kultur- oder nicht kulturbasierte Untersuchung des tiefen Weichgewebes der Inzision mit negativem Befund erfüllt dieses Kriterium nicht."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
+msgstr ""
+"Oberflächliche Inzision, die absichtlich von einem Chirurgen, Arzt* oder "
+"einem vom Arzt Beauftragten geöffnet wird, ohne dass eine Kultur- oder nicht "
+"kulturbasierte Untersuchung der oberflächlichen Inzision oder des subkutanen "
+"Gewebes durchgeführt wird. Eine Kultur- oder nicht kulturbasierte "
+"Untersuchung des tiefen Weichgewebes der Inzision mit negativem Befund "
+"erfüllt dieses Kriterium nicht."
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
-msgstr "Der Patient weist mindestens eines der folgenden Anzeichen oder Symptome auf: lokalisierte Schmerzen oder Druckempfindlichkeit, lokalisierte Schwellung, Erythem oder Überwärmung."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
+msgstr ""
+"Der Patient weist mindestens eines der folgenden Anzeichen oder Symptome "
+"auf: lokalisierte Schmerzen oder Druckempfindlichkeit, lokalisierte "
+"Schwellung, Erythem oder Überwärmung."
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
-msgstr "Diagnose einer oberflächlichen Wundinfektion durch einen Arzt* oder einen von ihm benannten Arzt."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
+msgstr ""
+"Diagnose einer oberflächlichen Wundinfektion durch einen Arzt* oder einen "
+"von ihm benannten Arzt."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
-msgstr "*Der Begriff \"Arzt\" für die Anwendung der NeoIPC-SSI-Kriterien kann so ausgelegt werden, dass er einen Chirurgen, einen Infektionsmediziner, einen Notfallmediziner, einen anderen an dem Fall beteiligten Arzt oder eine von dem Arzt benannte Person (Krankenpfleger oder Arzthelfer) umfasst."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
+msgstr ""
+"*Der Begriff \"Arzt\" für die Anwendung der NeoIPC-SSI-Kriterien kann so "
+"ausgelegt werden, dass er einen Chirurgen, einen Infektionsmediziner, einen "
+"Notfallmediziner, einen anderen an dem Fall beteiligten Arzt oder eine von "
+"dem Arzt benannte Person (Krankenpfleger oder Arzthelfer) umfasst."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
-msgstr "Die folgenden Kriterien erfüllen nicht die Definition einer oberflächlichen Wundinfektion"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
+msgstr ""
+"Die folgenden Kriterien erfüllen nicht die Definition einer oberflächlichen "
+"Wundinfektion"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
-msgstr "Die Diagnose/Behandlung einer Cellulitis (Rötung/Erwärmung/Schwellung) allein erfüllt nicht das Kriterium „d“ für oberflächliche Schnittwunden-SSI."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
+msgstr ""
+"Die Diagnose/Behandlung einer Cellulitis (Rötung/Erwärmung/Schwellung) "
+"allein erfüllt nicht das Kriterium „d“ für oberflächliche Schnittwunden-SSI."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
-msgstr "Ein Fadenabszess allein (minimale Entzündung und Ausfluss, beschränkt auf die Stellen, an denen die Nähte eindringen)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
+msgstr ""
+"Ein Fadenabszess allein (minimale Entzündung und Ausfluss, beschränkt auf "
+"die Stellen, an denen die Nähte eindringen)."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
-msgstr "Eine lokalisierte Einstichstellen- oder Pin-Track-Infektion. Hinweis: Eine laparoskopische Trokarstelle gilt als OP-Wunde und nicht als Einstichstelle. Wenn ein Chirurg am Ende eines Eingriffs eine Drainage über eine laparoskopische Trokarstelle legt, gilt dies als OP-Wunde."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
+msgstr ""
+"Eine lokalisierte Einstichstellen- oder Pin-Track-Infektion. Hinweis: Eine "
+"laparoskopische Trokarstelle gilt als OP-Wunde und nicht als Einstichstelle. "
+"Wenn ein Chirurg am Ende eines Eingriffs eine Drainage über eine "
+"laparoskopische Trokarstelle legt, gilt dies als OP-Wunde."
 
 #. type: Content of: <root><data><value>
 #: doc/protocol/resx/NeoIPC-Core-Decision-Flow.resx:10
@@ -3927,5 +6209,14 @@ msgstr "Einschluss"
 msgid "Ineligible"
 msgstr "Kein Einschluss"
 
-#~ msgid "Sepsis is classified as either culture negative or culture proven in the NeoIPC surveillance system.  As well, culture proven sepsis (LCBSI = \"Laboratory-confirmed bloodstream infection\") is classified into two categories based on the culture result."
-#~ msgstr "Sepsis wird im NeoIPC-Surveillance-System entweder als klinis (kulturnegativ) oder mikrobiologisch bestätigt eingestuft.  Die mikrobiologisch bestätigte Sepsis (LCBSI = „Laboratory-confirmed bloodstream infection“) wird auf der Grundlage des Kulturergebnisses in zwei weitere Unterkategorien eingeteilt."
+#~ msgid ""
+#~ "Sepsis is classified as either culture negative or culture proven in the "
+#~ "NeoIPC surveillance system.  As well, culture proven sepsis (LCBSI = "
+#~ "\"Laboratory-confirmed bloodstream infection\") is classified into two "
+#~ "categories based on the culture result."
+#~ msgstr ""
+#~ "Sepsis wird im NeoIPC-Surveillance-System entweder als klinis "
+#~ "(kulturnegativ) oder mikrobiologisch bestätigt eingestuft.  Die "
+#~ "mikrobiologisch bestätigte Sepsis (LCBSI = „Laboratory-confirmed "
+#~ "bloodstream infection“) wird auf der Grundlage des Kulturergebnisses in "
+#~ "zwei weitere Unterkategorien eingeteilt."

--- a/po/documentation.el.po
+++ b/po/documentation.el.po
@@ -31,22 +31,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -63,12 +92,27 @@ msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
 msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
 msgstr ""
 
 #. type: Title ===
@@ -79,17 +123,30 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
@@ -99,22 +156,31 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
 msgstr ""
 
 #. type: Title ===
@@ -125,7 +191,24 @@ msgstr ""
 
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
 msgstr ""
 
 #. type: Title ===
@@ -136,22 +219,43 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -171,7 +275,9 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -191,22 +297,42 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
 msgstr ""
 
 #. type: Title ==
@@ -223,7 +349,16 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
 msgstr ""
 
 #. type: Title ====
@@ -234,7 +369,22 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
 msgstr ""
 
 #. type: Title ====
@@ -245,22 +395,49 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
 msgstr ""
 
 #. type: Title ===
@@ -271,47 +448,80 @@ msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
 msgstr ""
 
 #. type: Title ==
@@ -322,17 +532,41 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
 msgstr ""
 
 #. type: #data-collection
@@ -347,7 +581,9 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
 msgstr ""
 
 #. type: #data-collection
@@ -357,7 +593,10 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
 msgstr ""
 
 #. type: #data-collection
@@ -386,17 +625,25 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
 msgstr ""
 
 #. type: Title ===
@@ -427,7 +674,10 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
 msgstr ""
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -464,7 +714,9 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
 msgstr ""
 
 #. type: Title ===
@@ -475,7 +727,10 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
 msgstr ""
 
 #. type: Title ====
@@ -486,27 +741,57 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
 msgstr ""
 
 #. type: Block title
@@ -550,12 +835,25 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
 msgstr ""
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -581,17 +879,41 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
 msgstr ""
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -617,7 +939,17 @@ msgstr ""
 
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
 msgstr ""
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -643,27 +975,68 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
 msgstr ""
 
 #. type: Title ====
@@ -674,7 +1047,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -701,7 +1079,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -721,7 +1104,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -748,7 +1136,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -774,7 +1167,11 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
@@ -804,7 +1201,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
 msgstr ""
 
 #. type: Block title
@@ -829,12 +1231,18 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
 msgstr ""
 
 #. type: Title ====
@@ -845,17 +1253,26 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
 msgstr ""
 
 #. type: loweralpha
@@ -884,7 +1301,9 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
 msgstr ""
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -916,17 +1335,38 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
@@ -951,7 +1391,9 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
 msgstr ""
 
 #. type: Block title
@@ -975,32 +1417,65 @@ msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
 msgstr ""
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
@@ -1056,17 +1531,26 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1076,17 +1560,21 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1104,7 +1592,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1130,7 +1621,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
 msgstr ""
 
 #. type: Title ====
@@ -1141,7 +1634,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1152,7 +1647,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1163,7 +1660,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
 msgstr ""
 
 #. type: Title ==
@@ -1174,12 +1674,22 @@ msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
 msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1213,12 +1723,21 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
 msgstr ""
 
 #. type: Labeled list
@@ -1229,7 +1748,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
 msgstr ""
 
 #. type: Labeled list
@@ -1245,7 +1767,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
 msgstr ""
 
 #. type: Labeled list
@@ -1256,7 +1783,13 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
 msgstr ""
 
 #. type: Labeled list
@@ -1267,7 +1800,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
 msgstr ""
 
 #. type: Labeled list
@@ -1278,7 +1816,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
@@ -1341,7 +1882,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
 msgstr ""
 
 #. type: Title ====
@@ -1358,7 +1902,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
 msgstr ""
 
 #. type: Labeled list
@@ -1369,12 +1915,16 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
@@ -1395,7 +1945,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
 msgstr ""
 
 #. type: Title ====
@@ -1412,7 +1965,8 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
-msgid "The day the data collection and follow-up for the patient has been stopped."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
 msgstr ""
 
 #. type: Labeled list
@@ -1444,7 +1998,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
 msgstr ""
 
 #. type: Labeled list
@@ -1455,7 +2012,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1466,7 +2025,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1477,7 +2038,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1488,7 +2051,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1499,7 +2065,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
 msgstr ""
 
 #. type: Labeled list
@@ -1510,7 +2079,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
 msgstr ""
 
 #. type: Labeled list
@@ -1521,7 +2092,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
 msgstr ""
 
 #. type: Labeled list
@@ -1532,7 +2106,17 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
 msgstr ""
 
 #. type: Labeled list
@@ -1543,7 +2127,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
 msgstr ""
 
 #. type: Title ===
@@ -1571,7 +2157,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
 msgstr ""
 
 #. type: Labeled list
@@ -1582,7 +2171,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
 msgstr ""
 
 #. type: Labeled list
@@ -1593,7 +2187,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
 msgstr ""
 
 #. type: Labeled list
@@ -1604,7 +2201,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
 msgstr ""
 
 #. type: Labeled list
@@ -1615,7 +2214,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
 msgstr ""
 
 #. type: Labeled list
@@ -1626,7 +2229,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
 msgstr ""
 
 #. type: Labeled list
@@ -1637,7 +2246,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
 msgstr ""
 
 #. type: Labeled list
@@ -1648,7 +2262,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
 msgstr ""
 
 #. type: Labeled list
@@ -1659,7 +2277,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
 msgstr ""
 
 #. type: Labeled list
@@ -1670,7 +2292,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
 msgstr ""
 
 #. type: Labeled list
@@ -1714,7 +2339,8 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
-msgid "A patient with severe systemic disease that is a constant threat to life"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
 msgstr ""
 
 #. type: Labeled list
@@ -1730,7 +2356,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 msgstr ""
 
 #. type: Labeled list
@@ -1762,7 +2390,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -1773,7 +2403,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
@@ -1800,12 +2432,21 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
 msgstr ""
 
 #. type: Labeled list
@@ -1816,7 +2457,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
 msgstr ""
 
 #. type: Labeled list
@@ -1827,7 +2471,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
 msgstr ""
 
 #. type: Labeled list
@@ -1838,7 +2486,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
 msgstr ""
 
 #. type: Block title
@@ -1849,27 +2503,44 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
@@ -1879,12 +2550,19 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
 msgstr ""
 
 #. type: Title ===
@@ -1907,7 +2585,9 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
 msgstr ""
 
 #. type: Labeled list
@@ -1918,7 +2598,12 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
 msgstr ""
 
 #. type: Labeled list
@@ -1949,17 +2634,25 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -1969,17 +2662,22 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
 msgstr ""
 
 #. type: Labeled list
@@ -1990,22 +2688,36 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -2027,12 +2739,17 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2047,12 +2764,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2118,7 +2838,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2129,7 +2853,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2140,7 +2866,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
 msgstr ""
 
 #. type: Labeled list
@@ -2151,7 +2879,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
 msgstr ""
 
 #. type: Labeled list
@@ -2162,7 +2898,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2173,7 +2911,16 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Labeled list
@@ -2184,7 +2931,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2195,7 +2946,10 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
 msgstr ""
 
 #. type: Labeled list
@@ -2206,7 +2960,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
 msgstr ""
 
 #. type: Title ====
@@ -2246,7 +3002,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
 msgstr ""
 
 #. type: Plain text
@@ -2261,13 +3019,17 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
 msgstr ""
 
 #. type: Labeled list
@@ -2289,12 +3051,18 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
 msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2316,7 +3084,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2327,7 +3099,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2349,7 +3123,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2360,7 +3138,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2371,7 +3151,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Labeled list
@@ -2382,7 +3166,10 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
 msgstr ""
 
 #. type: Labeled list
@@ -2410,7 +3197,10 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -2422,12 +3212,17 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
 msgstr ""
 
 #. type: Labeled list
@@ -2438,27 +3233,44 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
 msgstr ""
 
 #. type: Labeled list
@@ -2469,7 +3281,11 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Title ==
@@ -2480,12 +3296,17 @@ msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
 msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
 msgstr ""
 
 #. type: #data-analysis
@@ -2522,27 +3343,38 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2553,47 +3385,76 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2604,22 +3465,33 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: Title ===
@@ -2636,22 +3508,32 @@ msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: Title ====
@@ -2662,42 +3544,70 @@ msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2708,7 +3618,18 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
@@ -2728,32 +3649,50 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
 msgstr ""
 
 #. type: Title ==
@@ -2770,7 +3709,9 @@ msgstr ""
 
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
 msgstr ""
 
 #. type: Labeled list
@@ -3257,7 +4198,9 @@ msgstr ""
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
 msgstr ""
 
 #. type: #imprint
@@ -3283,7 +4226,9 @@ msgstr ""
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3294,17 +4239,23 @@ msgstr ""
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3312,7 +4263,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:8
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3329,7 +4282,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:42
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3337,7 +4292,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3345,7 +4302,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:12
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3377,7 +4336,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:16
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3437,7 +4398,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3454,7 +4424,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3471,22 +4443,36 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
 msgstr ""
 
 #. type: Plain text
@@ -3497,7 +4483,11 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: Block title
@@ -3508,7 +4498,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
 msgstr ""
 
 #. type: Block title
@@ -3520,7 +4512,9 @@ msgstr ""
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3536,12 +4530,22 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3552,7 +4556,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: Block title
@@ -3563,7 +4569,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3604,7 +4612,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3651,32 +4660,51 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3691,7 +4719,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3701,7 +4731,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3711,12 +4743,15 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3726,27 +4761,40 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
 msgstr ""
 
 #. type: Plain text
@@ -3756,12 +4804,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
 msgstr ""
 
 #. type: Block title
@@ -3777,7 +4829,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
 msgstr ""
 
 #. type: loweralpha
@@ -3787,47 +4840,75 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
 msgstr ""
 
 #. type: Content of: <root><data><value>

--- a/po/documentation.es.po
+++ b/po/documentation.es.po
@@ -34,22 +34,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -67,14 +96,47 @@ msgstr "¿Qué está leyendo aquí?"
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
 #, fuzzy
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
-msgstr "Este documento es el protocolo de vigilancia para el módulo central de la vigilancia NeoIPC que cubre la vigilancia de las infecciones nosocomiales en recién nacidos de muy bajo peso al nacer (MBPN)/muy prematuros (MPN).  Forma parte de un conjunto de herramientas para la vigilancia de las infecciones relacionadas con la asistencia sanitaria (HAI) en neonatología que hemos desarrollado en el marco del proyecto NeoIPC.  Si desea realizar la vigilancia de las infecciones de aparición temprana o de las infecciones relacionadas con la asistencia sanitaria en lactantes con un peso al nacer superior a 1500 g y una edad gestacional superior a 32 semanas, el kit de herramientas proporciona métodos adicionales que se tratan en protocolos independientes."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
+msgstr ""
+"Este documento es el protocolo de vigilancia para el módulo central de la "
+"vigilancia NeoIPC que cubre la vigilancia de las infecciones nosocomiales en "
+"recién nacidos de muy bajo peso al nacer (MBPN)/muy prematuros (MPN).  Forma "
+"parte de un conjunto de herramientas para la vigilancia de las infecciones "
+"relacionadas con la asistencia sanitaria (HAI) en neonatología que hemos "
+"desarrollado en el marco del proyecto NeoIPC.  Si desea realizar la "
+"vigilancia de las infecciones de aparición temprana o de las infecciones "
+"relacionadas con la asistencia sanitaria en lactantes con un peso al nacer "
+"superior a 1500 g y una edad gestacional superior a 32 semanas, el kit de "
+"herramientas proporciona métodos adicionales que se tratan en protocolos "
+"independientes."
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
 #, fuzzy
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
-msgstr "Este protocolo proporciona referencias metodológicas y apoyo para la vigilancia de las IRAS en las unidades neonatales o para aquellos que planean desarrollar un programa de vigilancia de las IRAS.  Si se adhiere a los métodos y definiciones que especificamos aquí, podrá asegurarse de que los datos de vigilancia que genere sean comparables a los datos de referencia del proyecto NeoIPC, aunque no participe activamente en el proyecto."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
+msgstr ""
+"Este protocolo proporciona referencias metodológicas y apoyo para la "
+"vigilancia de las IRAS en las unidades neonatales o para aquellos que "
+"planean desarrollar un programa de vigilancia de las IRAS.  Si se adhiere a "
+"los métodos y definiciones que especificamos aquí, podrá asegurarse de que "
+"los datos de vigilancia que genere sean comparables a los datos de "
+"referencia del proyecto NeoIPC, aunque no participe activamente en el "
+"proyecto."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:29
@@ -85,19 +147,44 @@ msgstr "Qué es el proyecto NeoIPC"
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
 #, fuzzy
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
-msgstr "Dentro del proyecto NeoIPC, queremos apoyarle con intervenciones y estrategias de prevención y control de infecciones (IPC) en su unidad de cuidados intensivos neonatales, especialmente si observa una alta prevalencia de infecciones adquiridas en el hospital o bacterias multirresistentes (MDR).  Somos un equipo internacional de clínicos y científicos de 13 instituciones asociadas colaboradoras con un historial probado en las áreas de cuidados intensivos neonatales, infección neonatal, prevención y control de infecciones (CIP), ciencia de la implementación, microbiología y vigilancia, que colaboran en este proyecto para lograr dos objetivos generales:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
+msgstr ""
+"Dentro del proyecto NeoIPC, queremos apoyarle con intervenciones y "
+"estrategias de prevención y control de infecciones (IPC) en su unidad de "
+"cuidados intensivos neonatales, especialmente si observa una alta "
+"prevalencia de infecciones adquiridas en el hospital o bacterias "
+"multirresistentes (MDR).  Somos un equipo internacional de clínicos y "
+"científicos de 13 instituciones asociadas colaboradoras con un historial "
+"probado en las áreas de cuidados intensivos neonatales, infección neonatal, "
+"prevención y control de infecciones (CIP), ciencia de la implementación, "
+"microbiología y vigilancia, que colaboran en este proyecto para lograr dos "
+"objetivos generales:"
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
 #, fuzzy
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
-msgstr "Desarrollar y aplicar un enfoque innovador para la evaluación de las intervenciones de CIP en neonatología mediante:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
+msgstr ""
+"Desarrollar y aplicar un enfoque innovador para la evaluación de las "
+"intervenciones de CIP en neonatología mediante:"
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
 #, fuzzy
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
 msgstr ""
 "Evaluación rigurosa de la eficacia de las intervenciones en un ensayo "
 "controlado aleatorio (ECA)"
@@ -111,26 +198,46 @@ msgstr "Identificación de una estrategia de aplicación adecuada."
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
 #, fuzzy
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
-msgstr "Generar resultados ampliamente relevantes y globalmente transferibles para mejorar la CIP en la atención neonatal a través de:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
+msgstr ""
+"Generar resultados ampliamente relevantes y globalmente transferibles para "
+"mejorar la CIP en la atención neonatal a través de:"
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
 #, fuzzy
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
-msgstr "Formación de una red de práctica clínica para apoyar la implementación de la CIP en los cuidados neonatales, incluyendo una variedad de entornos de práctica como la unidad de cuidados intensivos neonatales (UCIN), cuidados intensivos, cuidados especiales y cuidados canguro (CCC)."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgstr ""
+"Formación de una red de práctica clínica para apoyar la implementación de la "
+"CIP en los cuidados neonatales, incluyendo una variedad de entornos de "
+"práctica como la unidad de cuidados intensivos neonatales (UCIN), cuidados "
+"intensivos, cuidados especiales y cuidados canguro (CCC)."
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
 #, fuzzy
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
-msgstr "Desarrollo de una estructura abierta para la vigilancia específica de los procesos y resultados de la CIP en una gran variedad de entornos."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
+msgstr ""
+"Desarrollo de una estructura abierta para la vigilancia específica de los "
+"procesos y resultados de la CIP en una gran variedad de entornos."
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
 #, fuzzy
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
-msgstr "Este proyecto ha recibido financiación del programa de investigación e innovación Horizonte 2020 de la Unión Europea en virtud del acuerdo de subvención nº 965328."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
+msgstr ""
+"Este proyecto ha recibido financiación del programa de investigación e "
+"innovación Horizonte 2020 de la Unión Europea en virtud del acuerdo de "
+"subvención nº 965328."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:43
@@ -141,8 +248,45 @@ msgstr "Antecedentes"
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
 #, fuzzy
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
-msgstr "En todo el mundo, los recién nacidos, y especialmente los prematuros, se encuentran entre los grupos de pacientes con mayor incidencia de infecciones nosocomiales.  Algunas de estas infecciones pueden evitarse con medidas de prevención de infecciones, que deben aplicarse en cada unidad neonatal y adaptarse a los riesgos de infección específicos de los pacientes.  En muchos hospitales de Europa y de todo el mundo, los profesionales sanitarios no disponen de buenos datos para evaluar la carga de infecciones relacionadas con la asistencia sanitaria y los factores de riesgo que contribuyen a su desarrollo, ni para evaluar la eficacia de las intervenciones de prevención de infecciones.  En la mayoría de los países no se dispone de apoyo para la vigilancia de las infecciones relacionadas con la asistencia sanitaria en neonatos ni de datos de referencia para la evaluación comparativa.  Cuando existen sistemas nacionales y supranacionales de recopilación de datos, suelen tener un enfoque amplio que resulta limitado en su capacidad para evaluar la situación con respecto a la prevención y el control de las infecciones.  A corto plazo, pretendemos mejorar esta situación proporcionando a los interesados en la vigilancia de la CIP en neonatología herramientas y métodos para empezar, y a largo plazo contribuyendo potencialmente a la formación de infraestructuras regionales de vigilancia."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
+msgstr ""
+"En todo el mundo, los recién nacidos, y especialmente los prematuros, se "
+"encuentran entre los grupos de pacientes con mayor incidencia de infecciones "
+"nosocomiales.  Algunas de estas infecciones pueden evitarse con medidas de "
+"prevención de infecciones, que deben aplicarse en cada unidad neonatal y "
+"adaptarse a los riesgos de infección específicos de los pacientes.  En "
+"muchos hospitales de Europa y de todo el mundo, los profesionales sanitarios "
+"no disponen de buenos datos para evaluar la carga de infecciones "
+"relacionadas con la asistencia sanitaria y los factores de riesgo que "
+"contribuyen a su desarrollo, ni para evaluar la eficacia de las "
+"intervenciones de prevención de infecciones.  En la mayoría de los países no "
+"se dispone de apoyo para la vigilancia de las infecciones relacionadas con "
+"la asistencia sanitaria en neonatos ni de datos de referencia para la "
+"evaluación comparativa.  Cuando existen sistemas nacionales y "
+"supranacionales de recopilación de datos, suelen tener un enfoque amplio que "
+"resulta limitado en su capacidad para evaluar la situación con respecto a la "
+"prevención y el control de las infecciones.  A corto plazo, pretendemos "
+"mejorar esta situación proporcionando a los interesados en la vigilancia de "
+"la CIP en neonatología herramientas y métodos para empezar, y a largo plazo "
+"contribuyendo potencialmente a la formación de infraestructuras regionales "
+"de vigilancia."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:52
@@ -153,26 +297,69 @@ msgstr "Consejos de uso y requisitos de participación"
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
 #, fuzzy
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
-msgstr "Si desea empezar a recopilar datos utilizando los métodos y herramientas de vigilancia de NeoIPC, puede hacerlo sin pedirnos permiso ni pagar ninguna cuota.  Todos los manuales y herramientas son de uso gratuito, y puede empezar a utilizarlos de inmediato si cree que le ayudarán a mejorar la calidad del control de infecciones en su departamento."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
+msgstr ""
+"Si desea empezar a recopilar datos utilizando los métodos y herramientas de "
+"vigilancia de NeoIPC, puede hacerlo sin pedirnos permiso ni pagar ninguna "
+"cuota.  Todos los manuales y herramientas son de uso gratuito, y puede "
+"empezar a utilizarlos de inmediato si cree que le ayudarán a mejorar la "
+"calidad del control de infecciones en su departamento."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
 #, fuzzy
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
-msgstr "Si empieza con formularios en papel y realiza los cálculos con bolígrafo y papel o utilizando una hoja de cálculo, tendrá una barrera de entrada muy baja, e incluso puede ayudarle a conocer a fondo los cálculos que realizan internamente las herramientas más avanzadas.  Si desea que las cosas funcionen eficazmente durante un periodo prolongado y dispone de los recursos necesarios, puede beneficiarse de esas herramientas utilizando el software de vigilancia avanzado a nivel local o participando en NeoIPC o en una red de vigilancia regional basada en sus métodos."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
+msgstr ""
+"Si empieza con formularios en papel y realiza los cálculos con bolígrafo y "
+"papel o utilizando una hoja de cálculo, tendrá una barrera de entrada muy "
+"baja, e incluso puede ayudarle a conocer a fondo los cálculos que realizan "
+"internamente las herramientas más avanzadas.  Si desea que las cosas "
+"funcionen eficazmente durante un periodo prolongado y dispone de los "
+"recursos necesarios, puede beneficiarse de esas herramientas utilizando el "
+"software de vigilancia avanzado a nivel local o participando en NeoIPC o en "
+"una red de vigilancia regional basada en sus métodos."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
 #, fuzzy
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
-msgstr "Para tener éxito a largo plazo en la vigilancia de las infecciones nosocomiales, será crucial recopilar datos y producir información fiable y comparable en su departamento durante un largo periodo de tiempo.  Para facilitar la recopilación de esos datos, tal vez desee aportar datos a la red de vigilancia NeoIPC.  Estos datos podrían utilizarse para generar informes y comparar las tasas de infección de su unidad neonatal con las de otras."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
+msgstr ""
+"Para tener éxito a largo plazo en la vigilancia de las infecciones "
+"nosocomiales, será crucial recopilar datos y producir información fiable y "
+"comparable en su departamento durante un largo periodo de tiempo.  Para "
+"facilitar la recopilación de esos datos, tal vez desee aportar datos a la "
+"red de vigilancia NeoIPC.  Estos datos podrían utilizarse para generar "
+"informes y comparar las tasas de infección de su unidad neonatal con las de "
+"otras."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
 #, fuzzy
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
-msgstr "Si recopila y envía datos, y es responsable de la mejora de la calidad, es esencial que tenga claro lo siguiente:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
+msgstr ""
+"Si recopila y envía datos, y es responsable de la mejora de la calidad, es "
+"esencial que tenga claro lo siguiente:"
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:66
@@ -195,7 +382,9 @@ msgstr "Procedimientos de cumplimentación y almacenamiento de formularios"
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
 #, fuzzy
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
 msgstr ""
 "Seguridad y privacidad de los datos (protección de la información que "
 "pudiera utilizarse para identificar a un paciente fuera de su departamento u "
@@ -217,31 +406,75 @@ msgstr "Procedimientos de gestión y finalización de datos"
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:72
 #, fuzzy
 msgid "Use of NeoIPC reports for monitoring and improving patient care"
-msgstr "Uso de los informes de NeoIPC para supervisar y mejorar la atención al paciente"
+msgstr ""
+"Uso de los informes de NeoIPC para supervisar y mejorar la atención al "
+"paciente"
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
 #, fuzzy
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
-msgstr "Debe asegurarse de que todo el equipo de recogida de datos de su centro acepta las definiciones de datos contenidas en este protocolo y envía sus datos en consecuencia.  Para poder generar informes de referencia actualizados con regularidad, NeoIPC requiere que los participantes envíen regularmente los datos a través de la interfaz basada en la web y que se aseguren de que sus sistemas de software y hardware cumplen los requisitos mínimos."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
+msgstr ""
+"Debe asegurarse de que todo el equipo de recogida de datos de su centro "
+"acepta las definiciones de datos contenidas en este protocolo y envía sus "
+"datos en consecuencia.  Para poder generar informes de referencia "
+"actualizados con regularidad, NeoIPC requiere que los participantes envíen "
+"regularmente los datos a través de la interfaz basada en la web y que se "
+"aseguren de que sus sistemas de software y hardware cumplen los requisitos "
+"mínimos."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
 #, fuzzy
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
-msgstr "Las políticas y procedimientos de su centro deben garantizar la privacidad de los pacientes y la seguridad de los datos.  Es importante proteger la información personal de los pacientes y otros datos que puedan conducir a su identificación de acuerdo con las leyes y políticas aplicables a su centro.  No envíe información personal de los pacientes a la red NeoIPC."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
+msgstr ""
+"Las políticas y procedimientos de su centro deben garantizar la privacidad "
+"de los pacientes y la seguridad de los datos.  Es importante proteger la "
+"información personal de los pacientes y otros datos que puedan conducir a su "
+"identificación de acuerdo con las leyes y políticas aplicables a su centro.  "
+"No envíe información personal de los pacientes a la red NeoIPC."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
 #, fuzzy
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
-msgstr "Nos aseguraremos de mantener la estricta confidencialidad de los datos desglosados enviados por cada departamento y le proporcionaremos periódicamente informes de referencia estandarizados y estratificados que contendrán datos agregados para que no se pueda identificar a ningún paciente individual ni a ningún departamento."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
+msgstr ""
+"Nos aseguraremos de mantener la estricta confidencialidad de los datos "
+"desglosados enviados por cada departamento y le proporcionaremos "
+"periódicamente informes de referencia estandarizados y estratificados que "
+"contendrán datos agregados para que no se pueda identificar a ningún "
+"paciente individual ni a ningún departamento."
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
 #, fuzzy
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
-msgstr "Para ayudarle a navegar y utilizar mejor las herramientas proporcionadas, ponemos a su disposición manuales de vigilancia, hojas de datos y material de formación en https://neoipc.org/surveillance/.  Aunque nuestros recursos para la interacción personal son limitados, también intentaremos apoyar a su equipo si envía sus preguntas a neoipc-support@charite.de."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
+msgstr ""
+"Para ayudarle a navegar y utilizar mejor las herramientas proporcionadas, "
+"ponemos a su disposición manuales de vigilancia, hojas de datos y material "
+"de formación en https://neoipc.org/surveillance/.  Aunque nuestros recursos "
+"para la interacción personal son limitados, también intentaremos apoyar a su "
+"equipo si envía sus preguntas a neoipc-support@charite.de."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:86
@@ -258,8 +491,27 @@ msgstr "Protección y seguridad de los datos"
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
 #, fuzzy
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
-msgstr "La vigilancia sistemática de las infecciones relacionadas con la asistencia sanitaria no es investigación, sino una forma de garantizar la calidad que forma parte de la atención habitual a los pacientes.  Por ello, la recopilación de datos asociada suele estar cubierta por los contratos de tratamiento hospitalario habitual o por la legislación especial que lo ordena y no necesita el consentimiento explícito de los pacientes afectados o de sus tutores legales.  No obstante, debe asegurarse de que esto se aplica en su país antes de empezar a recopilar datos y, además, cumplir algunas normas mínimas universales que deben aplicarse con independencia del marco jurídico."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
+msgstr ""
+"La vigilancia sistemática de las infecciones relacionadas con la asistencia "
+"sanitaria no es investigación, sino una forma de garantizar la calidad que "
+"forma parte de la atención habitual a los pacientes.  Por ello, la "
+"recopilación de datos asociada suele estar cubierta por los contratos de "
+"tratamiento hospitalario habitual o por la legislación especial que lo "
+"ordena y no necesita el consentimiento explícito de los pacientes afectados "
+"o de sus tutores legales.  No obstante, debe asegurarse de que esto se "
+"aplica en su país antes de empezar a recopilar datos y, además, cumplir "
+"algunas normas mínimas universales que deben aplicarse con independencia del "
+"marco jurídico."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:94
@@ -270,8 +522,40 @@ msgstr "Información del paciente"
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
 #, fuzzy
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
-msgstr "La información sanitaria se encuentra entre las categorías más privadas de información sobre seres humanos en la mayoría de las culturas y debe tratarse con especial cuidado.  Cuando se almacena o transmite información que puede llevar a la identificación de un paciente individual, esto debe hacerse generalmente de forma que ningún tercero no autorizado pueda acceder a ella.  Aunque esto suele estar muy claro en el caso de los identificadores humanos típicos, como la combinación de apellido, nombre y fecha de nacimiento, en el caso de los neonatos incluso un peso al nacer o una edad gestacional muy poco frecuentes pueden llevar a la identificación de un paciente individual si se combinan con suficiente información adicional, como la fecha de nacimiento o el hospital en el que se atiende al paciente.  Piense en este fenómeno especial siempre que publique datos o información resultantes de sus actividades relacionadas con la vigilancia o los transmita a un sistema que no esté aprobado por su hospital.  Esto puede aplicarse incluso a un software de vigilancia NeoIPC mantenido externamente si no existen contratos que regulen el procesamiento y la propiedad de los datos."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
+msgstr ""
+"La información sanitaria se encuentra entre las categorías más privadas de "
+"información sobre seres humanos en la mayoría de las culturas y debe "
+"tratarse con especial cuidado.  Cuando se almacena o transmite información "
+"que puede llevar a la identificación de un paciente individual, esto debe "
+"hacerse generalmente de forma que ningún tercero no autorizado pueda acceder "
+"a ella.  Aunque esto suele estar muy claro en el caso de los identificadores "
+"humanos típicos, como la combinación de apellido, nombre y fecha de "
+"nacimiento, en el caso de los neonatos incluso un peso al nacer o una edad "
+"gestacional muy poco frecuentes pueden llevar a la identificación de un "
+"paciente individual si se combinan con suficiente información adicional, "
+"como la fecha de nacimiento o el hospital en el que se atiende al paciente.  "
+"Piense en este fenómeno especial siempre que publique datos o información "
+"resultantes de sus actividades relacionadas con la vigilancia o los "
+"transmita a un sistema que no esté aprobado por su hospital.  Esto puede "
+"aplicarse incluso a un software de vigilancia NeoIPC mantenido externamente "
+"si no existen contratos que regulen el procesamiento y la propiedad de los "
+"datos."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:102
@@ -282,26 +566,83 @@ msgstr "Información sobre hospitales"
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
 #, fuzzy
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
-msgstr "Por lo general, la información sobre los hospitales no está protegida por la ley, pero algunos datos pueden considerarse secreto de empresa y, en ese caso, como miembro del personal, normalmente no está permitido divulgarlos.  Si la información de vigilancia (\"tasas de infección hospitalaria\") es un secreto de empresa o debería serlo, es un tema de amplio debate y es comprensible que las organizaciones de defensa de los derechos de los pacientes aboguen por la transparencia a este respecto.  Sin embargo, la publicación de los datos de vigilancia puede tener un efecto perjudicial tanto en la percepción de la calidad del tratamiento de un hospital como en la capacidad del equipo de vigilancia para realizar la vigilancia de forma honesta y autocrítica."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
+msgstr ""
+"Por lo general, la información sobre los hospitales no está protegida por la "
+"ley, pero algunos datos pueden considerarse secreto de empresa y, en ese "
+"caso, como miembro del personal, normalmente no está permitido divulgarlos.  "
+"Si la información de vigilancia (\"tasas de infección hospitalaria\") es un "
+"secreto de empresa o debería serlo, es un tema de amplio debate y es "
+"comprensible que las organizaciones de defensa de los derechos de los "
+"pacientes aboguen por la transparencia a este respecto.  Sin embargo, la "
+"publicación de los datos de vigilancia puede tener un efecto perjudicial "
+"tanto en la percepción de la calidad del tratamiento de un hospital como en "
+"la capacidad del equipo de vigilancia para realizar la vigilancia de forma "
+"honesta y autocrítica."
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
 #, fuzzy
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
-msgstr "Al tratarse de una herramienta de autoevaluación, la vigilancia no puede descartar todas las formas de subjetividad y deshonestidad, y la presión pública tiende a desviar la recopilación de datos hacia una evaluación excesivamente crítica de los registros de infecciones, lo que da lugar a tasas bajas sobre las que ya no se puede actuar.  Además del problema de la vigilancia pro-forma, puede haber razones muy legítimas o incluso honorables para las altas tasas de infección en un hospital, como tratar a quienes tienen un riesgo especialmente alto de contraer infecciones, que no pueden ajustarse por los medios de estandarización o estratificación de los datos recogidos.  Estas razones son notoriamente difíciles de comunicar al público, lo que puede llevar a una simplificación excesiva y al abuso político."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
+msgstr ""
+"Al tratarse de una herramienta de autoevaluación, la vigilancia no puede "
+"descartar todas las formas de subjetividad y deshonestidad, y la presión "
+"pública tiende a desviar la recopilación de datos hacia una evaluación "
+"excesivamente crítica de los registros de infecciones, lo que da lugar a "
+"tasas bajas sobre las que ya no se puede actuar.  Además del problema de la "
+"vigilancia pro-forma, puede haber razones muy legítimas o incluso honorables "
+"para las altas tasas de infección en un hospital, como tratar a quienes "
+"tienen un riesgo especialmente alto de contraer infecciones, que no pueden "
+"ajustarse por los medios de estandarización o estratificación de los datos "
+"recogidos.  Estas razones son notoriamente difíciles de comunicar al "
+"público, lo que puede llevar a una simplificación excesiva y al abuso "
+"político."
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
 #, fuzzy
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
-msgstr "Dado que no existe una solución fácil para estos problemas, NeoIPC no revelará la identidad de los hospitales participantes y se asegurará de que las publicaciones e informes no contengan información que pueda conducir a la identificación de un hospital concreto."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
+msgstr ""
+"Dado que no existe una solución fácil para estos problemas, NeoIPC no "
+"revelará la identidad de los hospitales participantes y se asegurará de que "
+"las publicaciones e informes no contengan información que pueda conducir a "
+"la identificación de un hospital concreto."
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
 #, fuzzy
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
-msgstr "Cuando publique datos usted mismo o como red regional, deberá considerar detenidamente los posibles efectos de incluir información a nivel de hospital y hacerlo en estrecha coordinación con las partes interesadas."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
+msgstr ""
+"Cuando publique datos usted mismo o como red regional, deberá considerar "
+"detenidamente los posibles efectos de incluir información a nivel de "
+"hospital y hacerlo en estrecha coordinación con las partes interesadas."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:116
@@ -312,56 +653,126 @@ msgstr "Presentación de datos"
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
 #, fuzzy
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
-msgstr "Como se ha indicado xref:introduction-advice-for-use-and-requirements-for-participation[arriba], puede utilizar las herramientas y métodos desarrollados por el proyecto NeoIPC para llevar a cabo la vigilancia de las infecciones nosocomiales en su departamento de neonatología sin enviar ninguna información al proyecto NeoIPC o a una red regional."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
+msgstr ""
+"Como se ha indicado xref:introduction-advice-for-use-and-requirements-for-"
+"participation[arriba], puede utilizar las herramientas y métodos "
+"desarrollados por el proyecto NeoIPC para llevar a cabo la vigilancia de las "
+"infecciones nosocomiales en su departamento de neonatología sin enviar "
+"ninguna información al proyecto NeoIPC o a una red regional."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
 #, fuzzy
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
-msgstr "No obstante, si decide enviar datos, le recomendamos encarecidamente que utilice el sistema de notificación por Internet que hemos desarrollado basado en el sistema de gestión de la información sanitaria https://dhis2.org/[DHIS2]."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
+msgstr ""
+"No obstante, si decide enviar datos, le recomendamos encarecidamente que "
+"utilice el sistema de notificación por Internet que hemos desarrollado "
+"basado en el sistema de gestión de la información sanitaria https://"
+"dhis2.org/[DHIS2]."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
 #, fuzzy
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
-msgstr "Dado que DHIS2 es un sistema de código abierto disponible gratuitamente, tiene múltiples opciones para utilizarlo:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
+msgstr ""
+"Dado que DHIS2 es un sistema de código abierto disponible gratuitamente, "
+"tiene múltiples opciones para utilizarlo:"
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
 #, fuzzy
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
-msgstr "Desplegarlo localmente en su hospital y utilizarlo para la recopilación de datos de NeoIPC dentro de su hospital, así como para otros posibles casos de uso."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
+msgstr ""
+"Desplegarlo localmente en su hospital y utilizarlo para la recopilación de "
+"datos de NeoIPC dentro de su hospital, así como para otros posibles casos de "
+"uso."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
 #, fuzzy
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
-msgstr "Desplegarlo a nivel nacional o regional (o utilizar un despliegue nacional o regional existente) para formar una red nacional o regional de unidades que realicen la vigilancia."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
+msgstr ""
+"Desplegarlo a nivel nacional o regional (o utilizar un despliegue nacional o "
+"regional existente) para formar una red nacional o regional de unidades que "
+"realicen la vigilancia."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
 #, fuzzy
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
-msgstr "Utilice el proyecto NeoIPC https://neoipc.charite.de/[instance] del sistema, que actualmente gestiona el equipo del Centro Nacional de Referencia Alemán para la Vigilancia de Infecciones Nosocomiales del Instituto de Higiene y Medicina Medioambiental de Charité."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
+msgstr ""
+"Utilice el proyecto NeoIPC https://neoipc.charite.de/[instance] del sistema, "
+"que actualmente gestiona el equipo del Centro Nacional de Referencia Alemán "
+"para la Vigilancia de Infecciones Nosocomiales del Instituto de Higiene y "
+"Medicina Medioambiental de Charité."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
 #, fuzzy
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
-msgstr "Una de las ventajas de utilizar el sistema de informes basado en la web es el hecho de que se puede utilizar para crear informes estandarizados basados en unidades en cualquier momento con unos pocos clics y compararlos con los informes de referencia de NeoIPC que se publican anualmente."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
+msgstr ""
+"Una de las ventajas de utilizar el sistema de informes basado en la web es "
+"el hecho de que se puede utilizar para crear informes estandarizados basados "
+"en unidades en cualquier momento con unos pocos clics y compararlos con los "
+"informes de referencia de NeoIPC que se publican anualmente."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
 #, fuzzy
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
-msgstr "Para crear el informe de referencia, realizamos un cálculo en un momento determinado cada año utilizando los datos disponibles en la base de datos NeoIPC en ese momento.  Para que esto sea posible, debe haber completado toda la introducción de datos y la adición de la información que falte del año anterior en las 6 semanas siguientes al final de un año natural.  Esto se aplica a los pacientes cuyo periodo de vigilancia finalizó el año anterior."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
+msgstr ""
+"Para crear el informe de referencia, realizamos un cálculo en un momento "
+"determinado cada año utilizando los datos disponibles en la base de datos "
+"NeoIPC en ese momento.  Para que esto sea posible, debe haber completado "
+"toda la introducción de datos y la adición de la información que falte del "
+"año anterior en las 6 semanas siguientes al final de un año natural.  Esto "
+"se aplica a los pacientes cuyo periodo de vigilancia finalizó el año "
+"anterior."
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
 #, fuzzy
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
-msgstr "Si el sistema de notificación basado en la web no está disponible temporalmente (por ejemplo, debido a mantenimiento o problemas técnicos), utilice las hojas de datos en papel para la documentación durante este período y recuerde introducir estos datos en la plataforma web lo antes posible una vez que vuelva a estar disponible."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
+msgstr ""
+"Si el sistema de notificación basado en la web no está disponible "
+"temporalmente (por ejemplo, debido a mantenimiento o problemas técnicos), "
+"utilice las hojas de datos en papel para la documentación durante este "
+"período y recuerde introducir estos datos en la plataforma web lo antes "
+"posible una vez que vuelva a estar disponible."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:136
@@ -372,20 +783,71 @@ msgstr "Recogida de datos"
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
 #, fuzzy
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
-msgstr "El objetivo principal de los métodos utilizados por el sistema de vigilancia NeoIPC es respaldar las normas internas de garantía de calidad, realizar afirmaciones válidas sobre la frecuencia de infecciones relacionadas con la asistencia sanitaria en lactantes elegibles durante su estancia hospitalaria y promover la aplicación de estrategias de CIP en una unidad neonatal."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
+msgstr ""
+"El objetivo principal de los métodos utilizados por el sistema de vigilancia "
+"NeoIPC es respaldar las normas internas de garantía de calidad, realizar "
+"afirmaciones válidas sobre la frecuencia de infecciones relacionadas con la "
+"asistencia sanitaria en lactantes elegibles durante su estancia hospitalaria "
+"y promover la aplicación de estrategias de CIP en una unidad neonatal."
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
 #, fuzzy
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
-msgstr "Basándonos en nuestra experiencia, prevemos que recopilará datos tanto a través de la revisión de las historias clínicas como a través de la interacción con los colegas que participan en el tratamiento y los cuidados del paciente sometido a vigilancia.  Por este motivo, lo ideal sería que la recopilación de datos se realizara junto a la cama del paciente, para maximizar la cantidad de información disponible (permitiendo a los médicos que lo atienden aclarar las entradas poco claras o incompletas de la historia clínica) y minimizar la cantidad de tiempo que implica la búsqueda de historias clínicas una vez que el paciente ha abandonado el hospital.  Normalmente, identificará a los pacientes con infecciones relacionadas con la asistencia sanitaria mediante el examen regular de los historiales existentes de los pacientes del departamento, incluidos los resultados de laboratorio.  El éxito de su participación en la vigilancia de NeoIPC dependerá en gran medida de la estrecha comunicación entre quienes realizan la vigilancia (normalmente profesionales de prevención y control de infecciones) y quienes atienden al paciente (normalmente profesionales de neonatología).  Dado que, en última instancia, los datos recogidos deberán introducirse en un ordenador, la combinación de la recogida y la introducción de datos en un único procedimiento puede ahorrar tiempo y reducir el riesgo de errores en la copia de datos."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
+msgstr ""
+"Basándonos en nuestra experiencia, prevemos que recopilará datos tanto a "
+"través de la revisión de las historias clínicas como a través de la "
+"interacción con los colegas que participan en el tratamiento y los cuidados "
+"del paciente sometido a vigilancia.  Por este motivo, lo ideal sería que la "
+"recopilación de datos se realizara junto a la cama del paciente, para "
+"maximizar la cantidad de información disponible (permitiendo a los médicos "
+"que lo atienden aclarar las entradas poco claras o incompletas de la "
+"historia clínica) y minimizar la cantidad de tiempo que implica la búsqueda "
+"de historias clínicas una vez que el paciente ha abandonado el hospital.  "
+"Normalmente, identificará a los pacientes con infecciones relacionadas con "
+"la asistencia sanitaria mediante el examen regular de los historiales "
+"existentes de los pacientes del departamento, incluidos los resultados de "
+"laboratorio.  El éxito de su participación en la vigilancia de NeoIPC "
+"dependerá en gran medida de la estrecha comunicación entre quienes realizan "
+"la vigilancia (normalmente profesionales de prevención y control de "
+"infecciones) y quienes atienden al paciente (normalmente profesionales de "
+"neonatología).  Dado que, en última instancia, los datos recogidos deberán "
+"introducirse en un ordenador, la combinación de la recogida y la "
+"introducción de datos en un único procedimiento puede ahorrar tiempo y "
+"reducir el riesgo de errores en la copia de datos."
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
 #, fuzzy
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
-msgstr "Hay dos hojas de recogida de datos de pacientes que deben cumplimentarse para todos los pacientes elegibles para el programa de vigilancia NeoIPC:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
+msgstr ""
+"Hay dos hojas de recogida de datos de pacientes que deben cumplimentarse "
+"para todos los pacientes elegibles para el programa de vigilancia NeoIPC:"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:148
@@ -402,8 +864,12 @@ msgstr "Cuadro de evolución del paciente"
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
 #, fuzzy
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
-msgstr "También debe cumplimentarse una tercera hoja de recogida de datos, si el paciente se somete a un procedimiento quirúrgico:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
+msgstr ""
+"También debe cumplimentarse una tercera hoja de recogida de datos, si el "
+"paciente se somete a un procedimiento quirúrgico:"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:153
@@ -414,8 +880,15 @@ msgstr "Formulario de recogida de datos del procedimiento quirúrgico"
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
 #, fuzzy
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
-msgstr "Además, si un lactante elegible desarrolla una infección asociada a la asistencia sanitaria durante el periodo de seguimiento de NeoIPC, deberá cumplimentar también la hoja u hojas de recogida de datos de infección correspondientes:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
+msgstr ""
+"Además, si un lactante elegible desarrolla una infección asociada a la "
+"asistencia sanitaria durante el periodo de seguimiento de NeoIPC, deberá "
+"cumplimentar también la hoja u hojas de recogida de datos de infección "
+"correspondientes:"
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:157
@@ -447,20 +920,36 @@ msgstr "Infección del sitio quirúrgico"
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
 #, fuzzy
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
-msgstr "Sólo deben registrarse estas infecciones adquiridas en los servicios de neonatología participantes."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
+msgstr ""
+"Sólo deben registrarse estas infecciones adquiridas en los servicios de "
+"neonatología participantes."
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
 #, fuzzy
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
-msgstr "Todos los lactantes elegibles deben ser observados hasta el final del periodo de vigilancia, definido como el momento en que el lactante fallece, es trasladado o recibe el alta hospitalaria."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
+msgstr ""
+"Todos los lactantes elegibles deben ser observados hasta el final del "
+"periodo de vigilancia, definido como el momento en que el lactante fallece, "
+"es trasladado o recibe el alta hospitalaria."
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
 #, fuzzy
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
-msgstr "En caso de intervención quirúrgica, se realiza un seguimiento adicional de los pacientes para detectar ISQ durante 30 o 90 días, dependiendo de si hay un implante.  Para más información, véase Infecciones del sitio quirúrgico."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
+msgstr ""
+"En caso de intervención quirúrgica, se realiza un seguimiento adicional de "
+"los pacientes para detectar ISQ durante 30 o 90 días, dependiendo de si hay "
+"un implante.  Para más información, véase Infecciones del sitio quirúrgico."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:169
@@ -490,13 +979,20 @@ msgstr "**Y/O**"
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:177
 #, fuzzy
 msgid "whose gestational age is less than 32 weeks (31 weeks 6 days inclusive)"
-msgstr "cuya edad gestacional sea inferior a 32 semanas (31 semanas 6 días inclusive)"
+msgstr ""
+"cuya edad gestacional sea inferior a 32 semanas (31 semanas 6 días inclusive)"
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
 #, fuzzy
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
-msgstr "ingresados en una sala de su unidad neonatal **dentro de los 120 días siguientes al nacimiento** son elegibles para su inclusión en el módulo básico del Programa de Vigilancia NeoIPC."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
+msgstr ""
+"ingresados en una sala de su unidad neonatal **dentro de los 120 días "
+"siguientes al nacimiento** son elegibles para su inclusión en el módulo "
+"básico del Programa de Vigilancia NeoIPC."
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:180
@@ -544,8 +1040,12 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
 #, fuzzy
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
-msgstr "Un lactante que no sea apto en el módulo principal puede serlo en otro módulo de vigilancia de NeoIPC."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
+msgstr ""
+"Un lactante que no sea apto en el módulo principal puede serlo en otro "
+"módulo de vigilancia de NeoIPC."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:198
@@ -556,8 +1056,14 @@ msgstr "Recogida de datos del paciente"
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
 #, fuzzy
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
-msgstr "Siempre que un paciente elegible ingrese o reingrese en una de las salas de su departamento de neonatología, deberá registrarlo, preferiblemente de forma directa, en la plataforma de informes en línea."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
+msgstr ""
+"Siempre que un paciente elegible ingrese o reingrese en una de las salas de "
+"su departamento de neonatología, deberá registrarlo, preferiblemente de "
+"forma directa, en la plataforma de informes en línea."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:202
@@ -568,32 +1074,97 @@ msgstr "Tabla de seudonimización"
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
 #, fuzzy
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
-msgstr "Si tiene un requisito legal o de otro tipo para identificar inequívocamente a los pacientes en la plataforma de informes en línea, debe asignar a cada paciente un NeoIPC-ID en el momento de la inscripción.  El NeoIPC-ID es un identificador aleatorio único, que le permite identificar a ese paciente dentro de su departamento.  Esto le permite utilizar los datos anónimos almacenados en el sistema para referirse a pacientes concretos, por ejemplo, en caso de readmisión o corrección de datos, pero imposibilita que terceros hagan lo mismo."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
+msgstr ""
+"Si tiene un requisito legal o de otro tipo para identificar inequívocamente "
+"a los pacientes en la plataforma de informes en línea, debe asignar a cada "
+"paciente un NeoIPC-ID en el momento de la inscripción.  El NeoIPC-ID es un "
+"identificador aleatorio único, que le permite identificar a ese paciente "
+"dentro de su departamento.  Esto le permite utilizar los datos anónimos "
+"almacenados en el sistema para referirse a pacientes concretos, por ejemplo, "
+"en caso de readmisión o corrección de datos, pero imposibilita que terceros "
+"hagan lo mismo."
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
 #, fuzzy
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
-msgstr "Cada paciente sólo puede tener un número de identificación NeoIPC.  Cuando un paciente es dado de alta y luego readmitido, el seguimiento inicial finaliza en el momento del alta, y debe realizarse una nueva inscripción utilizando el mismo número de identificación NeoIPC cuando el paciente es readmitido."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
+msgstr ""
+"Cada paciente sólo puede tener un número de identificación NeoIPC.  Cuando "
+"un paciente es dado de alta y luego readmitido, el seguimiento inicial "
+"finaliza en el momento del alta, y debe realizarse una nueva inscripción "
+"utilizando el mismo número de identificación NeoIPC cuando el paciente es "
+"readmitido."
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
 #, fuzzy
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
-msgstr "Usted es responsable de organizar la recuperación de los datos del paciente basándose en identificadores únicos.  Le aconsejamos que genere una lista de seudonimización que contenga el NeoIPC ID (números aleatorios únicos) junto con otra información identificativa (nombre, fecha de nacimiento, identificación del paciente del sistema de información del hospital) o que anote esa información en la hoja de datos maestros de vigilancia de pacientes en papel.  Debe almacenar la lista de seudonimización y las hojas en papel en las mismas condiciones en las que almacena los datos sanitarios secretos de los pacientes y destruirla o destruir la información contenida de forma segura en cuanto ya no sea necesaria.  Para garantizar la privacidad de los datos, nunca debe utilizar un identificador que se utilice en un contexto distinto al de la Vigilancia de NeoIPC y que no controle totalmente (por ejemplo, no **utilice** el identificador de paciente de su sistema de información hospitalaria, el nombre del paciente o cualquier identificador único que se utilice en otro lugar) mientras crea el identificador de NeoIPC."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
+msgstr ""
+"Usted es responsable de organizar la recuperación de los datos del paciente "
+"basándose en identificadores únicos.  Le aconsejamos que genere una lista de "
+"seudonimización que contenga el NeoIPC ID (números aleatorios únicos) junto "
+"con otra información identificativa (nombre, fecha de nacimiento, "
+"identificación del paciente del sistema de información del hospital) o que "
+"anote esa información en la hoja de datos maestros de vigilancia de "
+"pacientes en papel.  Debe almacenar la lista de seudonimización y las hojas "
+"en papel en las mismas condiciones en las que almacena los datos sanitarios "
+"secretos de los pacientes y destruirla o destruir la información contenida "
+"de forma segura en cuanto ya no sea necesaria.  Para garantizar la "
+"privacidad de los datos, nunca debe utilizar un identificador que se utilice "
+"en un contexto distinto al de la Vigilancia de NeoIPC y que no controle "
+"totalmente (por ejemplo, no **utilice** el identificador de paciente de su "
+"sistema de información hospitalaria, el nombre del paciente o cualquier "
+"identificador único que se utilice en otro lugar) mientras crea el "
+"identificador de NeoIPC."
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
 #, fuzzy
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
-msgstr "Para la generación de informes de referencia, NeoIPC no necesita realizar un seguimiento individual de los pacientes y los ID que usted asigne no serán utilizados por NeoIPC en modo alguno."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
+msgstr ""
+"Para la generación de informes de referencia, NeoIPC no necesita realizar un "
+"seguimiento individual de los pacientes y los ID que usted asigne no serán "
+"utilizados por NeoIPC en modo alguno."
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
 #, fuzzy
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
-msgstr "Para crear una lista de pseudonimización puede utilizar las plantillas (hoja de cálculo Excel y hoja de datos en papel) disponibles en la https://neoipc.org/surveillance/resources/[sección de recursos] de nuestro sitio web."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
+msgstr ""
+"Para crear una lista de pseudonimización puede utilizar las plantillas (hoja "
+"de cálculo Excel y hoja de datos en papel) disponibles en la https://"
+"neoipc.org/surveillance/resources/[sección de recursos] de nuestro sitio web."
 
 #. type: Block title
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:219
@@ -644,14 +1215,42 @@ msgstr "Hoja maestra de recogida de datos"
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
 #, fuzzy
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
-msgstr "Cada vez que un paciente elegible es admitido o readmitido en su departamento de neonatología, usted debe inscribir a este paciente, preferiblemente directamente en la plataforma de informes en línea.  Después de inscribir a un paciente, debe introducir la información de admisión y seguir recopilando los datos de seguimiento utilizando los gráficos de evolución del paciente.  Cuando el paciente recibe el alta, es trasladado a otro hospital o fallece, debe finalizar el seguimiento de este paciente, totalizar los datos registrados en el xref:patient-progress-chart[gráfico de evolución del paciente] y transferirlos a la hoja de datos maestros o introducirlos directamente en el sistema de introducción de datos en línea."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
+msgstr ""
+"Cada vez que un paciente elegible es admitido o readmitido en su "
+"departamento de neonatología, usted debe inscribir a este paciente, "
+"preferiblemente directamente en la plataforma de informes en línea.  Después "
+"de inscribir a un paciente, debe introducir la información de admisión y "
+"seguir recopilando los datos de seguimiento utilizando los gráficos de "
+"evolución del paciente.  Cuando el paciente recibe el alta, es trasladado a "
+"otro hospital o fallece, debe finalizar el seguimiento de este paciente, "
+"totalizar los datos registrados en el xref:patient-progress-chart[gráfico de "
+"evolución del paciente] y transferirlos a la hoja de datos maestros o "
+"introducirlos directamente en el sistema de introducción de datos en línea."
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
 #, fuzzy
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
-msgstr "Puede utilizar la hoja maestra de recogida de datos para guardar localmente la inscripción, la información de admisión y los datos de fin de vigilancia.  Sin embargo, si envía datos a NeoIPC, la información que recoja en la hoja maestra de recogida de datos deberá introducirse en última instancia en el sistema de introducción de datos en línea."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
+msgstr ""
+"Puede utilizar la hoja maestra de recogida de datos para guardar localmente "
+"la inscripción, la información de admisión y los datos de fin de "
+"vigilancia.  Sin embargo, si envía datos a NeoIPC, la información que recoja "
+"en la hoja maestra de recogida de datos deberá introducirse en última "
+"instancia en el sistema de introducción de datos en línea."
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -681,20 +1280,70 @@ msgstr "Gráfico de progreso del paciente"
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
 #, fuzzy
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
-msgstr "Los pacientes elegibles que han sido inscritos en el sistema deben ser seguidos utilizando gráficos de evolución del paciente hasta su muerte, traslado o alta.  Los factores acumulativos de riesgo y protección, como los días de paciente, los días de dispositivo y los días de antibiótico, se registran en el gráfico, a ser posible diariamente.  Este gráfico debe conservarse en su centro y para simplificar la recogida de datos y el seguimiento del paciente.  Durante el periodo de vigilancia, debe conservar el gráfico o los gráficos de evolución de cada lactante que cumpla los requisitos.  Es posible introducir hasta seis sustancias antibióticas diferentes en un mismo gráfico.  Si su paciente ha recibido más de seis tipos de antibióticos, utilice un gráfico adicional para documentarlos."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
+msgstr ""
+"Los pacientes elegibles que han sido inscritos en el sistema deben ser "
+"seguidos utilizando gráficos de evolución del paciente hasta su muerte, "
+"traslado o alta.  Los factores acumulativos de riesgo y protección, como los "
+"días de paciente, los días de dispositivo y los días de antibiótico, se "
+"registran en el gráfico, a ser posible diariamente.  Este gráfico debe "
+"conservarse en su centro y para simplificar la recogida de datos y el "
+"seguimiento del paciente.  Durante el periodo de vigilancia, debe conservar "
+"el gráfico o los gráficos de evolución de cada lactante que cumpla los "
+"requisitos.  Es posible introducir hasta seis sustancias antibióticas "
+"diferentes en un mismo gráfico.  Si su paciente ha recibido más de seis "
+"tipos de antibióticos, utilice un gráfico adicional para documentarlos."
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
 #, fuzzy
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
-msgstr "Cuando un paciente es dado de alta, trasladado a otro hospital o fallece, debe finalizar el seguimiento de ese paciente y la suma de los datos de las gráficas de evolución del paciente serán los datos finales de vigilancia del paciente.  Estos datos deben introducirse finalmente en la plataforma de informes en línea bajo el evento \"fin de vigilancia\".  Puede utilizar la hoja maestra de recogida de datos para guardar estos datos localmente."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
+msgstr ""
+"Cuando un paciente es dado de alta, trasladado a otro hospital o fallece, "
+"debe finalizar el seguimiento de ese paciente y la suma de los datos de las "
+"gráficas de evolución del paciente serán los datos finales de vigilancia del "
+"paciente.  Estos datos deben introducirse finalmente en la plataforma de "
+"informes en línea bajo el evento \"fin de vigilancia\".  Puede utilizar la "
+"hoja maestra de recogida de datos para guardar estos datos localmente."
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
 #, fuzzy
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
-msgstr "Para simplificar, los pacientes que abandonan su departamento durante un máximo de dos días (por ejemplo, para someterse a una intervención quirúrgica) no se consideran trasladados ni dados de alta.  Deberá registrar los datos de los días no pasados en el departamento en el momento del reingreso.  Si transcurren más de 48 horas entre el traslado y el reingreso, debe finalizar la recogida de datos para ese paciente y seleccionar \"traslado\" como motivo del fin de la vigilancia.  En este caso, cualquier reingreso debe registrarse como un nuevo ingreso, y el tipo de ingreso debe seleccionarse como \"trasladada a su centro ≥ 24h postnatal\"."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgstr ""
+"Para simplificar, los pacientes que abandonan su departamento durante un "
+"máximo de dos días (por ejemplo, para someterse a una intervención "
+"quirúrgica) no se consideran trasladados ni dados de alta.  Deberá registrar "
+"los datos de los días no pasados en el departamento en el momento del "
+"reingreso.  Si transcurren más de 48 horas entre el traslado y el reingreso, "
+"debe finalizar la recogida de datos para ese paciente y seleccionar "
+"\"traslado\" como motivo del fin de la vigilancia.  En este caso, cualquier "
+"reingreso debe registrarse como un nuevo ingreso, y el tipo de ingreso debe "
+"seleccionarse como \"trasladada a su centro ≥ 24h postnatal\"."
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -724,8 +1373,29 @@ msgstr "Recogida de datos de procedimientos quirúrgicos"
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
 #, fuzzy
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
-msgstr "Siempre que deba realizarse una intervención quirúrgica en neonatos y especialmente en lactantes con MBPN/VPT es un indicador de un curso complicado y un factor de riesgo adicional de infecciones nosocomiales y de aparición de patógenos multirresistentes.  Por esta razón, cada procedimiento quirúrgico que se realiza en un lactante elegible se registra en NeoIPC.  Puede utilizar la hoja de papel de procedimientos quirúrgicos para la documentación local o introducir la información correspondiente directamente en el sistema de notificación.  Además de registrar el procedimiento, debe iniciar el seguimiento del lactante afectado por infecciones del sitio quirúrgico durante 30 o 90 días, dependiendo de si se ha dejado un implante durante el procedimiento."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
+msgstr ""
+"Siempre que deba realizarse una intervención quirúrgica en neonatos y "
+"especialmente en lactantes con MBPN/VPT es un indicador de un curso "
+"complicado y un factor de riesgo adicional de infecciones nosocomiales y de "
+"aparición de patógenos multirresistentes.  Por esta razón, cada "
+"procedimiento quirúrgico que se realiza en un lactante elegible se registra "
+"en NeoIPC.  Puede utilizar la hoja de papel de procedimientos quirúrgicos "
+"para la documentación local o introducir la información correspondiente "
+"directamente en el sistema de notificación.  Además de registrar el "
+"procedimiento, debe iniciar el seguimiento del lactante afectado por "
+"infecciones del sitio quirúrgico durante 30 o 90 días, dependiendo de si se "
+"ha dejado un implante durante el procedimiento."
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -755,32 +1425,120 @@ msgstr "Recogida de datos sobre infecciones"
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
 #, fuzzy
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
-msgstr "Las infecciones del torrente sanguíneo adquiridas en el hospital, la neumonía, la ECN y las infecciones del sitio quirúrgico en pacientes elegibles deben documentarse hasta el final del periodo de vigilancia."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
+msgstr ""
+"Las infecciones del torrente sanguíneo adquiridas en el hospital, la "
+"neumonía, la ECN y las infecciones del sitio quirúrgico en pacientes "
+"elegibles deben documentarse hasta el final del periodo de vigilancia."
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
 #, fuzzy
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
-msgstr "A grandes rasgos, las infecciones neonatales pueden dividirse en infecciones de aparición temprana y de aparición tardía.  La mayoría de las infecciones de aparición temprana se deben a riesgos asociados al embarazo y al parto, en los que los patógenos causantes suelen afectar a la madre en forma de colonización microbiana o infección antes de provocar una infección en el niño.  En cambio, la mayoría de las infecciones de aparición tardía se deben a riesgos asociados a la asistencia sanitaria, y los patógenos causantes suelen proceder de personas o superficies inanimadas que entran en estrecho contacto con el niño durante los cuidados neonatales.  Dado que sólo estas últimas son susceptibles de acción inmediata para los profesionales sanitarios que trabajan en las salas de neonatología, NeoIPC se centra en estas infecciones \"nosocomiales\" de aparición tardía, pero también trata de ayudarle cuando intenta vigilar las infecciones de aparición temprana.  Aunque un valor de corte fijo basado en el tiempo no capta exactamente si una infección se adquirió en el entorno de la UCIN, existe un consenso internacional relativamente amplio de que un valor de corte de 72 horas sirve como un buen estimador para las infecciones nosocomiales en neonatología.  Por este motivo, las infecciones en las que los primeros síntomas se producen dentro de las 72 horas posteriores al nacimiento no deben considerarse infecciones nosocomiales y, por lo tanto, no deben registrarse en el módulo básico de NeoIPC.  Sin embargo, es posible registrarlas por separado como infecciones de inicio precoz si se opta por el módulo de infecciones de inicio precoz de NeoIPC.  Si una infección comienza antes de las 72 horas y es claramente adquirida en el hospital (es decir, hay signos claros de infección en el lugar de entrada del catéter) o comienza después de las 72 horas y es claramente vertical (por ejemplo, todas las infecciones transplacentarias que no son evidentes al nacer, como la toxoplasmosis, el CMV, el VIH, la rubéola y la sífilis), este valor de corte puede ignorarse."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
+msgstr ""
+"A grandes rasgos, las infecciones neonatales pueden dividirse en infecciones "
+"de aparición temprana y de aparición tardía.  La mayoría de las infecciones "
+"de aparición temprana se deben a riesgos asociados al embarazo y al parto, "
+"en los que los patógenos causantes suelen afectar a la madre en forma de "
+"colonización microbiana o infección antes de provocar una infección en el "
+"niño.  En cambio, la mayoría de las infecciones de aparición tardía se deben "
+"a riesgos asociados a la asistencia sanitaria, y los patógenos causantes "
+"suelen proceder de personas o superficies inanimadas que entran en estrecho "
+"contacto con el niño durante los cuidados neonatales.  Dado que sólo estas "
+"últimas son susceptibles de acción inmediata para los profesionales "
+"sanitarios que trabajan en las salas de neonatología, NeoIPC se centra en "
+"estas infecciones \"nosocomiales\" de aparición tardía, pero también trata "
+"de ayudarle cuando intenta vigilar las infecciones de aparición temprana.  "
+"Aunque un valor de corte fijo basado en el tiempo no capta exactamente si "
+"una infección se adquirió en el entorno de la UCIN, existe un consenso "
+"internacional relativamente amplio de que un valor de corte de 72 horas "
+"sirve como un buen estimador para las infecciones nosocomiales en "
+"neonatología.  Por este motivo, las infecciones en las que los primeros "
+"síntomas se producen dentro de las 72 horas posteriores al nacimiento no "
+"deben considerarse infecciones nosocomiales y, por lo tanto, no deben "
+"registrarse en el módulo básico de NeoIPC.  Sin embargo, es posible "
+"registrarlas por separado como infecciones de inicio precoz si se opta por "
+"el módulo de infecciones de inicio precoz de NeoIPC.  Si una infección "
+"comienza antes de las 72 horas y es claramente adquirida en el hospital (es "
+"decir, hay signos claros de infección en el lugar de entrada del catéter) o "
+"comienza después de las 72 horas y es claramente vertical (por ejemplo, "
+"todas las infecciones transplacentarias que no son evidentes al nacer, como "
+"la toxoplasmosis, el CMV, el VIH, la rubéola y la sífilis), este valor de "
+"corte puede ignorarse."
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
 #, fuzzy
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
-msgstr "Para los pacientes que son trasladados o readmitidos en una sala de su servicio de neonatología, hay que aplicar un valor de corte adicional.  En este caso, una infección sólo se considera una infección nosocomial si el día de inicio de los síntomas es mayor o igual al día 3 de la estancia hospitalaria del paciente, donde el día de ingreso se considera el día 1."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgstr ""
+"Para los pacientes que son trasladados o readmitidos en una sala de su "
+"servicio de neonatología, hay que aplicar un valor de corte adicional.  En "
+"este caso, una infección sólo se considera una infección nosocomial si el "
+"día de inicio de los síntomas es mayor o igual al día 3 de la estancia "
+"hospitalaria del paciente, donde el día de ingreso se considera el día 1."
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
 #, fuzzy
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
-msgstr "Las directrices del NeoIPC no ofrecen un marco temporal estricto para que se produzcan los elementos de las definiciones pero, por lo general, todos los elementos necesarios para cumplir una definición de infección suelen producirse en un plazo de 7-10 días, con no más de 2-3 días entre los elementos."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
+msgstr ""
+"Las directrices del NeoIPC no ofrecen un marco temporal estricto para que se "
+"produzcan los elementos de las definiciones pero, por lo general, todos los "
+"elementos necesarios para cumplir una definición de infección suelen "
+"producirse en un plazo de 7-10 días, con no más de 2-3 días entre los "
+"elementos."
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
 #, fuzzy
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
-msgstr "En presencia de una infección previamente registrada, cuando se aísla un nuevo agente patógeno en el mismo sistema de órganos, no podemos registrarlo como una nueva infección.  Se requiere un mínimo de 14 días y un periodo sin síntomas relevantes de infección para registrar de nuevo el mismo tipo de infección."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
+msgstr ""
+"En presencia de una infección previamente registrada, cuando se aísla un "
+"nuevo agente patógeno en el mismo sistema de órganos, no podemos registrarlo "
+"como una nueva infección.  Se requiere un mínimo de 14 días y un periodo sin "
+"síntomas relevantes de infección para registrar de nuevo el mismo tipo de "
+"infección."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:302
@@ -791,8 +1549,20 @@ msgstr "Sepsis primaria/BSI"
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
 #, fuzzy
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
-msgstr "Si un lactante elegible desarrolla una sepsis primaria/infección del torrente sanguíneo adquirida en el hospital de acuerdo con los criterios de vigilancia de NeoIPC (ver Definiciones de infección: sepsis primaria/infección del torrente sanguíneo) durante el periodo de vigilancia, debe registrar y enviar los datos requeridos utilizando la hoja de recogida de datos que aparece a continuación y/o a través de la plataforma de notificación en línea."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
+msgstr ""
+"Si un lactante elegible desarrolla una sepsis primaria/infección del "
+"torrente sanguíneo adquirida en el hospital de acuerdo con los criterios de "
+"vigilancia de NeoIPC (ver Definiciones de infección: sepsis primaria/"
+"infección del torrente sanguíneo) durante el periodo de vigilancia, debe "
+"registrar y enviar los datos requeridos utilizando la hoja de recogida de "
+"datos que aparece a continuación y/o a través de la plataforma de "
+"notificación en línea."
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -823,8 +1593,19 @@ msgstr "Enterocolitis necrotizante"
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
 #, fuzzy
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
-msgstr "Si un lactante elegible desarrolla una enterocolitis necrotizante según los criterios de vigilancia del NeoIPC (ver Definiciones de infección: Enterocolitis necrotizante (ECN)) durante el periodo de vigilancia, deberá registrar y enviar los datos requeridos utilizando la hoja de recogida de datos que figura a continuación y/o a través de la plataforma de notificación en línea."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
+msgstr ""
+"Si un lactante elegible desarrolla una enterocolitis necrotizante según los "
+"criterios de vigilancia del NeoIPC (ver Definiciones de infección: "
+"Enterocolitis necrotizante (ECN)) durante el periodo de vigilancia, deberá "
+"registrar y enviar los datos requeridos utilizando la hoja de recogida de "
+"datos que figura a continuación y/o a través de la plataforma de "
+"notificación en línea."
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -848,8 +1629,18 @@ msgstr "NeoIPC-Core-NEC-Reporting-Sheet-Image.png"
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
 #, fuzzy
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
-msgstr "Si un lactante elegible desarrolla una neumonía adquirida en el hospital de acuerdo con los criterios de vigilancia de NeoIPC (ver Definiciones de infección: neumonía) durante el periodo de vigilancia, debe registrar y enviar los datos requeridos utilizando la hoja de recogida de datos que aparece a continuación y/o a través de la plataforma de notificación online."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
+msgstr ""
+"Si un lactante elegible desarrolla una neumonía adquirida en el hospital de "
+"acuerdo con los criterios de vigilancia de NeoIPC (ver Definiciones de "
+"infección: neumonía) durante el periodo de vigilancia, debe registrar y "
+"enviar los datos requeridos utilizando la hoja de recogida de datos que "
+"aparece a continuación y/o a través de la plataforma de notificación online."
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -880,8 +1671,18 @@ msgstr "Infecciones del sitio quirúrgico"
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
 #, fuzzy
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
-msgstr "Si un lactante elegible desarrolla una infección del sitio quirúrgico según los criterios de vigilancia de NeoIPC (ver Definiciones: Infección del sitio quirúrgico (ISQ)) durante el periodo de vigilancia, debe registrar y enviar los datos requeridos utilizando la hoja de recopilación de datos que aparece a continuación y/o a través de la plataforma de notificación en línea."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
+msgstr ""
+"Si un lactante elegible desarrolla una infección del sitio quirúrgico según "
+"los criterios de vigilancia de NeoIPC (ver Definiciones: Infección del sitio "
+"quirúrgico (ISQ)) durante el periodo de vigilancia, debe registrar y enviar "
+"los datos requeridos utilizando la hoja de recopilación de datos que aparece "
+"a continuación y/o a través de la plataforma de notificación en línea."
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -911,8 +1712,17 @@ msgstr "Infección asociada a dispositivos"
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
 #, fuzzy
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
-msgstr "La terapia intravenosa y la ventilación mecánica son factores de riesgo establecidos para las infecciones nosocomiales en neonatología.  Este tipo de infecciones se consideran típicamente infecciones asociadas a dispositivos y se registran en asociación con dispositivos médicos como catéteres vasculares o intubación."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
+msgstr ""
+"La terapia intravenosa y la ventilación mecánica son factores de riesgo "
+"establecidos para las infecciones nosocomiales en neonatología.  Este tipo "
+"de infecciones se consideran típicamente infecciones asociadas a "
+"dispositivos y se registran en asociación con dispositivos médicos como "
+"catéteres vasculares o intubación."
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:343
@@ -947,8 +1757,19 @@ msgstr "Infecciones asociadas al catéter venoso periférico (PVC)"
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
 #, fuzzy
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
-msgstr "Dado que el establecimiento de una relación causal entre un dispositivo y una infección hospitalaria es difícil e inviable en muchos entornos de neonatología, NeoIPC se centra únicamente en una asociación basada en el tiempo.  Para crear una asociación entre un dispositivo y la infección, el dispositivo debe haber estado en uso durante un periodo definido antes de la infección."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
+msgstr ""
+"Dado que el establecimiento de una relación causal entre un dispositivo y "
+"una infección hospitalaria es difícil e inviable en muchos entornos de "
+"neonatología, NeoIPC se centra únicamente en una asociación basada en el "
+"tiempo.  Para crear una asociación entre un dispositivo y la infección, el "
+"dispositivo debe haber estado en uso durante un periodo definido antes de la "
+"infección."
 
 #. type: Block title
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:352
@@ -981,14 +1802,26 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
 #, fuzzy
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
-msgstr "Si un paciente que desarrolla una infección del torrente sanguíneo cumple los criterios de asociación tanto de PVC como de CVC, se considera que el CVC es el dispositivo con un riesgo de infección relativamente mayor y la ISB debe registrarse como ISB asociada a CVC."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
+msgstr ""
+"Si un paciente que desarrolla una infección del torrente sanguíneo cumple "
+"los criterios de asociación tanto de PVC como de CVC, se considera que el "
+"CVC es el dispositivo con un riesgo de infección relativamente mayor y la "
+"ISB debe registrarse como ISB asociada a CVC."
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
 #, fuzzy
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
-msgstr "Si se utilizó ventilación invasiva y no invasiva de forma intermitente, la neumonía debe registrarse como neumonía asociada a INV."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
+msgstr ""
+"Si se utilizó ventilación invasiva y no invasiva de forma intermitente, la "
+"neumonía debe registrarse como neumonía asociada a INV."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:371
@@ -999,20 +1832,41 @@ msgstr "Infección secundaria del torrente sanguíneo"
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
 #, fuzzy
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
-msgstr "Dentro de la vigilancia de NeoIPC, es posible registrar las infecciones del torrente sanguíneo secundarias a neumonía, ECN e ISQ.  La recopilación de datos sobre infecciones secundarias del torrente sanguíneo es opcional; por lo tanto, es posible seleccionar **\"Sin seguimiento\"** si no está realizando un seguimiento de los pacientes por infecciones secundarias del torrente sanguíneo."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
+msgstr ""
+"Dentro de la vigilancia de NeoIPC, es posible registrar las infecciones del "
+"torrente sanguíneo secundarias a neumonía, ECN e ISQ.  La recopilación de "
+"datos sobre infecciones secundarias del torrente sanguíneo es opcional; por "
+"lo tanto, es posible seleccionar **\"Sin seguimiento\"** si no está "
+"realizando un seguimiento de los pacientes por infecciones secundarias del "
+"torrente sanguíneo."
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
 #, fuzzy
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
-msgstr "Para asignar una infección secundaria del torrente sanguíneo a una neumonía, una ECN o una ISQ, deben cumplirse los siguientes criterios:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
+msgstr ""
+"Para asignar una infección secundaria del torrente sanguíneo a una neumonía, "
+"una ECN o una ISQ, deben cumplirse los siguientes criterios:"
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
 #, fuzzy
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
-msgstr "La muestra de sangre se recoge en el periodo comprendido entre 3 días antes y 13 días después del día de la infección primaria (día de la infección primaria=primeros síntomas o primer cultivo positivo en el lugar de la infección primaria)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
+msgstr ""
+"La muestra de sangre se recoge en el periodo comprendido entre 3 días antes "
+"y 13 días después del día de la infección primaria (día de la infección "
+"primaria=primeros síntomas o primer cultivo positivo en el lugar de la "
+"infección primaria)."
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:380
@@ -1042,8 +1896,12 @@ msgstr "**Y**"
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
 #, fuzzy
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
-msgstr "Al menos un microorganismo de la muestra de sangre coincide con un microorganismo identificado en el foco de infección primaria."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
+msgstr ""
+"Al menos un microorganismo de la muestra de sangre coincide con un "
+"microorganismo identificado en el foco de infección primaria."
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -1078,19 +1936,46 @@ msgstr "Sepsis primaria / Infección del torrente sanguíneo"
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
 #, fuzzy
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
-msgstr "Las infecciones causadas por microorganismos que entran en el torrente sanguíneo desde un lugar de infección primario (excepto las infecciones asociadas a catéteres) no se contabilizan en esta sección.  Para obtener información detallada, consulte xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Infección secundaria del torrente sanguíneo]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
+msgstr ""
+"Las infecciones causadas por microorganismos que entran en el torrente "
+"sanguíneo desde un lugar de infección primario (excepto las infecciones "
+"asociadas a catéteres) no se contabilizan en esta sección.  Para obtener "
+"información detallada, consulte xref:data-collection-infection-data-"
+"collection-secondary-bloodstream-infection[Infección secundaria del torrente "
+"sanguíneo]."
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:401
@@ -1119,8 +2004,12 @@ msgstr "LCBSI causada por un comensal común*"
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
 #, fuzzy
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
-msgstr "*Ver xref:appendix-list-of-list-of-infectious-agents[Lista de agentes infecciosos]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
+msgstr ""
+"*Ver xref:appendix-list-of-list-of-infectious-agents[Lista de agentes "
+"infecciosos]"
 
 #. type: Block title
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:409
@@ -1148,38 +2037,109 @@ msgstr "LCBSI causadas por comensales comunes"
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
 #, fuzzy
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
-msgstr "Si los hemocultivos muestran crecimiento de uno o varios comensales comunes (por ejemplo, estafilococos coagulasa-negativos), en muchos casos no está claro si las bacterias detectadas son el agente causal de una presunta infección o si una contaminación conduce a un diagnóstico erróneo.  Ha habido múltiples enfoques para resolver este problema adaptando las definiciones de vigilancia a este hecho.  Desgraciadamente, todos estos enfoques están limitados por los hábitos de diagnóstico y la disponibilidad de recursos, lo que hace casi imposible la comparación de datos de diferentes entornos."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
+msgstr ""
+"Si los hemocultivos muestran crecimiento de uno o varios comensales comunes "
+"(por ejemplo, estafilococos coagulasa-negativos), en muchos casos no está "
+"claro si las bacterias detectadas son el agente causal de una presunta "
+"infección o si una contaminación conduce a un diagnóstico erróneo.  Ha "
+"habido múltiples enfoques para resolver este problema adaptando las "
+"definiciones de vigilancia a este hecho.  Desgraciadamente, todos estos "
+"enfoques están limitados por los hábitos de diagnóstico y la disponibilidad "
+"de recursos, lo que hace casi imposible la comparación de datos de "
+"diferentes entornos."
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
 #, fuzzy
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
-msgstr "Dado que el objetivo de NeoIPC es proporcionar herramientas y definiciones que funcionen en una amplia gama de entornos diferentes, ofrecemos 3 definiciones diferentes de LCBSI causada por comensales comunes que pueden utilizarse en una amplia gama de entornos.  Dado que las herramientas recogen los datos brutos que conducen al diagnóstico de una infección, es posible evaluar la aplicación de diferentes definiciones en diversos entornos y, posiblemente, evaluar el efecto sobre las incidencias calculadas."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
+msgstr ""
+"Dado que el objetivo de NeoIPC es proporcionar herramientas y definiciones "
+"que funcionen en una amplia gama de entornos diferentes, ofrecemos 3 "
+"definiciones diferentes de LCBSI causada por comensales comunes que pueden "
+"utilizarse en una amplia gama de entornos.  Dado que las herramientas "
+"recogen los datos brutos que conducen al diagnóstico de una infección, es "
+"posible evaluar la aplicación de diferentes definiciones en diversos "
+"entornos y, posiblemente, evaluar el efecto sobre las incidencias calculadas."
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
 #, fuzzy
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
-msgstr "En cualquier caso, debido a este hecho, se debe tener mucho cuidado al comparar las tasas de LCBSI causadas por comensales comunes en diferentes entornos."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
+msgstr ""
+"En cualquier caso, debido a este hecho, se debe tener mucho cuidado al "
+"comparar las tasas de LCBSI causadas por comensales comunes en diferentes "
+"entornos."
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
 #, fuzzy
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
-msgstr "Los criterios de vigilancia de la enterocolitis necrotizante (ECN) consisten en una combinación de hallazgos radiológicos y signos clínicos o en un diagnóstico basado en pruebas quirúrgicos y/o patológicos.  El conjunto de datos de ECN incluye información sobre si el paciente presenta una perforación intestinal.  Sin embargo, éste no es uno de los criterios de definición de la vigilancia.  Esto significa que no se deben notificar como ECN los casos en los que se tenga evidencia quirúrgica de perforación intestinal sin evidencia de necrosis primaria o neumatosis intestinal (por ejemplo, perforación intestinal espontánea)."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
+msgstr ""
+"Los criterios de vigilancia de la enterocolitis necrotizante (ECN) consisten "
+"en una combinación de hallazgos radiológicos y signos clínicos o en un "
+"diagnóstico basado en pruebas quirúrgicos y/o patológicos.  El conjunto de "
+"datos de ECN incluye información sobre si el paciente presenta una "
+"perforación intestinal.  Sin embargo, éste no es uno de los criterios de "
+"definición de la vigilancia.  Esto significa que no se deben notificar como "
+"ECN los casos en los que se tenga evidencia quirúrgica de perforación "
+"intestinal sin evidencia de necrosis primaria o neumatosis intestinal (por "
+"ejemplo, perforación intestinal espontánea)."
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
 #, fuzzy
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
-msgstr "La neumonía en neonatos es una entidad muy difícil de definir con fines de vigilancia, como puede deducirse del hecho de que muchos sistemas de vigilancia se abstienen de registrarla en absoluto, mientras que otros registran los eventos asociados a la ventilación, en los que la vigilancia se limita a los pacientes ventilados y la neumonía es sólo una de las entidades captadas por la definición."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
+msgstr ""
+"La neumonía en neonatos es una entidad muy difícil de definir con fines de "
+"vigilancia, como puede deducirse del hecho de que muchos sistemas de "
+"vigilancia se abstienen de registrarla en absoluto, mientras que otros "
+"registran los eventos asociados a la ventilación, en los que la vigilancia "
+"se limita a los pacientes ventilados y la neumonía es sólo una de las "
+"entidades captadas por la definición."
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
 #, fuzzy
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
-msgstr "Para cumplir los criterios de neumonía hospitalaria asociada a dispositivos, los pacientes deben estar ventilados durante al menos 4 días naturales (el día 1 es el día de inicio de la ventilación invasiva/no invasiva).  La fecha más temprana del evento es el día 3 de ventilación."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
+msgstr ""
+"Para cumplir los criterios de neumonía hospitalaria asociada a dispositivos, "
+"los pacientes deben estar ventilados durante al menos 4 días naturales (el "
+"día 1 es el día de inicio de la ventilación invasiva/no invasiva).  La fecha "
+"más temprana del evento es el día 3 de ventilación."
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:449
@@ -1255,20 +2215,39 @@ msgstr ""
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
 #, fuzzy
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
-msgstr "Una infección de la herida que se produce en la incisión o en el lecho quirúrgico se registra como infección del sitio quirúrgico (ISQ) si se produce en un intervalo de tiempo determinado después de un procedimiento quirúrgico que también se registró en el sistema de vigilancia NeoIPC."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
+msgstr ""
+"Una infección de la herida que se produce en la incisión o en el lecho "
+"quirúrgico se registra como infección del sitio quirúrgico (ISQ) si se "
+"produce en un intervalo de tiempo determinado después de un procedimiento "
+"quirúrgico que también se registró en el sistema de vigilancia NeoIPC."
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
 #, fuzzy
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
-msgstr "Las ISQ que se producen en pacientes sin un registro de procedimiento quirúrgico en el sistema de vigilancia NeoIPC (por ejemplo, un paciente trasladado a su centro tras un procedimiento quirúrgico realizado en otro centro) no son elegibles."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
+msgstr ""
+"Las ISQ que se producen en pacientes sin un registro de procedimiento "
+"quirúrgico en el sistema de vigilancia NeoIPC (por ejemplo, un paciente "
+"trasladado a su centro tras un procedimiento quirúrgico realizado en otro "
+"centro) no son elegibles."
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
 #, fuzzy
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
-msgstr "Se aplican en detalle los siguientes tiempos de vigilancia (día 1 = fecha del procedimiento):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
+msgstr ""
+"Se aplican en detalle los siguientes tiempos de vigilancia (día 1 = fecha "
+"del procedimiento):"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:484
@@ -1279,20 +2258,26 @@ msgstr "ISQ incisional superficial: 30 días"
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
 #, fuzzy
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
 msgstr "ISQ incisional profunda: 30 días o 90 días si se ha dejado un implante"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
 #, fuzzy
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
 msgstr "ISQ en órgano/espacio: 30 días o 90 días si se ha dejado un implante"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
 #, fuzzy
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
-msgstr "El seguimiento de las ISQ puede interrumpirse de forma preliminar para una intervención quirúrgica por dos motivos:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
+msgstr ""
+"El seguimiento de las ISQ puede interrumpirse de forma preliminar para una "
+"intervención quirúrgica por dos motivos:"
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:490
@@ -1313,8 +2298,15 @@ msgstr ""
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
 #, fuzzy
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
-msgstr "Las intervenciones menores como simples punciones de hematoma/seroma no cuentan como procedimientos de revisión.  La vigilancia no puede finalizar por estos procedimientos menores y no inician un nuevo periodo de seguimiento."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
+msgstr ""
+"Las intervenciones menores como simples punciones de hematoma/seroma no "
+"cuentan como procedimientos de revisión.  La vigilancia no puede finalizar "
+"por estos procedimientos menores y no inician un nuevo periodo de "
+"seguimiento."
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:497
@@ -1343,8 +2335,12 @@ msgstr ""
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
 #, fuzzy
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
-msgstr "El paciente no debe haber fallecido (por ejemplo, se excluye la cirugía post-mortem en caso de donación de órganos)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
+msgstr ""
+"El paciente no debe haber fallecido (por ejemplo, se excluye la cirugía post-"
+"mortem en caso de donación de órganos)."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:508
@@ -1355,8 +2351,12 @@ msgstr "ISQ incisional superficial"
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
 #, fuzzy
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
-msgstr "Pertenecen a esta categoría las infecciones del sitio quirúrgico que sólo afectan a la piel y al tejido subcutáneo."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
+msgstr ""
+"Pertenecen a esta categoría las infecciones del sitio quirúrgico que sólo "
+"afectan a la piel y al tejido subcutáneo."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:514
@@ -1367,8 +2367,13 @@ msgstr "ISQ incisional profunda"
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
 #, fuzzy
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
-msgstr "Pertenecen a esta categoría las infecciones del sitio quirúrgico que afectan a los tejidos blandos profundos de la incisión (por ejemplo, las capas fasciales y musculares)."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
+msgstr ""
+"Pertenecen a esta categoría las infecciones del sitio quirúrgico que afectan "
+"a los tejidos blandos profundos de la incisión (por ejemplo, las capas "
+"fasciales y musculares)."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:520
@@ -1379,8 +2384,14 @@ msgstr "ISQ de órgano/espacio"
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
 #, fuzzy
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
-msgstr "Pertenecen a esta categoría las infecciones del sitio quirúrgico que afectan a cualquier parte del cuerpo más profunda que las capas fascial/muscular que se abre o manipula durante el procedimiento quirúrgico."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
+msgstr ""
+"Pertenecen a esta categoría las infecciones del sitio quirúrgico que afectan "
+"a cualquier parte del cuerpo más profunda que las capas fascial/muscular que "
+"se abre o manipula durante el procedimiento quirúrgico."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:526
@@ -1391,12 +2402,26 @@ msgstr "Diccionario de datos"
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
 #, fuzzy
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
-msgstr "Los siguientes elementos de datos aparecen en las hojas de documentación de NeoIPC o en la plataforma de informes.  Algunos de ellos (por ejemplo, id de paciente y nombre de paciente) se utilizan sólo para su documentación local y no se utilizan en las herramientas centrales del software NeoIPC."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
+msgstr ""
+"Los siguientes elementos de datos aparecen en las hojas de documentación de "
+"NeoIPC o en la plataforma de informes.  Algunos de ellos (por ejemplo, id de "
+"paciente y nombre de paciente) se utilizan sólo para su documentación local "
+"y no se utilizan en las herramientas centrales del software NeoIPC."
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1432,14 +2457,33 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-neoipc-id]]NeoIPC-ID (id
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
 #, fuzzy
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
-msgstr "El id único que asignas al paciente para su seguimiento en la plataforma de informes.  Le aconsejamos que almacene esta información en una lista de pseudonimización."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
+msgstr ""
+"El id único que asignas al paciente para su seguimiento en la plataforma de "
+"informes.  Le aconsejamos que almacene esta información en una lista de "
+"pseudonimización."
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
 #, fuzzy
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
-msgstr "Utilice este identificador para identificar de forma única a un paciente en el sistema.  Lo ideal es utilizar una cadena de caracteres aleatoria y única.  Si tiene la necesidad de identificar a un paciente que ha introducido aquí, puede utilizar este identificador como clave NeoIPC para la seudonimización.  NUNCA utilice un identificador que se utilice en otro lugar y que no controle totalmente (por ejemplo, NO utilice el identificador de paciente de su sistema de información hospitalario)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
+msgstr ""
+"Utilice este identificador para identificar de forma única a un paciente en "
+"el sistema.  Lo ideal es utilizar una cadena de caracteres aleatoria y "
+"única.  Si tiene la necesidad de identificar a un paciente que ha "
+"introducido aquí, puede utilizar este identificador como clave NeoIPC para "
+"la seudonimización.  NUNCA utilice un identificador que se utilice en otro "
+"lugar y que no controle totalmente (por ejemplo, NO utilice el identificador "
+"de paciente de su sistema de información hospitalario)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:545
@@ -1450,8 +2494,14 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-patient-id]]Patient-ID"
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
 #, fuzzy
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
-msgstr "El identificador único del paciente en el hospital, que la mayoría de las veces procede del sistema de información del hospital (HIS) o del sistema de gestión de datos del paciente (PDMS)."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
+msgstr ""
+"El identificador único del paciente en el hospital, que la mayoría de las "
+"veces procede del sistema de información del hospital (HIS) o del sistema de "
+"gestión de datos del paciente (PDMS)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
@@ -1468,8 +2518,19 @@ msgstr "El nombre del paciente (por ejemplo, nombre seguido del apellido)."
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
 #, fuzzy
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
-msgstr "El ID del paciente y el nombre del paciente no forman parte del conjunto de datos de NeoIPC y no deben enviarse a la plataforma de recogida de datos (por ejemplo, NO utilice ninguno de ellos como NeoIPC-ID).  Están disponibles en las hojas de papel de recogida de datos para que pueda identificar al paciente dentro del hospital y para buscar el archivo en el sistema de información del hospital."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
+msgstr ""
+"El ID del paciente y el nombre del paciente no forman parte del conjunto de "
+"datos de NeoIPC y no deben enviarse a la plataforma de recogida de datos "
+"(por ejemplo, NO utilice ninguno de ellos como NeoIPC-ID).  Están "
+"disponibles en las hojas de papel de recogida de datos para que pueda "
+"identificar al paciente dentro del hospital y para buscar el archivo en el "
+"sistema de información del hospital."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:551
@@ -1480,8 +2541,20 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-gestational-age]]Edad ge
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
 #, fuzzy
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
-msgstr "La edad gestacional, expresada en semanas y días completos (por ejemplo, 25 semanas y 4 días: 25+4) en el momento del nacimiento.  Normalmente se refiere a la edad gestacional calculada o estimada por el obstetra de la madre, pero cuando no se dispone de ella (por ejemplo, en embarazos no observados) puede registrarse la edad gestacional evaluada por el médico tratante (por ejemplo, mediante la puntuación de Ballard)."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
+msgstr ""
+"La edad gestacional, expresada en semanas y días completos (por ejemplo, 25 "
+"semanas y 4 días: 25+4) en el momento del nacimiento.  Normalmente se "
+"refiere a la edad gestacional calculada o estimada por el obstetra de la "
+"madre, pero cuando no se dispone de ella (por ejemplo, en embarazos no "
+"observados) puede registrarse la edad gestacional evaluada por el médico "
+"tratante (por ejemplo, mediante la puntuación de Ballard)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
@@ -1492,8 +2565,18 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-birthweight]]Peso al nac
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
 #, fuzzy
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
-msgstr "El peso del bebé inmediatamente después del nacimiento en gramos.  Normalmente, este valor se basa en una medición, pero en caso de que el peso al nacer sea desconocido o tenga un valor altamente patológico que no refleje la madurez del bebé (por ejemplo, hidropesía fetal), puede introducir el peso al nacer estimado por el médico tratante."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
+msgstr ""
+"El peso del bebé inmediatamente después del nacimiento en gramos.  "
+"Normalmente, este valor se basa en una medición, pero en caso de que el peso "
+"al nacer sea desconocido o tenga un valor altamente patológico que no "
+"refleje la madurez del bebé (por ejemplo, hidropesía fetal), puede "
+"introducir el peso al nacer estimado por el médico tratante."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
@@ -1504,8 +2587,14 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-sex]]Sexo"
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
 #, fuzzy
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
-msgstr "Típicamente el sexo fenotípico del paciente.  Si el sexo no puede determinarse a partir del fenotipo o genotipo del paciente, o si el genotipo no es ni XX ni XY, se considera indeterminado a efectos de vigilancia."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
+msgstr ""
+"Típicamente el sexo fenotípico del paciente.  Si el sexo no puede "
+"determinarse a partir del fenotipo o genotipo del paciente, o si el genotipo "
+"no es ni XX ni XY, se considera indeterminado a efectos de vigilancia."
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:559
@@ -1573,8 +2662,13 @@ msgstr "[[data-dictionary-patient-master-data-enrolment-number-of-infants]]Núme
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
 #, fuzzy
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
-msgstr "El número de bebés nacidos del embarazo (múltiple) al que pertenece este bebé.  Indique el número total de lactantes, incluido el que registra aquí."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
+msgstr ""
+"El número de bebés nacidos del embarazo (múltiple) al que pertenece este "
+"bebé.  Indique el número total de lactantes, incluido el que registra aquí."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:572
@@ -1591,8 +2685,12 @@ msgstr "[[data-dictionary-patient-master-data-admission-information-admission-da
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
 #, fuzzy
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
-msgstr "El día en que el paciente ingresa en el hospital.  Para los niños nacidos en su hospital, esta fecha coincide con la fecha de nacimiento."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
+msgstr ""
+"El día en que el paciente ingresa en el hospital.  Para los niños nacidos en "
+"su hospital, esta fecha coincide con la fecha de nacimiento."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
@@ -1603,14 +2701,22 @@ msgstr "[[data-dictionary-patient-master-data-admission-information-admission-ty
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
 #, fuzzy
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
-msgstr "Describe si el bebé nació en su hospital o si ingresó después de nacer y, en caso afirmativo, cuánto tiempo transcurrió desde el nacimiento:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
+msgstr ""
+"Describe si el bebé nació en su hospital o si ingresó después de nacer y, en "
+"caso afirmativo, cuánto tiempo transcurrió desde el nacimiento:"
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
 #, fuzzy
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
-msgstr "Admitido desde la sala de partos (admisión inicial para bebés nacidos en su hospital)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
+msgstr ""
+"Admitido desde la sala de partos (admisión inicial para bebés nacidos en su "
+"hospital)"
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:579
@@ -1622,7 +2728,9 @@ msgstr "Trasladado/reingresado en su hospital el día del nacimiento"
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:580
 #, fuzzy
 msgid "Transferred/readmitted to your hospital the day after birth or later"
-msgstr "Trasladado/reingresado en su hospital al día siguiente del nacimiento o más tarde"
+msgstr ""
+"Trasladado/reingresado en su hospital al día siguiente del nacimiento o más "
+"tarde"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:580
@@ -1633,7 +2741,10 @@ msgstr "[[data-dictionary-patient-master-data-admission-information-admission-da
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
 #, fuzzy
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
 msgstr ""
 "Para niños que no ha sido entregado en vuestro hospital propio, récord el "
 "día del niño de vida en el día de admisión (Día de Día = de nacimiento de "
@@ -1654,8 +2765,11 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-date]]Fecha de fi
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
 #, fuzzy
-msgid "The day the data collection and follow-up for the patient has been stopped."
-msgstr "El día en que se ha interrumpido la recogida de datos y el seguimiento del paciente."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
+msgstr ""
+"El día en que se ha interrumpido la recogida de datos y el seguimiento del "
+"paciente."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
@@ -1667,7 +2781,8 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-reason]]Fecha de 
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:588
 #, fuzzy
 msgid "The reason for ending data collection.  One of the following:"
-msgstr "El motivo de finalización de la recogida de datos.  Uno de los siguientes:"
+msgstr ""
+"El motivo de finalización de la recogida de datos.  Uno de los siguientes:"
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:590
@@ -1690,8 +2805,14 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-patient-days]]Dí
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
 #, fuzzy
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
-msgstr "El número acumulado de días que el paciente permaneció en el departamento, incluyendo el día de ingreso y el día de alta/traslado/muerte (sin duración mínima de estancia)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
+msgstr ""
+"El número acumulado de días que el paciente permaneció en el departamento, "
+"incluyendo el día de ingreso y el día de alta/traslado/muerte (sin duración "
+"mínima de estancia)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
@@ -1702,8 +2823,12 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-cvc-days]]Días C
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
 #, fuzzy
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
-msgstr "El número acumulado de días en los que un catéter venoso central estuvo colocado durante al menos 12 horas/día."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
+msgstr ""
+"El número acumulado de días en los que un catéter venoso central estuvo "
+"colocado durante al menos 12 horas/día."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
@@ -1714,8 +2839,12 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-pvc-days]]Días d
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
 #, fuzzy
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
-msgstr "Número acumulado de días en los que se colocó un catéter vascular periférico durante al menos 12 horas/día."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
+msgstr ""
+"Número acumulado de días en los que se colocó un catéter vascular periférico "
+"durante al menos 12 horas/día."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
@@ -1726,8 +2855,12 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-inv-days]]INV dí
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
 #, fuzzy
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
-msgstr "El número acumulado de días en los que el lactante estuvo con ventilación invasiva (intubado) durante al menos 12 horas/día."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
+msgstr ""
+"El número acumulado de días en los que el lactante estuvo con ventilación "
+"invasiva (intubado) durante al menos 12 horas/día."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
@@ -1738,8 +2871,14 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-niv-days]]NIV day
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
 #, fuzzy
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
-msgstr "El número acumulado de días en los que el lactante estuvo en ventilación no invasiva (no intubado; por ejemplo, cánulas nasales de alto flujo o CPAP) durante al menos 12 horas/día."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
+msgstr ""
+"El número acumulado de días en los que el lactante estuvo en ventilación no "
+"invasiva (no intubado; por ejemplo, cánulas nasales de alto flujo o CPAP) "
+"durante al menos 12 horas/día."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
@@ -1750,8 +2889,14 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-human-milk-days]]
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
 #, fuzzy
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
-msgstr "El número acumulado de días en que la alimentación enteral del paciente consiste exclusivamente en leche materna (de la propia madre o de donante).  La leche materna enriquecida se considera leche materna."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
+msgstr ""
+"El número acumulado de días en que la alimentación enteral del paciente "
+"consiste exclusivamente en leche materna (de la propia madre o de donante).  "
+"La leche materna enriquecida se considera leche materna."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
@@ -1762,8 +2907,12 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-kangaroo-care-day
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
 #, fuzzy
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
-msgstr "El número acumulado de días que el paciente recibió cuidados canguro (contacto intensivo piel con piel) durante al menos 2 horas."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
+msgstr ""
+"El número acumulado de días que el paciente recibió cuidados canguro "
+"(contacto intensivo piel con piel) durante al menos 2 horas."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
@@ -1774,8 +2923,14 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-probiotic-days]]D
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
 #, fuzzy
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
-msgstr "El número acumulado de días que el paciente recibe un probiótico oral que contiene al menos uno de Lactobacillus spp. o Bifidobacterium spp., independientemente de la cantidad."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
+msgstr ""
+"El número acumulado de días que el paciente recibe un probiótico oral que "
+"contiene al menos uno de Lactobacillus spp. o Bifidobacterium spp., "
+"independientemente de la cantidad."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
@@ -1786,8 +2941,29 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-total-antibiotic-
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
 #, fuzzy
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
-msgstr "El número acumulado de díasfootnote:ab-days-comment[Se cuentan el día de la primera dosis y el día de la última dosis de una terapia antibiótica, así como todos los días intermedios.  Los días en los que no se aplicó ninguna dosis entre la primera y la última dosis (por ejemplo, dosis omitidas debido a niveles altos del fármaco en la monitorización terapéutica de fármacos) se cuentan como si se hubiera aplicado una dosis.  Los días posteriores a la última dosis no se cuentan independientemente del nivel de fármaco medido o supuesto en el paciente.] cuando el lactante recibió (cualquier) antibiótico sistémico.  Sólo se puede registrar un día de antibiótico por día, lo que significa que un día en el que el paciente recibió varios antibióticos se sigue contando como un día de antibiótico."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
+msgstr ""
+"El número acumulado de díasfootnote:ab-days-comment[Se cuentan el día de la "
+"primera dosis y el día de la última dosis de una terapia antibiótica, así "
+"como todos los días intermedios.  Los días en los que no se aplicó ninguna "
+"dosis entre la primera y la última dosis (por ejemplo, dosis omitidas debido "
+"a niveles altos del fármaco en la monitorización terapéutica de fármacos) se "
+"cuentan como si se hubiera aplicado una dosis.  Los días posteriores a la "
+"última dosis no se cuentan independientemente del nivel de fármaco medido o "
+"supuesto en el paciente.] cuando el lactante recibió (cualquier) antibiótico "
+"sistémico.  Sólo se puede registrar un día de antibiótico por día, lo que "
+"significa que un día en el que el paciente recibió varios antibióticos se "
+"sigue contando como un día de antibiótico."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
@@ -1798,8 +2974,13 @@ msgstr "[[data-dictionary-patient-master-data-surveillance-end-antibiotic-substa
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
 #, fuzzy
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
-msgstr "El número acumulado de díasfootnote:ab-days-comment[] en los que el lactante recibió una sustancia antibiótica sistémica especificada.  Ej: Días gentamicina"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgstr ""
+"El número acumulado de díasfootnote:ab-days-comment[] en los que el lactante "
+"recibió una sustancia antibiótica sistémica especificada.  Ej: Días "
+"gentamicina"
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:608
@@ -1828,8 +3009,14 @@ msgstr "[[data-dictionary-surgical-procedure-description]]Descripción del proce
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
 #, fuzzy
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
-msgstr "Un nombre o descripción legible por humanos del procedimiento quirúrgico tal y como lo denominan habitualmente los cirujanos de su institución (por ejemplo; ligadura de conducto arterial permeable)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
+msgstr ""
+"Un nombre o descripción legible por humanos del procedimiento quirúrgico tal "
+"y como lo denominan habitualmente los cirujanos de su institución (por "
+"ejemplo; ligadura de conducto arterial permeable)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
@@ -1840,8 +3027,19 @@ msgstr "[[data-dictionary-surgical-procedure-main-procedure-code]]Código del pr
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
 #, fuzzy
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
-msgstr "El código de la Clasificación Internacional de Intervenciones Sanitarias (ICHI) del procedimiento principal realizado.  Si se realizan varios procedimientos diferentes durante una intervención quirúrgica, el cirujano decide cuál es el procedimiento principal (normalmente el más complejo o el que causa mayor riesgo de infección).  Visite https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgstr ""
+"El código de la Clasificación Internacional de Intervenciones Sanitarias "
+"(ICHI) del procedimiento principal realizado.  Si se realizan varios "
+"procedimientos diferentes durante una intervención quirúrgica, el cirujano "
+"decide cuál es el procedimiento principal (normalmente el más complejo o el "
+"que causa mayor riesgo de infección).  Visite https://icd.who.int/dev11/l-"
+"ichi/en"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
@@ -1852,8 +3050,14 @@ msgstr "[[data-dictionary-surgical-procedure-side-procedure-code]]Código de pro
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
 #, fuzzy
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
-msgstr "El código de la Clasificación Internacional de Intervenciones Sanitarias (ICHI) del procedimiento o procedimientos secundarios realizados.  Es posible capturar hasta dos procedimientos secundarios."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
+msgstr ""
+"El código de la Clasificación Internacional de Intervenciones Sanitarias "
+"(ICHI) del procedimiento o procedimientos secundarios realizados.  Es "
+"posible capturar hasta dos procedimientos secundarios."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
@@ -1864,8 +3068,12 @@ msgstr "[[data-dictionary-surgical-procedure-duration]]Duración"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
 #, fuzzy
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
-msgstr "La duración del procedimiento quirúrgico en minutos (tiempo de incisión a sutura si está disponible)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
+msgstr ""
+"La duración del procedimiento quirúrgico en minutos (tiempo de incisión a "
+"sutura si está disponible)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
@@ -1876,8 +3084,17 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class]]Clase de herida"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
 #, fuzzy
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
-msgstr "Evaluación del grado de contaminación de una herida quirúrgica en el momento del procedimiento quirúrgico según las directrices de los CDC.  Es asignada por una persona implicada en el procedimiento quirúrgico (por ejemplo, cirujano, enfermera circulante, etc.).  Las cuatro clasificaciones de heridas son:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
+msgstr ""
+"Evaluación del grado de contaminación de una herida quirúrgica en el momento "
+"del procedimiento quirúrgico según las directrices de los CDC.  Es asignada "
+"por una persona implicada en el procedimiento quirúrgico (por ejemplo, "
+"cirujano, enfermera circulante, etc.).  Las cuatro clasificaciones de "
+"heridas son:"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
@@ -1888,8 +3105,20 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class-i]]Clase I/Limpia"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
 #, fuzzy
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
-msgstr "Una herida operatoria no infectada en la que no se encuentra inflamación y no se penetra en el tracto respiratorio, alimentario, genital o urinario no infectado.  Además, las heridas limpias están principalmente cerradas y, si es necesario, drenadas con drenaje cerrado.  Las heridas incisionales operatorias que no son consecuencia de un traumatismo penetrante (romo) deben incluirse en esta categoría si cumplen los criterios."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
+msgstr ""
+"Una herida operatoria no infectada en la que no se encuentra inflamación y "
+"no se penetra en el tracto respiratorio, alimentario, genital o urinario no "
+"infectado.  Además, las heridas limpias están principalmente cerradas y, si "
+"es necesario, drenadas con drenaje cerrado.  Las heridas incisionales "
+"operatorias que no son consecuencia de un traumatismo penetrante (romo) "
+"deben incluirse en esta categoría si cumplen los criterios."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
@@ -1900,8 +3129,19 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class-ii]]Clase II/Limpia-Con
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
 #, fuzzy
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
-msgstr "Herida operatoria en la que se penetra en las vías respiratoria, alimentaria, genital o urinaria en condiciones controladas y sin contaminación inusual.  En concreto, se incluyen en esta categoría las operaciones que afectan a las vías biliares, el apéndice, la vagina y la orofaringe, siempre que no se encuentren indicios de infección o ruptura importante de una técnica estéril."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
+msgstr ""
+"Herida operatoria en la que se penetra en las vías respiratoria, "
+"alimentaria, genital o urinaria en condiciones controladas y sin "
+"contaminación inusual.  En concreto, se incluyen en esta categoría las "
+"operaciones que afectan a las vías biliares, el apéndice, la vagina y la "
+"orofaringe, siempre que no se encuentren indicios de infección o ruptura "
+"importante de una técnica estéril."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
@@ -1912,8 +3152,17 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class-iii]]Clase III/Contamin
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
 #, fuzzy
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
-msgstr "Heridas abiertas, frescas y accidentales.  Además, se incluyen en esta categoría las intervenciones con rupturas importantes de una técnica estéril (p. ej., masaje cardíaco abierto) o derrame macroscópico del tracto gastrointestinal, y las incisiones en las que se encuentra inflamación aguda o no purulenta."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
+msgstr ""
+"Heridas abiertas, frescas y accidentales.  Además, se incluyen en esta "
+"categoría las intervenciones con rupturas importantes de una técnica estéril "
+"(p. ej., masaje cardíaco abierto) o derrame macroscópico del tracto "
+"gastrointestinal, y las incisiones en las que se encuentra inflamación aguda "
+"o no purulenta."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
@@ -1924,8 +3173,16 @@ msgstr "[[data-dictionary-surgical-procedure-wound-class-iv]]Clase IV/infectada 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
 #, fuzzy
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
-msgstr "Heridas traumáticas antiguas con tejido desvitalizado retenido y las que implican infección clínica existente o vísceras perforadas.  Esta definición sugiere que los organismos causantes de la infección postoperatoria estaban presentes en el campo operatorio antes de la intervención."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
+msgstr ""
+"Heridas traumáticas antiguas con tejido desvitalizado retenido y las que "
+"implican infección clínica existente o vísceras perforadas.  Esta definición "
+"sugiere que los organismos causantes de la infección postoperatoria estaban "
+"presentes en el campo operatorio antes de la intervención."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:630
@@ -1936,8 +3193,14 @@ msgstr "[[data-dictionary-surgical-procedure-asa-score]]Puntuación ASA"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
 #, fuzzy
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
-msgstr "Sistema de clasificación del estado físico de la Sociedad Americana de Anestesiólogos (ASA) para evaluar y comunicar las comorbilidades médicas preanestésicas de un paciente:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
+msgstr ""
+"Sistema de clasificación del estado físico de la Sociedad Americana de "
+"Anestesiólogos (ASA) para evaluar y comunicar las comorbilidades médicas "
+"preanestésicas de un paciente:"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:633
@@ -1984,8 +3247,11 @@ msgstr "[[data-dictionary-surgical-procedure-asa-score-iv]]ASA IV"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
 #, fuzzy
-msgid "A patient with severe systemic disease that is a constant threat to life"
-msgstr "Un paciente con enfermedad sistémica grave que es una amenaza constante para la vida"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
+msgstr ""
+"Un paciente con enfermedad sistémica grave que es una amenaza constante para "
+"la vida"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
@@ -2002,8 +3268,12 @@ msgstr "Un paciente moribundo que no se espera que sobreviva sin la operación"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
 #, fuzzy
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
-msgstr "Visite https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
+msgstr ""
+"Visite https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
@@ -2036,8 +3306,12 @@ msgstr "No"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
 #, fuzzy
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
-msgstr "La intervención se realizó abierta o asistida por endoscopia, o se cambió a una técnica abierta durante un procedimiento endoscópico."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
+msgstr ""
+"La intervención se realizó abierta o asistida por endoscopia, o se cambió a "
+"una técnica abierta durante un procedimiento endoscópico."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
@@ -2048,8 +3322,12 @@ msgstr "[[data-dictionary-surgical-procedure-emergency]]Procedimiento de emergen
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
 #, fuzzy
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
-msgstr "Procedimiento documentado según el protocolo del centro como procedimiento de Urgencia o Emergencia."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
+msgstr ""
+"Procedimiento documentado según el protocolo del centro como procedimiento "
+"de Urgencia o Emergencia."
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:647
@@ -2078,14 +3356,33 @@ msgstr "[[data-dictionary-surgical-procedure-primary-closure]]Cierre primario"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
 #, fuzzy
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
-msgstr "El cierre del nivel de la piel durante la cirugía original, independientemente de la presencia de cables, mechas, drenajes u otros dispositivos u objetos que se extruyan a través de la incisión.  Esta categoría incluye las cirugías en las que la piel se cierra por algún medio.  Por lo tanto, si cualquier parte de la incisión se cierra a nivel de la piel, de cualquier manera, se debe asignar a la cirugía una designación de cierre primario."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
+msgstr ""
+"El cierre del nivel de la piel durante la cirugía original, "
+"independientemente de la presencia de cables, mechas, drenajes u otros "
+"dispositivos u objetos que se extruyan a través de la incisión.  Esta "
+"categoría incluye las cirugías en las que la piel se cierra por algún "
+"medio.  Por lo tanto, si cualquier parte de la incisión se cierra a nivel de "
+"la piel, de cualquier manera, se debe asignar a la cirugía una designación "
+"de cierre primario."
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
 #, fuzzy
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
-msgstr "Si un procedimiento tiene múltiples sitios de incisión/trocar laparoscópico y cualquiera de las incisiones se cierra primariamente, entonces la técnica del procedimiento se registra como cerrada primaria."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
+msgstr ""
+"Si un procedimiento tiene múltiples sitios de incisión/trocar laparoscópico "
+"y cualquiera de las incisiones se cierra primariamente, entonces la técnica "
+"del procedimiento se registra como cerrada primaria."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:654
@@ -2096,8 +3393,15 @@ msgstr "[[data-dictionary-surgical-procedure-revision-procedure]]Procedimiento d
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
 #, fuzzy
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
-msgstr "Los procedimientos de revisión son procedimientos de seguimiento, sustitución o corrección tras un procedimiento inicial.  Un procedimiento de revisión pone fin al seguimiento del procedimiento primario e inicia un nuevo periodo de seguimiento."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
+msgstr ""
+"Los procedimientos de revisión son procedimientos de seguimiento, "
+"sustitución o corrección tras un procedimiento inicial.  Un procedimiento de "
+"revisión pone fin al seguimiento del procedimiento primario e inicia un "
+"nuevo periodo de seguimiento."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
@@ -2108,8 +3412,16 @@ msgstr "[[data-dictionary-surgical-procedure-implant]]Implante"
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
 #, fuzzy
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
-msgstr "Un implante es un cuerpo extraño de origen no humano que se coloca de forma permanente en un paciente durante una operación y que no se manipula de forma rutinaria con fines diagnósticos o terapéuticos (por ejemplo, prótesis vasculares, tornillos, alambres, mallas)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
+msgstr ""
+"Un implante es un cuerpo extraño de origen no humano que se coloca de forma "
+"permanente en un paciente durante una operación y que no se manipula de "
+"forma rutinaria con fines diagnósticos o terapéuticos (por ejemplo, prótesis "
+"vasculares, tornillos, alambres, mallas)."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
@@ -2120,8 +3432,21 @@ msgstr "[[data-dictionary-surgical-procedure-signs-of-infetion]]Signos de infecc
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
 #, fuzzy
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
-msgstr "Rellene este campo si se identificaron signos de infección durante el procedimiento quirúrgico.  Los signos de infección deben anotarse intraoperatoriamente y documentarse en la parte narrativa de la nota de operación o informe de cirugía.  Si se produce una infección del lecho quirúrgico, esta información se utilizará para determinar si los signos enumerados en esta sección pueden interpretarse como \"Infección presente en el momento de la intervención quirúrgica\"."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
+msgstr ""
+"Rellene este campo si se identificaron signos de infección durante el "
+"procedimiento quirúrgico.  Los signos de infección deben anotarse "
+"intraoperatoriamente y documentarse en la parte narrativa de la nota de "
+"operación o informe de cirugía.  Si se produce una infección del lecho "
+"quirúrgico, esta información se utilizará para determinar si los signos "
+"enumerados en esta sección pueden interpretarse como \"Infección presente en "
+"el momento de la intervención quirúrgica\"."
 
 #. type: Block title
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:661
@@ -2132,32 +3457,65 @@ msgstr "Signos de infección en el momento de la intervención"
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
 #, fuzzy
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
-msgstr "Ejemplos que indican evidencia de infección incluyen pero no se limitan a: absceso, infección, purulencia/pus, flemón o \"peritonitis feculenta\".  Un apéndice roto/perforado es evidencia de infección a nivel de órgano/espacio."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
+msgstr ""
+"Ejemplos que indican evidencia de infección incluyen pero no se limitan a: "
+"absceso, infección, purulencia/pus, flemón o \"peritonitis feculenta\".  Un "
+"apéndice roto/perforado es evidencia de infección a nivel de órgano/espacio."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
 #, fuzzy
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
-msgstr "Ejemplos de verborrea que no se considera evidencia de infección incluyen pero no se limitan a: perforación de colon, contaminación, necrosis, gangrena, derrame fecal, intestino mellado durante el procedimiento, fluido turbio o documentación de inflamación."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
+msgstr ""
+"Ejemplos de verborrea que no se considera evidencia de infección incluyen "
+"pero no se limitan a: perforación de colon, contaminación, necrosis, "
+"gangrena, derrame fecal, intestino mellado durante el procedimiento, fluido "
+"turbio o documentación de inflamación."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
 #, fuzzy
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
-msgstr "El uso de la terminación \"itis\" en una nota o informe quirúrgico no cuenta automáticamente como prueba de infección, ya que puede reflejar únicamente una inflamación que no es de naturaleza infecciosa (por ejemplo, diverticulitis, peritonitis y apendicitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
+msgstr ""
+"El uso de la terminación \"itis\" en una nota o informe quirúrgico no cuenta "
+"automáticamente como prueba de infección, ya que puede reflejar únicamente "
+"una inflamación que no es de naturaleza infecciosa (por ejemplo, "
+"diverticulitis, peritonitis y apendicitis)."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
 #, fuzzy
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
-msgstr "Los resultados de los informes patológicos y de las pruebas de imagen no pueden utilizarse como prueba de infección."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
+msgstr ""
+"Los resultados de los informes patológicos y de las pruebas de imagen no "
+"pueden utilizarse como prueba de infección."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
 #, fuzzy
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
-msgstr "La identificación de un organismo mediante un método microbiológico basado o no en cultivos o en un informe patológico de una muestra quirúrgica no puede utilizarse como prueba de infección."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
+msgstr ""
+"La identificación de un organismo mediante un método microbiológico basado o "
+"no en cultivos o en un informe patológico de una muestra quirúrgica no puede "
+"utilizarse como prueba de infección."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:670
@@ -2168,14 +3526,28 @@ msgstr "La clase de herida no puede utilizarse como prueba de infección."
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
 #, fuzzy
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
-msgstr "Un traumatismo que dé lugar a un caso contaminado no cuenta automáticamente como prueba de infección.  Por ejemplo, una herida de bala reciente en el abdomen puede ser un traumatismo con una clase de herida alta, pero no habría tiempo para que se desarrollara la infección."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
+msgstr ""
+"Un traumatismo que dé lugar a un caso contaminado no cuenta automáticamente "
+"como prueba de infección.  Por ejemplo, una herida de bala reciente en el "
+"abdomen puede ser un traumatismo con una clase de herida alta, pero no "
+"habría tiempo para que se desarrollara la infección."
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
 #, fuzzy
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
-msgstr "Las complicaciones del procedimiento, como la perforación intestinal durante la cirugía, no pueden utilizarse como prueba de infección, ya que no había infección en el momento de la cirugía."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
+msgstr ""
+"Las complicaciones del procedimiento, como la perforación intestinal durante "
+"la cirugía, no pueden utilizarse como prueba de infección, ya que no había "
+"infección en el momento de la cirugía."
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:676
@@ -2198,8 +3570,13 @@ msgstr "[[data-dictionary-general-infection-data-infection-date]]Fecha de la inf
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
 #, fuzzy
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
-msgstr "El día en que aparecieron los primeros síntomas de infección.  Si no aparecen síntomas, el día del primer cultivo positivo en el lugar de la infección primaria."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
+msgstr ""
+"El día en que aparecieron los primeros síntomas de infección.  Si no "
+"aparecen síntomas, el día del primer cultivo positivo en el lugar de la "
+"infección primaria."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:682
@@ -2210,8 +3587,19 @@ msgstr "[[data-dictionary-general-infection-data-common-commensal]]Comensal com�
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
 #, fuzzy
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
-msgstr "Tipo de microorganismo (por ejemplo, estafilococos coagulasa-negativos), que suele estar presente en las superficies corporales cubiertas de epitelio (por ejemplo, la piel).  Cuando una o varias de estas especies crecen en un hemocultivo, es más probable que se trate de una contaminación que cuando crece un patógeno reconocido.  Véase la lista maestra de organismos en https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
+msgstr ""
+"Tipo de microorganismo (por ejemplo, estafilococos coagulasa-negativos), que "
+"suele estar presente en las superficies corporales cubiertas de epitelio "
+"(por ejemplo, la piel).  Cuando una o varias de estas especies crecen en un "
+"hemocultivo, es más probable que se trate de una contaminación que cuando "
+"crece un patógeno reconocido.  Véase la lista maestra de organismos en "
+"https://neoipc.org/surveillance/resources/"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:686
@@ -2246,7 +3634,10 @@ msgstr "ERV: Enterococos resistentes a la vancomicina"
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
 #, fuzzy
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
 msgstr ""
 "3GCR: Multi droga grama-resistente el patógeno negativo resistente a 3ª "
 "generación Cephalosporins según el corte del laboratorio propio-de valores "
@@ -2255,7 +3646,10 @@ msgstr ""
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
 #, fuzzy
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
 msgstr ""
 "Resistente a los carbapenémicos: Resistente al menos a uno de los siguientes "
 "(imipenem, meropenem, ertapenem) según los valores de corte de nuestro "
@@ -2265,8 +3659,12 @@ msgstr ""
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
 #, fuzzy
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
-msgstr "Resistente a la colistina: Resistente a la colistina según los valores de corte del propio laboratorio."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
+msgstr ""
+"Resistente a la colistina: Resistente a la colistina según los valores de "
+"corte del propio laboratorio."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:695
@@ -2277,20 +3675,31 @@ msgstr "Opciones para cada grupo:"
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
 #, fuzzy
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
-msgstr "Sí: el organismo aislado es resistente al grupo o grupos de antibióticos especificados."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgstr ""
+"Sí: el organismo aislado es resistente al grupo o grupos de antibióticos "
+"especificados."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
 #, fuzzy
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
-msgstr "No: el organismo aislado no es resistente a los grupos de antibióticos especificados."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
+msgstr ""
+"No: el organismo aislado no es resistente a los grupos de antibióticos "
+"especificados."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
 #, fuzzy
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
-msgstr "No sometido a prueba: el organismo aislado no ha sido sometido a pruebas de resistencia a los grupos de antibióticos especificados."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
+msgstr ""
+"No sometido a prueba: el organismo aislado no ha sido sometido a pruebas de "
+"resistencia a los grupos de antibióticos especificados."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:700
@@ -2301,19 +3710,41 @@ msgstr "[[data-dictionary-general-infection-data-secondary-bsi]]Infección secun
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
 #, fuzzy
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
-msgstr "Una ISB que se cree que se ha sembrado a partir de una infección específica de otro lugar del cuerpo (excepto en el caso de las infecciones asociadas a catéteres).  Una ISB puede atribuirse a una infección específica del lugar (ECN, NP o ISQ) si se produce en un periodo de 17 días que incluye el día de la infección (=primeros síntomas de la infección específica del lugar), 3 días antes y 13 días después."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
+msgstr ""
+"Una ISB que se cree que se ha sembrado a partir de una infección específica "
+"de otro lugar del cuerpo (excepto en el caso de las infecciones asociadas a "
+"catéteres).  Una ISB puede atribuirse a una infección específica del lugar "
+"(ECN, NP o ISQ) si se produce en un periodo de 17 días que incluye el día de "
+"la infección (=primeros síntomas de la infección específica del lugar), 3 "
+"días antes y 13 días después."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
 #, fuzzy
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
-msgstr "La recopilación de datos sobre la ISQ secundaria es opcional; por lo tanto, es posible seleccionar \"Sin seguimiento\" si no está siguiendo a los pacientes por ISQ secundaria.  Para obtener información detallada, consulte Infección secundaria del torrente sanguíneo."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
+msgstr ""
+"La recopilación de datos sobre la ISQ secundaria es opcional; por lo tanto, "
+"es posible seleccionar \"Sin seguimiento\" si no está siguiendo a los "
+"pacientes por ISQ secundaria.  Para obtener información detallada, consulte "
+"Infección secundaria del torrente sanguíneo."
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
 #, fuzzy
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
 msgstr ""
 "Sí: si estás realizando el seguimiento de pacientes con infección sanguínea "
 "secundaria y el paciente ha desarrollado una sepsis secundaria que cumple la "
@@ -2323,8 +3754,12 @@ msgstr ""
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
 #, fuzzy
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
-msgstr "No: si está siguiendo a pacientes por BSI secundaria y el paciente no ha desarrollado una sepsis secundaria que cumpla la definición de NeoIPC"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
+msgstr ""
+"No: si está siguiendo a pacientes por BSI secundaria y el paciente no ha "
+"desarrollado una sepsis secundaria que cumpla la definición de NeoIPC"
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:709
@@ -2347,14 +3782,24 @@ msgstr "[[data-dictionary-bsi-specific-data-cvc]]Catéter vascular central (CVC)
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
 #, fuzzy
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
-msgstr "Catéter intravascular que termina en o cerca del corazón o en uno de los grandes vasos que se utiliza para infusión, extracción de sangre o monitorización hemodinámica."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
+msgstr ""
+"Catéter intravascular que termina en o cerca del corazón o en uno de los "
+"grandes vasos que se utiliza para infusión, extracción de sangre o "
+"monitorización hemodinámica."
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
 #, fuzzy
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
-msgstr "Catéter venoso central (CVC), incluidos los catéteres venosos centrales no tunelizados, tunelizados e implantados."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
+msgstr ""
+"Catéter venoso central (CVC), incluidos los catéteres venosos centrales no "
+"tunelizados, tunelizados e implantados."
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:717
@@ -2371,14 +3816,20 @@ msgstr "Catéter arterial umbilical (CAU) o catéter venoso umbilical (CVU)"
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
 #, fuzzy
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
-msgstr "La oxigenación por membrana extracorpórea (ECMO) y los catéteres arteriales (excepto arteria pulmonar, aorta o arteria umbilical) NO se consideran CVC."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgstr ""
+"La oxigenación por membrana extracorpórea (ECMO) y los catéteres arteriales "
+"(excepto arteria pulmonar, aorta o arteria umbilical) NO se consideran CVC."
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
 #, fuzzy
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
-msgstr "Se consideran grandes vasos a efectos de notificación de CVC los siguientes:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
+msgstr ""
+"Se consideran grandes vasos a efectos de notificación de CVC los siguientes:"
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:724
@@ -2455,8 +3906,16 @@ msgstr "[[data-dictionary-bsi-specific-data-cvc-associated-bsi]]ICS asociada a C
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
 #, fuzzy
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
-msgstr "Una infección primaria del torrente sanguíneo se considera <<bsi-specific-data_cvc,CVC>>-asociada si el CVC ha estado colocado durante al menos tres días consecutivos el día de la infección (=primeros síntomas o primera prueba diagnóstica positiva; por ejemplo, cultivo) o el día anterior."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
+msgstr ""
+"Una infección primaria del torrente sanguíneo se considera <<bsi-specific-"
+"data_cvc,CVC>>-asociada si el CVC ha estado colocado durante al menos tres "
+"días consecutivos el día de la infección (=primeros síntomas o primera "
+"prueba diagnóstica positiva; por ejemplo, cultivo) o el día anterior."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:738
@@ -2467,8 +3926,12 @@ msgstr "[[data-dictionary-bsi-specific-data-cvc-day]]CVC-dia"
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
 #, fuzzy
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
-msgstr "Día en el que el paciente tuvo colocado un <<bsi-specific-data_cvc,CVC>> durante al menos 12 horas acumuladas."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
+msgstr ""
+"Día en el que el paciente tuvo colocado un <<bsi-specific-data_cvc,CVC>> "
+"durante al menos 12 horas acumuladas."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:740
@@ -2479,8 +3942,12 @@ msgstr "[[data-dictionary-bsi-specific-data-pvc]]Catéter vascular periférico (
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
 #, fuzzy
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
-msgstr "Un PVC es un catéter que se coloca en una vena periférica y no llega a uno de los grandes vasos mencionados en CVC."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
+msgstr ""
+"Un PVC es un catéter que se coloca en una vena periférica y no llega a uno "
+"de los grandes vasos mencionados en CVC."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:742
@@ -2491,8 +3958,25 @@ msgstr "[[data-dictionary-bsi-specific-data-pvc-associated-bsi]]ICS asociada a P
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
 #, fuzzy
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
-msgstr "Una infección primaria del torrente sanguíneo se considera <<bsi-specific-data_pvc,PVC>>-asociada si el PVC ha estado presente durante al menos tres días consecutivos el día de la infección (=primeros síntomas o primera prueba diagnóstica positiva; por ejemplo, cultivo) o el día anterior y no cumple los criterios de ICS asociada a CVC.  Es decir, si un paciente que desarrolla una infección del torrente sanguíneo cumple los criterios de asociación tanto con el PVC como con el CVC, se considera que el CVC es el dispositivo con un riesgo de infección relativamente mayor y la ISB debe registrarse como ISB asociada al CVC."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
+msgstr ""
+"Una infección primaria del torrente sanguíneo se considera <<bsi-specific-"
+"data_pvc,PVC>>-asociada si el PVC ha estado presente durante al menos tres "
+"días consecutivos el día de la infección (=primeros síntomas o primera "
+"prueba diagnóstica positiva; por ejemplo, cultivo) o el día anterior y no "
+"cumple los criterios de ICS asociada a CVC.  Es decir, si un paciente que "
+"desarrolla una infección del torrente sanguíneo cumple los criterios de "
+"asociación tanto con el PVC como con el CVC, se considera que el CVC es el "
+"dispositivo con un riesgo de infección relativamente mayor y la ISB debe "
+"registrarse como ISB asociada al CVC."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:745
@@ -2503,8 +3987,12 @@ msgstr "[[data-dictionary-bsi-specific-data-pvc-day]]Día de PVC"
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
 #, fuzzy
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
-msgstr "Día en el que el paciente tuvo colocado un <<bsi-specific-data_pvc,PVC>> durante al menos 12 horas acumuladas."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
+msgstr ""
+"Día en el que el paciente tuvo colocado un <<bsi-specific-data_pvc,PVC>> "
+"durante al menos 12 horas acumuladas."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:747
@@ -2515,8 +4003,27 @@ msgstr "[[data-dictionary-bsi-specific-data-iv-ab-therapy-initiated]]Terapia ant
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
 #, fuzzy
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
-msgstr "Se inició tratamiento antibiótico durante al menos cinco días.  Se cuentan el día de la primera dosis y el día de la última dosis.  Los días en los que no se administró ninguna dosis entre la primera y la última (por ejemplo, dosis omitidas debido a niveles elevados del fármaco en la monitorización terapéutica de fármacos) se cuentan como si se hubiera administrado una dosis.  Los días posteriores a la última dosis no se cuentan, independientemente del nivel de fármaco medido o supuesto del paciente.  Si el lactante falleció, fue dado de alta o trasladado antes del final del ciclo de cinco días de antibióticos intravenosos, esta condición se cumple si el tratamiento estaba programado para cinco días o más."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
+msgstr ""
+"Se inició tratamiento antibiótico durante al menos cinco días.  Se cuentan "
+"el día de la primera dosis y el día de la última dosis.  Los días en los que "
+"no se administró ninguna dosis entre la primera y la última (por ejemplo, "
+"dosis omitidas debido a niveles elevados del fármaco en la monitorización "
+"terapéutica de fármacos) se cuentan como si se hubiera administrado una "
+"dosis.  Los días posteriores a la última dosis no se cuentan, "
+"independientemente del nivel de fármaco medido o supuesto del paciente.  Si "
+"el lactante falleció, fue dado de alta o trasladado antes del final del "
+"ciclo de cinco días de antibióticos intravenosos, esta condición se cumple "
+"si el tratamiento estaba programado para cinco días o más."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:753
@@ -2527,8 +4034,16 @@ msgstr "[[data-dictionary-bsi-specific-data-increased-oxygen-demand-or-ventilato
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
 #, fuzzy
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
-msgstr "Episodios nuevos o más frecuentes de apnea que duran más de 20 segundos, o un aumento de la cantidad de oxígeno necesaria para mantener una oxigenación adecuada, o una intensificación del soporte ventilatorio, como un aumento del flujo con terapia de alto flujo o intubación para ventilación invasiva."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
+msgstr ""
+"Episodios nuevos o más frecuentes de apnea que duran más de 20 segundos, o "
+"un aumento de la cantidad de oxígeno necesaria para mantener una oxigenación "
+"adecuada, o una intensificación del soporte ventilatorio, como un aumento "
+"del flujo con terapia de alto flujo o intubación para ventilación invasiva."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:755
@@ -2539,8 +4054,14 @@ msgstr "[[data-dictionary-bsi-specific-data-enteral-feeding-intolerance]]Intoler
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
 #, fuzzy
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
-msgstr "Intolerancia a la alimentación enteral, distensión abdominal o íleo sin hallazgos de imagen o quirúrgicos que sugieran una entrocolitis necrotizante o una perforación intestinal espontánea."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
+msgstr ""
+"Intolerancia a la alimentación enteral, distensión abdominal o íleo sin "
+"hallazgos de imagen o quirúrgicos que sugieran una entrocolitis necrotizante "
+"o una perforación intestinal espontánea."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:757
@@ -2551,8 +4072,12 @@ msgstr "[[data-dictionary-bsi-specific-data-unexplained-metabolic-acidosis]]Acid
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
 #, fuzzy
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
-msgstr "Acidosis metabólica inexplicada con un déficit de bases superior (más negativo) a 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
+msgstr ""
+"Acidosis metabólica inexplicada con un déficit de bases superior (más "
+"negativo) a 10 mmol/L (10 mEq/L)."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:760
@@ -2593,7 +4118,9 @@ msgstr "Nuevo inicio de soporte respiratorio o aumento del nivel de soporte resp
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
 #, fuzzy
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
 msgstr ""
 "Aumento de la necesidad de una FiO₂ ≥ 0,25 (25 puntos) en un plazo de 24 "
 "horas (en este caso deben tenerse en cuenta los valores mínimos diarios de "
@@ -2613,15 +4140,23 @@ msgstr "O"
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
 #, fuzzy
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
-msgstr "inicio de soporte ventilatorio no invasivo (excluido el cambio de ventilación invasiva)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
+msgstr ""
+"inicio de soporte ventilatorio no invasivo (excluido el cambio de "
+"ventilación invasiva)"
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
 #, fuzzy
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
-msgstr "inicio de ventilación mecánica invasiva (incluido el cambio de soporte ventilatorio no invasivo)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
+msgstr ""
+"inicio de ventilación mecánica invasiva (incluido el cambio de soporte "
+"ventilatorio no invasivo)"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:778
@@ -2644,14 +4179,26 @@ msgstr "… después de al menos 2 días de estabilidad o mejoría"
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
 #, fuzzy
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
-msgstr "Se requiere un periodo de referencia estable o de mejoría de al menos dos días antes de que se produzca la condición mencionada."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
+msgstr ""
+"Se requiere un periodo de referencia estable o de mejoría de al menos dos "
+"días antes de que se produzca la condición mencionada."
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
 #, fuzzy
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
-msgstr "Para cumplir los criterios de neumonía adquirida en el hospital asociada a un dispositivo, los pacientes deben estar ventilados durante al menos 4 días naturales (el día 1 es el día de inicio de la ventilación invasiva/no invasiva). La fecha más temprana del evento es el día 3 de ventilación."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
+msgstr ""
+"Para cumplir los criterios de neumonía adquirida en el hospital asociada a "
+"un dispositivo, los pacientes deben estar ventilados durante al menos 4 días "
+"naturales (el día 1 es el día de inicio de la ventilación invasiva/no "
+"invasiva). La fecha más temprana del evento es el día 3 de ventilación."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:785
@@ -2674,8 +4221,16 @@ msgstr "[[data-dictionary-pneumonia-specific-data-inv-associated-pneumonia]]Neum
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
 #, fuzzy
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
-msgstr "Una neumonía está asociada a <<neumonia-specific-data_inv,INV>> si el paciente tuvo una cánula endotraqueal o de traqueotomía durante al menos 3 días consecutivos el día de la infección (=primeros síntomas o primer cultivo positivo) o el día anterior."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
+msgstr ""
+"Una neumonía está asociada a <<neumonia-specific-data_inv,INV>> si el "
+"paciente tuvo una cánula endotraqueal o de traqueotomía durante al menos 3 "
+"días consecutivos el día de la infección (=primeros síntomas o primer "
+"cultivo positivo) o el día anterior."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:789
@@ -2686,8 +4241,12 @@ msgstr "[[data-dictionary-pneumonia-specific-data-inv-day]]INV-Día"
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
 #, fuzzy
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
-msgstr "Día en el que el paciente recibió ventilación invasiva mediante tubo endotraqueal o de traqueostomía durante al menos 12 horas acumuladas."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
+msgstr ""
+"Día en el que el paciente recibió ventilación invasiva mediante tubo "
+"endotraqueal o de traqueostomía durante al menos 12 horas acumuladas."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:791
@@ -2710,8 +4269,17 @@ msgstr "[[data-dictionary-pneumonia-specific-data-niv-associated-pneumonia]]Neum
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
 #, fuzzy
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
-msgstr "Una neumonía está asociada a <<pneumonia-specific-data_niv,NIV>> si el paciente recibió asistencia ventilatoria no invasiva (por ejemplo, CPAP o Cánula Nasal de Alto Flujo) durante al menos 3 días consecutivos el día de la infección (=primeros síntomas o primer cultivo positivo) o el día anterior."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
+msgstr ""
+"Una neumonía está asociada a <<pneumonia-specific-data_niv,NIV>> si el "
+"paciente recibió asistencia ventilatoria no invasiva (por ejemplo, CPAP o "
+"Cánula Nasal de Alto Flujo) durante al menos 3 días consecutivos el día de "
+"la infección (=primeros síntomas o primer cultivo positivo) o el día "
+"anterior."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:795
@@ -2722,8 +4290,13 @@ msgstr "[[data-dictionary-pneumonia-specific-data-niv-day]]Día de VNI"
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
 #, fuzzy
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
-msgstr "Día en el que el paciente recibió asistencia ventilatoria no invasiva mediante CPAP o cánula nasal de alto flujo durante al menos 12 horas acumuladas."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgstr ""
+"Día en el que el paciente recibió asistencia ventilatoria no invasiva "
+"mediante CPAP o cánula nasal de alto flujo durante al menos 12 horas "
+"acumuladas."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:797
@@ -2734,8 +4307,16 @@ msgstr "[[data-dictionary-pneumonia-specific-data-organisms-rt]]Organismos ident
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
 #, fuzzy
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
-msgstr "Se ha identificado al menos un organismo del tracto respiratorio mediante un cultivo o un método de prueba microbiológica no basado en cultivos que se realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, cultivo/prueba de vigilancia NO activa (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
+msgstr ""
+"Se ha identificado al menos un organismo del tracto respiratorio mediante un "
+"cultivo o un método de prueba microbiológica no basado en cultivos que se "
+"realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, cultivo/"
+"prueba de vigilancia NO activa (ASC/AST))."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:799
@@ -2746,8 +4327,14 @@ msgstr "[[data-dictionary-pneumonia-specific-data-organisms-lrt]]Recuperado de l
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
 #, fuzzy
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
-msgstr "Seleccione si se detectan patógenos fúngicos, bacterianos o víricos (gen vírico, antígeno o anticuerpo mediante, por ejemplo, EIA, FAMA, ensayo en vial de concha, PCR) en las vías respiratorias inferiores."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
+msgstr ""
+"Seleccione si se detectan patógenos fúngicos, bacterianos o víricos (gen "
+"vírico, antígeno o anticuerpo mediante, por ejemplo, EIA, FAMA, ensayo en "
+"vial de concha, PCR) en las vías respiratorias inferiores."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
@@ -2759,7 +4346,9 @@ msgstr "[[data-dictionary-pneumonia-specific-data-organisms-urt]]Recuperados del
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:801
 #, fuzzy
 msgid "Select only if viral pathogens are detected in upper respiratory tract."
-msgstr "Seleccione sólo si se detectan patógenos víricos en el tracto respiratorio superior."
+msgstr ""
+"Seleccione sólo si se detectan patógenos víricos en el tracto respiratorio "
+"superior."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:803
@@ -2776,8 +4365,14 @@ msgstr "[[data-dictionary-ssi-specific-data-infection-present]]Infección presen
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
 #, fuzzy
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
-msgstr "Seleccione SÍ, sólo si el signo de infección identificado durante el procedimiento quirúrgico se aplica a la profundidad de la ISQ que se atribuye al procedimiento."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
+msgstr ""
+"Seleccione SÍ, sólo si el signo de infección identificado durante el "
+"procedimiento quirúrgico se aplica a la profundidad de la ISQ que se "
+"atribuye al procedimiento."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:807
@@ -2789,14 +4384,24 @@ msgstr "Ejemplo"
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
 #, fuzzy
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
-msgstr "Si un paciente tiene documentación de una infección intraabdominal en el momento de la cirugía y más tarde regresa con una ISQ de órgano/espacio = SÍ."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
+msgstr ""
+"Si un paciente tiene documentación de una infección intraabdominal en el "
+"momento de la cirugía y más tarde regresa con una ISQ de órgano/espacio = SÍ."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
 #, fuzzy
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
-msgstr "Si un paciente tiene documentada una infección intraabdominal en el momento de la intervención y más tarde vuelve con una ISQ incisional superficial o profunda = NO."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
+msgstr ""
+"Si un paciente tiene documentada una infección intraabdominal en el momento "
+"de la intervención y más tarde vuelve con una ISQ incisional superficial o "
+"profunda = NO."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:812
@@ -2807,32 +4412,68 @@ msgstr "[[data-dictionary-ssi-specific-data-ssi-type]]Tipo de ISQ"
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
 #, fuzzy
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
-msgstr "Una ISQ incisional superficial afecta sólo a la piel y el tejido subcutáneo de la incisión y los primeros síntomas aparecen en los 30 días siguientes a la operación."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
+msgstr ""
+"Una ISQ incisional superficial afecta sólo a la piel y el tejido subcutáneo "
+"de la incisión y los primeros síntomas aparecen en los 30 días siguientes a "
+"la operación."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
 #, fuzzy
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
-msgstr "Una ISQ incisional profunda afecta a los tejidos blandos profundos de la incisión (por ejemplo, las capas fasciales y musculares) y los primeros síntomas aparecen en los 30 días siguientes a la operación o 90 días después de la operación cuando se ha dejado un implante."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
+msgstr ""
+"Una ISQ incisional profunda afecta a los tejidos blandos profundos de la "
+"incisión (por ejemplo, las capas fasciales y musculares) y los primeros "
+"síntomas aparecen en los 30 días siguientes a la operación o 90 días después "
+"de la operación cuando se ha dejado un implante."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
 #, fuzzy
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
-msgstr "Una ISQ de órgano/espacio afecta a cualquier parte del cuerpo más profunda que las capas fascial/muscular que se abre o manipula durante la intervención quirúrgica y los primeros síntomas se producen en los 30 días siguientes a la operación o 90 días después de la operación cuando se ha dejado un implante."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
+msgstr ""
+"Una ISQ de órgano/espacio afecta a cualquier parte del cuerpo más profunda "
+"que las capas fascial/muscular que se abre o manipula durante la "
+"intervención quirúrgica y los primeros síntomas se producen en los 30 días "
+"siguientes a la operación o 90 días después de la operación cuando se ha "
+"dejado un implante."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
 #, fuzzy
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
-msgstr "La ISQ notificada debe reflejar el nivel tisular más profundo en el que se cumplen los criterios de ISQ durante el periodo de vigilancia."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
+msgstr ""
+"La ISQ notificada debe reflejar el nivel tisular más profundo en el que se "
+"cumplen los criterios de ISQ durante el periodo de vigilancia."
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
 #, fuzzy
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
-msgstr "Si una ISQ comenzó como ISQ incisional profunda el día 10 del periodo de vigilancia de ISQ y una semana después (día 17) cumple los criterios de ISQ órgano/espacio.  Debe notificarla como ISQ órgano/espacio independientemente de la afectación del tejido superficial o profundo.  El día de la infección en este caso sería el \"Día 17\"."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
+msgstr ""
+"Si una ISQ comenzó como ISQ incisional profunda el día 10 del periodo de "
+"vigilancia de ISQ y una semana después (día 17) cumple los criterios de ISQ "
+"órgano/espacio.  Debe notificarla como ISQ órgano/espacio independientemente "
+"de la afectación del tejido superficial o profundo.  El día de la infección "
+"en este caso sería el \"Día 17\"."
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:827
@@ -2843,8 +4484,16 @@ msgstr "[[data-dictionary-ssi-specific-data-organism-identified]]Organismo(s) id
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
 #, fuzzy
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
-msgstr "Se ha identificado al menos un organismo en la zona quirúrgica mediante un cultivo o un método de prueba microbiológica no basado en cultivos que se realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, cultivo/prueba de vigilancia NO activa (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
+msgstr ""
+"Se ha identificado al menos un organismo en la zona quirúrgica mediante un "
+"cultivo o un método de prueba microbiológica no basado en cultivos que se "
+"realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, cultivo/"
+"prueba de vigilancia NO activa (ASC/AST))."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:830
@@ -2855,14 +4504,24 @@ msgstr "Análisis de datos"
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
 #, fuzzy
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
-msgstr "Los siguientes índices se han calculado tanto para los informes de los departamentos como para los informes de referencia y pueden servir como punto de partida para posteriores análisis y debates en su departamento."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
+msgstr ""
+"Los siguientes índices se han calculado tanto para los informes de los "
+"departamentos como para los informes de referencia y pueden servir como "
+"punto de partida para posteriores análisis y debates en su departamento."
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
 #, fuzzy
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
-msgstr "Para el módulo básico, las tasas se estratifican generalmente en 4 grupos según el peso al nacer de los lactantes:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
+msgstr ""
+"Para el módulo básico, las tasas se estratifican generalmente en 4 grupos "
+"según el peso al nacer de los lactantes:"
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:836
@@ -2903,32 +4562,55 @@ msgstr "Utilización de dispositivos"
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
 #, fuzzy
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
-msgstr "El índice de utilización de un dispositivo describe el porcentaje de días-paciente en los que se utilizó un dispositivo específico.  Se calcula dividiendo el número de días de dispositivo por el número de días de paciente y multiplicando el resultado por 100."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
+msgstr ""
+"El índice de utilización de un dispositivo describe el porcentaje de días-"
+"paciente en los que se utilizó un dispositivo específico.  Se calcula "
+"dividiendo el número de días de dispositivo por el número de días de "
+"paciente y multiplicando el resultado por 100."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
 #, fuzzy
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
-msgstr "stem:[\"Tasa de utilización de CVC\" = \"Total días CVC\" / \"Total días paciente\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
+msgstr ""
+"stem:[\"Tasa de utilización de CVC\" = \"Total días CVC\" / \"Total días "
+"paciente\" xx 100 ]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
 #, fuzzy
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
-msgstr "stem:[\"Índice de utilización de PVC\" = \"Días totales de PVC\" / \"Días totales de paciente\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
+msgstr ""
+"stem:[\"Índice de utilización de PVC\" = \"Días totales de PVC\" / \"Días "
+"totales de paciente\" xx 100 ]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
 #, fuzzy
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
-msgstr "stem:[\"Índice de utilización de INV\" = \"Días totales de INV\" / \"Días totales de paciente\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
+msgstr ""
+"stem:[\"Índice de utilización de INV\" = \"Días totales de INV\" / \"Días "
+"totales de paciente\" xx 100 ]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
 #, fuzzy
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Tasa de utilización de VNI\" = \"Días totales de VNI\" / \"Días totales de pacientes\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
+msgstr ""
+"stem:[\"Tasa de utilización de VNI\" = \"Días totales de VNI\" / \"Días "
+"totales de pacientes\" xx 100]"
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:856
@@ -2939,56 +4621,116 @@ msgstr "Uso de antibióticos"
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
 #, fuzzy
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
-msgstr "La tasa de utilización de antibióticos describe el porcentaje de días de paciente en los que se utilizaron antibióticos sistémicos en relación con el total de días de paciente.  Se calcula dividiendo el número de días de antibiótico por el número de días de paciente y multiplicando el resultado por 100."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
+msgstr ""
+"La tasa de utilización de antibióticos describe el porcentaje de días de "
+"paciente en los que se utilizaron antibióticos sistémicos en relación con el "
+"total de días de paciente.  Se calcula dividiendo el número de días de "
+"antibiótico por el número de días de paciente y multiplicando el resultado "
+"por 100."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
 #, fuzzy
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Tasa de uso de antibióticos\" = \"Días totales de antibióticos\" / \"Días totales de pacientes\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
+msgstr ""
+"stem:[\"Tasa de uso de antibióticos\" = \"Días totales de antibióticos\" / "
+"\"Días totales de pacientes\" xx 100]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
 #, fuzzy
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
-msgstr "Además de la tasa global de uso de antibióticos, las tasas de uso de antibióticos y las proporciones de pacientes que reciben una sustancia se calculan para sustancias individuales y grupos de sustancias."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
+msgstr ""
+"Además de la tasa global de uso de antibióticos, las tasas de uso de "
+"antibióticos y las proporciones de pacientes que reciben una sustancia se "
+"calculan para sustancias individuales y grupos de sustancias."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
 #, fuzzy
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
-msgstr "Las sustancias y grupos se derivan de la Clasificación Anatómica Terapéutica Química (ATC) nota:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] publicada en el índice ATC/DDD más recientenotadepie:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgstr ""
+"Las sustancias y grupos se derivan de la Clasificación Anatómica Terapéutica "
+"Química (ATC) nota:[Anatomical Therapeutic Chemical Classificationpass:p[ +] "
+"https://www.who.int/tools/atc-ddd-toolkit/atc-classification] publicada en "
+"el índice ATC/DDD más recientenotadepie:[ATC/DDD Indexpass:p[ +] https://"
+"www.whocc.no/atc_ddd_index/]."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
 #, fuzzy
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
-msgstr "Actualmente se utilizan los niveles 1, 2, 4 y 5 de la ATC para agrupar las sustancias."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
+msgstr ""
+"Actualmente se utilizan los niveles 1, 2, 4 y 5 de la ATC para agrupar las "
+"sustancias."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
 #, fuzzy
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
-msgstr "Dado que las cifras de los grupos individuales suelen ser muy pequeñas, las tasas de consumo específicas de la sustancia y del grupo se calculan dividiendo el número de días de la sustancia (grupo) por el número de días del paciente y multiplicando el resultado por 1000."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
+msgstr ""
+"Dado que las cifras de los grupos individuales suelen ser muy pequeñas, las "
+"tasas de consumo específicas de la sustancia y del grupo se calculan "
+"dividiendo el número de días de la sustancia (grupo) por el número de días "
+"del paciente y multiplicando el resultado por 1000."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
 #, fuzzy
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Tasa de uso de grupo de sustancias\" = \"Total de días de terapia para el grupo de sustancias\" / \"Total de días de paciente\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
+msgstr ""
+"stem:[\"Tasa de uso de grupo de sustancias\" = \"Total de días de terapia "
+"para el grupo de sustancias\" / \"Total de días de paciente\" xx 100]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
 #, fuzzy
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
-msgstr "La proporción de pacientes que reciben alguna(s) sustancia(s) específica(s) de un grupo de sustancias se calcula como la relación entre el número total de pacientes que reciben una sustancia o grupo de antibióticos específico y el número total de pacientes que reciben cualquier tipo de antibiótico multiplicado por 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
+msgstr ""
+"La proporción de pacientes que reciben alguna(s) sustancia(s) específica(s) "
+"de un grupo de sustancias se calcula como la relación entre el número total "
+"de pacientes que reciben una sustancia o grupo de antibióticos específico y "
+"el número total de pacientes que reciben cualquier tipo de antibiótico "
+"multiplicado por 100."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
 #, fuzzy
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Proporción de pacientes que reciben una sustancia o grupo AB\" = \"Días totales de terapia para esa sustancia o grupo\" / \"Días totales de pacientes\" xx 100]."
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
+msgstr ""
+"stem:[\"Proporción de pacientes que reciben una sustancia o grupo AB\" = "
+"\"Días totales de terapia para esa sustancia o grupo\" / \"Días totales de "
+"pacientes\" xx 100]."
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:879
@@ -2999,26 +4741,48 @@ msgstr "Utilización del factor de protección"
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
 #, fuzzy
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
-msgstr "La tasa de utilización de un factor de protección describe el porcentaje de días de paciente en los que un paciente recibió un factor de protección específico, como leche materna, probióticos o cuidados madre canguro.  Se calcula dividiendo el número de días de factor protector por el número de días de paciente y multiplicando el resultado por 100."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
+msgstr ""
+"La tasa de utilización de un factor de protección describe el porcentaje de "
+"días de paciente en los que un paciente recibió un factor de protección "
+"específico, como leche materna, probióticos o cuidados madre canguro.  Se "
+"calcula dividiendo el número de días de factor protector por el número de "
+"días de paciente y multiplicando el resultado por 100."
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
 #, fuzzy
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Tasa de consumo de leche materna\" = \"Total de días de leche materna\" / \"Total de días de paciente\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
+msgstr ""
+"stem:[\"Tasa de consumo de leche materna\" = \"Total de días de leche "
+"materna\" / \"Total de días de paciente\" xx 100]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
 #, fuzzy
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Tasa de uso de probióticos\" = \"Días totales de probióticos\" / \"Días totales de pacientes\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
+msgstr ""
+"stem:[\"Tasa de uso de probióticos\" = \"Días totales de probióticos\" / "
+"\"Días totales de pacientes\" xx 100]"
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
 #, fuzzy
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
-msgstr "stem:[\"Tasa de utilización de cuidados canguro\" = \"Días totales de cuidados canguro\" / \"Días totales de paciente\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
+msgstr ""
+"stem:[\"Tasa de utilización de cuidados canguro\" = \"Días totales de "
+"cuidados canguro\" / \"Días totales de paciente\" xx 100]"
 
 #. type: Title ===
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:890
@@ -3035,26 +4799,48 @@ msgstr "Densidades de incidencia"
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
 #, fuzzy
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
-msgstr "Dado que una proporción sustancial de infecciones no puede vincularse a un factor de riesgo específico, se calculan densidades de incidencia para infecciones del torrente sanguíneo, neumonía, ECN.  El factor de riesgo representa aquí el número acumulado de días-paciente y se estandariza como 1000 días-paciente."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
+msgstr ""
+"Dado que una proporción sustancial de infecciones no puede vincularse a un "
+"factor de riesgo específico, se calculan densidades de incidencia para "
+"infecciones del torrente sanguíneo, neumonía, ECN.  El factor de riesgo "
+"representa aquí el número acumulado de días-paciente y se estandariza como "
+"1000 días-paciente."
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
 #, fuzzy
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
-msgstr "stem:[\"Densidad de incidencia de infecciones del torrente sanguíneo\" = \"Total de casos de infecciones del torrente sanguíneo\" / \"Total de días-paciente\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
+msgstr ""
+"stem:[\"Densidad de incidencia de infecciones del torrente sanguíneo\" = "
+"\"Total de casos de infecciones del torrente sanguíneo\" / \"Total de días-"
+"paciente\" xx 1000]"
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
 #, fuzzy
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
-msgstr "stem:[\"Densidad de incidencia de neumonía\" = \"Casos totales de neumonía\" / \"Días totales de paciente\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
+msgstr ""
+"stem:[\"Densidad de incidencia de neumonía\" = \"Casos totales de "
+"neumonía\" / \"Días totales de paciente\" xx 1000]"
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
 #, fuzzy
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
-msgstr "stem:[\"Densidad de incidencia de ECN\" = \"Casos totales de ECN\" / \"Días totales de paciente\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
+msgstr ""
+"stem:[\"Densidad de incidencia de ECN\" = \"Casos totales de ECN\" / \"Días "
+"totales de paciente\" xx 1000]"
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:903
@@ -3065,43 +4851,95 @@ msgstr "Infecciones asociadas a dispositivos"
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
 #, fuzzy
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
-msgstr "La tasa de infecciones asociadas a dispositivos es una importante métrica de gestión de la calidad y describe cuántas infecciones asociadas a dispositivos se producen por cada 1000 días de dispositivo.  En este proceso denominado normalización, las infecciones (por ejemplo, ICB) que se producen en presencia de un determinado factor de riesgo (por ejemplo, CVC) se asocian con el número total de días de riesgo (por ejemplo, Días CVC) y el resultado se multiplica por 1000."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
+msgstr ""
+"La tasa de infecciones asociadas a dispositivos es una importante métrica de "
+"gestión de la calidad y describe cuántas infecciones asociadas a "
+"dispositivos se producen por cada 1000 días de dispositivo.  En este proceso "
+"denominado normalización, las infecciones (por ejemplo, ICB) que se producen "
+"en presencia de un determinado factor de riesgo (por ejemplo, CVC) se "
+"asocian con el número total de días de riesgo (por ejemplo, Días CVC) y el "
+"resultado se multiplica por 1000."
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
 #, fuzzy
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
-msgstr "stem:[\"Tasa de BSI asociada a CVC\" = \"Total de casos de BSI en pacientes con CVC\" / \"Total de días CVC\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
+msgstr ""
+"stem:[\"Tasa de BSI asociada a CVC\" = \"Total de casos de BSI en pacientes "
+"con CVC\" / \"Total de días CVC\" xx 1000]"
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
 #, fuzzy
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
-msgstr "stem:[\"Tasa de ICB asociada a PVC\" = \"Total de casos de ICB en pacientes con PVC\" / \"Total de días de PVC\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
+msgstr ""
+"stem:[\"Tasa de ICB asociada a PVC\" = \"Total de casos de ICB en pacientes "
+"con PVC\" / \"Total de días de PVC\" xx 1000]"
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
 #, fuzzy
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
-msgstr "stem:[\"Tasa de neumonía asociada a INV\" = \"Total de casos de neumonía en pacientes con INV\" / \"Total de días con INV\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgstr ""
+"stem:[\"Tasa de neumonía asociada a INV\" = \"Total de casos de neumonía en "
+"pacientes con INV\" / \"Total de días con INV\" xx 1000]"
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
 #, fuzzy
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
-msgstr "stem:[\"Tasa de neumonía asociada a VMNI\" = \"Total de casos de neumonía en pacientes con VMNI\" / \"Total de días con VMNI\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgstr ""
+"stem:[\"Tasa de neumonía asociada a VMNI\" = \"Total de casos de neumonía en "
+"pacientes con VMNI\" / \"Total de días con VMNI\" xx 1000]"
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
 #, fuzzy
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
-msgstr "Las tasas de infección del sitio quirúrgico (ISQ) definen el porcentaje de ISQ que se producen durante el periodo de observación tras una intervención quirúrgica.  Se calcula dividiendo el número de ISQ que se producen tras un procedimiento quirúrgico por el número de procedimientos quirúrgicos y multiplicando el resultado por 100.  Dado que el riesgo de desarrollar una ISQ depende del tipo de intervención quirúrgica, se calculan múltiples tasas de ISQ para grupos de intervenciones similares.  No obstante, se calculará una tasa global de ISQ para tener en cuenta el hecho de que la cirugía en lactantes con MBPN/VPT es menos frecuente que en adultos y que la agrupación de procedimientos puede dar lugar a recuentos de procedimientos muy bajos por grupo."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
+msgstr ""
+"Las tasas de infección del sitio quirúrgico (ISQ) definen el porcentaje de "
+"ISQ que se producen durante el periodo de observación tras una intervención "
+"quirúrgica.  Se calcula dividiendo el número de ISQ que se producen tras un "
+"procedimiento quirúrgico por el número de procedimientos quirúrgicos y "
+"multiplicando el resultado por 100.  Dado que el riesgo de desarrollar una "
+"ISQ depende del tipo de intervención quirúrgica, se calculan múltiples tasas "
+"de ISQ para grupos de intervenciones similares.  No obstante, se calculará "
+"una tasa global de ISQ para tener en cuenta el hecho de que la cirugía en "
+"lactantes con MBPN/VPT es menos frecuente que en adultos y que la agrupación "
+"de procedimientos puede dar lugar a recuentos de procedimientos muy bajos "
+"por grupo."
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
 #, fuzzy
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
 msgstr ""
 "stem:[\"Tasa global de SSI\" = \"Total de casos de SSI\" / \"Número total de "
 "intervenciones quirúrgicas\" × 100]"
@@ -3109,8 +4947,13 @@ msgstr ""
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
 #, fuzzy
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
-msgstr "stem:[\"Tasa de ISQ agrupada\" = \"Total de casos de ISQ observados tras los procedimientos en este grupo\" / \"Número total de procedimientos en este grupo\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgstr ""
+"stem:[\"Tasa de ISQ agrupada\" = \"Total de casos de ISQ observados tras los "
+"procedimientos en este grupo\" / \"Número total de procedimientos en este "
+"grupo\" xx 100]"
 
 #. type: Title ====
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:927
@@ -3121,14 +4964,39 @@ msgstr "Tasa de infección estandarizada"
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
 #, fuzzy
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
-msgstr "Con las tasas de infección descritas anteriormente, es posible observar en detalle los factores de riesgo y las infecciones para las 3 clases de peso al nacer.  Sin embargo, 500 g de peso al nacer es una estratificación relativamente cruda del riesgo de infección neonatal, y tampoco tiene en cuenta el hecho de que los lactantes pueden ser trasladados a otros departamentos (por ejemplo, para cirugía o a un departamento más cercano al domicilio de los padres) mucho antes de que se les dé el alta normalmente y que los días de alto riesgo de la fase de estabilización se acumularían en algunos departamentos de neonatología mientras que otros acumularían los días de bajo riesgo de los lactantes ya estabilizados.  Para tener esto en cuenta, NeoIPC calcula una tasa de infección estandarizada (TIE) , que compara las frecuencias de infección entre departamentos en función de la composición de su población de pacientes."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
+msgstr ""
+"Con las tasas de infección descritas anteriormente, es posible observar en "
+"detalle los factores de riesgo y las infecciones para las 3 clases de peso "
+"al nacer.  Sin embargo, 500 g de peso al nacer es una estratificación "
+"relativamente cruda del riesgo de infección neonatal, y tampoco tiene en "
+"cuenta el hecho de que los lactantes pueden ser trasladados a otros "
+"departamentos (por ejemplo, para cirugía o a un departamento más cercano al "
+"domicilio de los padres) mucho antes de que se les dé el alta normalmente y "
+"que los días de alto riesgo de la fase de estabilización se acumularían en "
+"algunos departamentos de neonatología mientras que otros acumularían los "
+"días de bajo riesgo de los lactantes ya estabilizados.  Para tener esto en "
+"cuenta, NeoIPC calcula una tasa de infección estandarizada (TIE) , que "
+"compara las frecuencias de infección entre departamentos en función de la "
+"composición de su población de pacientes."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:933
 #, fuzzy
 msgid "Standardized infection rates are calculated based on two factors:"
-msgstr "Las tasas de infección estandarizadas se calculan en función de dos factores:"
+msgstr ""
+"Las tasas de infección estandarizadas se calculan en función de dos factores:"
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:935
@@ -3145,38 +5013,76 @@ msgstr "Riesgo de infección para un determinado día de vida"
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
 #, fuzzy
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
-msgstr "A partir de la base de datos de referencia, se calcula el riesgo medio de ISB o neumonía para un determinado día de vida de un lactante con un determinado peso al nacer."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
+msgstr ""
+"A partir de la base de datos de referencia, se calcula el riesgo medio de "
+"ISB o neumonía para un determinado día de vida de un lactante con un "
+"determinado peso al nacer."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
 #, fuzzy
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
-msgstr "A continuación, se calcula el número de infecciones esperadas (riesgo acumulado) para un departamento sumando los riesgos medios de los lactantes y los días respectivos que pasaron en el departamento."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
+msgstr ""
+"A continuación, se calcula el número de infecciones esperadas (riesgo "
+"acumulado) para un departamento sumando los riesgos medios de los lactantes "
+"y los días respectivos que pasaron en el departamento."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
 #, fuzzy
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
-msgstr "El SIR representa la relación entre las infecciones observadas y las infecciones esperadas en un departamento y puede ofrecer una visión general del riesgo de infección en un departamento."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
+msgstr ""
+"El SIR representa la relación entre las infecciones observadas y las "
+"infecciones esperadas en un departamento y puede ofrecer una visión general "
+"del riesgo de infección en un departamento."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
 #, fuzzy
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
-msgstr "stem:[\"Tasa de infección estandarizada\" = \"Total de infecciones observadas\" / \"Total de infecciones esperadas\"] Cuando la tasa de infección estandarizada es mayor que uno, se han observado más infecciones de las que cabría esperar de su composición de pacientes en comparación con los datos de referencia."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
+msgstr ""
+"stem:[\"Tasa de infección estandarizada\" = \"Total de infecciones "
+"observadas\" / \"Total de infecciones esperadas\"] Cuando la tasa de "
+"infección estandarizada es mayor que uno, se han observado más infecciones "
+"de las que cabría esperar de su composición de pacientes en comparación con "
+"los datos de referencia."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
 #, fuzzy
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
-msgstr "Cuando la tasa de infección estandarizada es igual a uno, se ha observado el mismo número de infecciones que el que cabría esperar de la composición de los pacientes en comparación con los datos de referencia."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
+msgstr ""
+"Cuando la tasa de infección estandarizada es igual a uno, se ha observado el "
+"mismo número de infecciones que el que cabría esperar de la composición de "
+"los pacientes en comparación con los datos de referencia."
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
 #, fuzzy
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
-msgstr "Cuando la tasa de infección estandarizada es inferior a uno, se han observado menos infecciones de las que cabría esperar a partir de la composición de los pacientes en comparación con los datos de referencia."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
+msgstr ""
+"Cuando la tasa de infección estandarizada es inferior a uno, se han "
+"observado menos infecciones de las que cabría esperar a partir de la "
+"composición de los pacientes en comparación con los datos de referencia."
 
 #. type: Title ==
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:951
@@ -3193,8 +5099,11 @@ msgstr "3GCR"
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
 #, fuzzy
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
-msgstr "Patógeno gramnegativo multirresistente a cefalosporinas de 3ª generación"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
+msgstr ""
+"Patógeno gramnegativo multirresistente a cefalosporinas de 3ª generación"
 
 #. type: Labeled list
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
@@ -3725,8 +5634,12 @@ msgstr "communication@pentafoundation.org"
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
 #, fuzzy
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
-msgstr "Para saber más sobre el ensayo NeoDeco y la Red de Práctica Clínica, escriba a:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
+msgstr ""
+"Para saber más sobre el ensayo NeoDeco y la Red de Práctica Clínica, escriba "
+"a:"
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1014
@@ -3754,7 +5667,9 @@ msgstr "Lista de antibióticos"
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3765,20 +5680,30 @@ msgstr "Lista de agentes infecciosos"
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
 #, fuzzy
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
-msgstr "**Ausencia de cultivo microbiológico positivo de sangre y/o líquido cefalorraquídeo**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
+msgstr ""
+"**Ausencia de cultivo microbiológico positivo de sangre y/o líquido "
+"cefalorraquídeo**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
 #, fuzzy
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
-msgstr "**Se inició tratamiento con CINCO o más días de antibióticos intravenosos$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
+msgstr ""
+"**Se inició tratamiento con CINCO o más días de antibióticos intravenosos$$*$"
+"$**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:11
@@ -3786,8 +5711,12 @@ msgstr "**Se inició tratamiento con CINCO o más días de antibióticos intrave
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
 #, fuzzy
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
-msgstr "**El paciente presenta al menos DOS de las siguientes características clínicas o de laboratorio de infección generalizada:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
+msgstr ""
+"**El paciente presenta al menos DOS de las siguientes características "
+"clínicas o de laboratorio de infección generalizada:**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:12
@@ -3805,8 +5734,12 @@ msgstr "Inestabilidad térmica, fiebre (> 38 °C) o hipotermia (< 36,5 °C)"
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
 #, fuzzy
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
-msgstr "Episodios nuevos/más frecuentes de bradicardia (<80/min) o taquicardia inexplicada (>200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
+msgstr ""
+"Episodios nuevos/más frecuentes de bradicardia (<80/min) o taquicardia "
+"inexplicada (>200/min)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:14
@@ -3814,7 +5747,9 @@ msgstr "Episodios nuevos/más frecuentes de bradicardia (<80/min) o taquicardia 
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
 #, fuzzy
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
 msgstr ""
 "Alteración de la perfusión periférica (tiempo de relleno capilar > 3 s, "
 "manchas en la piel o diferencia de temperatura entre el centro y la "
@@ -3826,8 +5761,12 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
 #, fuzzy
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
-msgstr "Episodios nuevos/más frecuentes de apnea (>20s) o aumento de la demanda de oxígeno o del soporte ventilatorio"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
+msgstr ""
+"Episodios nuevos/más frecuentes de apnea (>20s) o aumento de la demanda de "
+"oxígeno o del soporte ventilatorio"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:16
@@ -3854,7 +5793,8 @@ msgstr "Irritabilidad, letargo, apatía o estado inestable"
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:68
 #, fuzzy
 msgid "Unexplained metabolic acidosis (base excess < −10 mmol/L; <−10 mEq/L)"
-msgstr "Acidosis metabólica inexplicable (exceso de bases < -10 mmol/L; <-10 mEq/L)"
+msgstr ""
+"Acidosis metabólica inexplicable (exceso de bases < -10 mmol/L; <-10 mEq/L)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:19
@@ -3862,8 +5802,12 @@ msgstr "Acidosis metabólica inexplicable (exceso de bases < -10 mmol/L; <-10 mE
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
 #, fuzzy
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
-msgstr "Hiperglucemia nueva e inexplicada (> 140 mg/dl; > 7,8 mmol/L) o hipoglucemia (< 40 mg/dl; <2,2 mmol/L)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgstr ""
+"Hiperglucemia nueva e inexplicada (> 140 mg/dl; > 7,8 mmol/L) o hipoglucemia "
+"(< 40 mg/dl; <2,2 mmol/L)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:20
@@ -3916,7 +5860,9 @@ msgstr "Procalcitonina ≥ 2μg/L (2 ng/mL; 200 ng/dL)"
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:75
 #, fuzzy
 msgid "I/T-Ratio > 0.2 (ratio of immature granulocytes to total granulocytes)"
-msgstr "Relación I/T > 0,2 (relación entre granulocitos inmaduros y granulocitos totales)"
+msgstr ""
+"Relación I/T > 0,2 (relación entre granulocitos inmaduros y granulocitos "
+"totales)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:26
@@ -3930,8 +5876,27 @@ msgstr "Aumento de los niveles de interleucina (IL) 6 u 8"
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
 #, fuzzy
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
-msgstr "Se inició tratamiento antibiótico durante al menos cinco días.  Se cuentan el día de la primera dosis y el día de la última dosis.  Los días en los que no se administró ninguna dosis entre la primera y la última (por ejemplo, dosis omitidas debido a niveles elevados del fármaco en la monitorización terapéutica de fármacos) se cuentan como si se hubiera administrado una dosis.  Los días posteriores a la última dosis no se cuentan, independientemente del nivel de fármaco medido o supuesto del paciente.  Si el lactante falleció, fue dado de alta o trasladado antes del final del ciclo de cinco días de antibióticos intravenosos, esta condición se cumple si el tratamiento estaba programado para cinco días o más."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
+msgstr ""
+"Se inició tratamiento antibiótico durante al menos cinco días.  Se cuentan "
+"el día de la primera dosis y el día de la última dosis.  Los días en los que "
+"no se administró ninguna dosis entre la primera y la última (por ejemplo, "
+"dosis omitidas debido a niveles elevados del fármaco en la monitorización "
+"terapéutica de fármacos) se cuentan como si se hubiera administrado una "
+"dosis.  Los días posteriores a la última dosis no se cuentan, "
+"independientemente del nivel de fármaco medido o supuesto del paciente.  Si "
+"el lactante falleció, fue dado de alta o trasladado antes del final del "
+"ciclo de cinco días de antibióticos intravenosos, esta condición se cumple "
+"si el tratamiento estaba programado para cinco días o más."
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:1
@@ -3944,13 +5909,19 @@ msgstr "ISQ incisional profunda"
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:5
 #, fuzzy
 msgid "**First symptoms occur within 30 or 90^#^ days after the operation**"
-msgstr "**Los primeros síntomas aparecen entre 30 y 90^#^ días después de la operación**"
+msgstr ""
+"**Los primeros síntomas aparecen entre 30 y 90^#^ días después de la "
+"operación**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
 #, fuzzy
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
-msgstr "**La infección afecta a los tejidos blandos profundos de la incisión (por ejemplo, las capas fasciales y musculares)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
+msgstr ""
+"**La infección afecta a los tejidos blandos profundos de la incisión (por "
+"ejemplo, las capas fasciales y musculares)**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:11
@@ -3969,26 +5940,56 @@ msgstr "Drenaje purulento de la incisión profunda."
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
 #, fuzzy
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
-msgstr "Una incisión profunda que se dehace espontáneamente, o es abierta o aspirada deliberadamente por un cirujano, médico* o médico designado"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
+msgstr ""
+"Una incisión profunda que se dehace espontáneamente, o es abierta o aspirada "
+"deliberadamente por un cirujano, médico* o médico designado"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
 #, fuzzy
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
-msgstr "Organismo(s) identificado(s) a partir de los tejidos blandos profundos de la incisión mediante un método de prueba microbiológica basado en cultivo o no basado en cultivo que se realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, cultivo/prueba de vigilancia no activa (ASC/AST)) o no se realiza un método de prueba microbiológica basado en cultivo o no basado en cultivo. Un cultivo o prueba no basada en cultivo de los tejidos blandos profundos de la incisión que tenga un resultado negativo no cumple este criterio."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
+msgstr ""
+"Organismo(s) identificado(s) a partir de los tejidos blandos profundos de la "
+"incisión mediante un método de prueba microbiológica basado en cultivo o no "
+"basado en cultivo que se realiza con fines de diagnóstico clínico o "
+"tratamiento (por ejemplo, cultivo/prueba de vigilancia no activa (ASC/AST)) "
+"o no se realiza un método de prueba microbiológica basado en cultivo o no "
+"basado en cultivo. Un cultivo o prueba no basada en cultivo de los tejidos "
+"blandos profundos de la incisión que tenga un resultado negativo no cumple "
+"este criterio."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
 #, fuzzy
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
-msgstr "El paciente presenta al menos uno de los siguientes signos o síntomas: Inestabilidad térmica, fiebre (> 38 °C) o hipotermia (< 36,5 °C); dolor o sensibilidad localizados."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
+msgstr ""
+"El paciente presenta al menos uno de los siguientes signos o síntomas: "
+"Inestabilidad térmica, fiebre (> 38 °C) o hipotermia (< 36,5 °C); dolor o "
+"sensibilidad localizados."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
 #, fuzzy
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
-msgstr "Un absceso u otra evidencia de infección que afecte a la incisión profunda y que se detecte en un examen anatómico o histopatológico macroscópico, o en una prueba de imagen."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
+msgstr ""
+"Un absceso u otra evidencia de infección que afecte a la incisión profunda y "
+"que se detecte en un examen anatómico o histopatológico macroscópico, o en "
+"una prueba de imagen."
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:25
@@ -3996,16 +5997,28 @@ msgstr "Un absceso u otra evidencia de infección que afecte a la incisión prof
 #, fuzzy
 msgid "^#^Follow-up of 90 days applies when an implant was left in place."
 msgstr ""
-"#-#-#-#-#  definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.es.adoc:25 (type Plain text)  #-#-#-#-#\n"
-"^#^Se aplica un seguimiento de 90 días cuando se ha dejado un implante en su sitio.\n"
-"#-#-#-#-#  definitions/NeoIPC-Core-Organ-Space-SSI-Definition.es.adoc:16 (type: Plain text)  #-#-#-#-#\n"
-"^#^ Se aplica un seguimiento de 90 días cuando se ha dejado un implante en su sitio."
+"#-#-#-#-#  definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.es.adoc:25 "
+"(type Plain text)  #-#-#-#-#\n"
+"^#^Se aplica un seguimiento de 90 días cuando se ha dejado un implante en su "
+"sitio.\n"
+"#-#-#-#-#  definitions/NeoIPC-Core-Organ-Space-SSI-Definition.es.adoc:16 "
+"(type: Plain text)  #-#-#-#-#\n"
+"^#^ Se aplica un seguimiento de 90 días cuando se ha dejado un implante en "
+"su sitio."
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
 #, fuzzy
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
-msgstr "*El término médico a efectos de la aplicación de los criterios de ISQ de la NHSN puede interpretarse como un cirujano, un médico especialista en enfermedades infecciosas, un médico de urgencias, otro médico del caso o una persona designada por el médico (enfermero o asistente médico)."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
+msgstr ""
+"*El término médico a efectos de la aplicación de los criterios de ISQ de la "
+"NHSN puede interpretarse como un cirujano, un médico especialista en "
+"enfermedades infecciosas, un médico de urgencias, otro médico del caso o una "
+"persona designada por el médico (enfermero o asistente médico)."
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:1
@@ -4016,8 +6029,12 @@ msgstr "Infección del torrente sanguíneo confirmada por laboratorio con un com
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
 #, fuzzy
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
-msgstr "**El mismo comensal común se recupera de al menos DOS cultivos de sangre y/o LCR CSF recogidas en distintas ocasiones**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
+msgstr ""
+"**El mismo comensal común se recupera de al menos DOS cultivos de sangre y/o "
+"LCR CSF recogidas en distintas ocasiones**"
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:25
@@ -4029,8 +6046,12 @@ msgstr "Infección del torrente sanguíneo confirmada por laboratorio con comens
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
 #, fuzzy
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
-msgstr "**Se recupera un comensal común de UNA muestra de hemocultivo y/o cultivo de LCR**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
+msgstr ""
+"**Se recupera un comensal común de UNA muestra de hemocultivo y/o cultivo de "
+"LCR**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:32
@@ -4047,14 +6068,36 @@ msgstr "Infección del torrente sanguíneo confirmada por laboratorio con comens
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
 #, fuzzy
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
-msgstr "**Se inició$$*$$ tratamiento con antibióticos intravenosos durante cinco o más días**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
+msgstr ""
+"**Se inició$$*$$ tratamiento con antibióticos intravenosos durante cinco o "
+"más días**"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
 #, fuzzy
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
-msgstr "*Se cuentan el día de la primera dosis y el día de la última dosis.  Los días en los que no se administró ninguna dosis entre la primera y la última (por ejemplo, dosis omitidas debido a niveles elevados del fármaco en la monitorización terapéutica de fármacos) se cuentan como si se hubiera administrado una dosis.  Los días posteriores a la última dosis no se cuentan, independientemente del nivel de fármaco medido o supuesto del paciente.  Si el lactante falleció, fue dado de alta o trasladado antes de finalizar el tratamiento de cinco días con antibióticos intravenosos, esta condición se cumple si el tratamiento estaba programado para cinco días o más."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
+msgstr ""
+"*Se cuentan el día de la primera dosis y el día de la última dosis.  Los "
+"días en los que no se administró ninguna dosis entre la primera y la última "
+"(por ejemplo, dosis omitidas debido a niveles elevados del fármaco en la "
+"monitorización terapéutica de fármacos) se cuentan como si se hubiera "
+"administrado una dosis.  Los días posteriores a la última dosis no se "
+"cuentan, independientemente del nivel de fármaco medido o supuesto del "
+"paciente.  Si el lactante falleció, fue dado de alta o trasladado antes de "
+"finalizar el tratamiento de cinco días con antibióticos intravenosos, esta "
+"condición se cumple si el tratamiento estaba programado para cinco días o "
+"más."
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:1
@@ -4065,8 +6108,12 @@ msgstr "Infección del torrente sanguíneo confirmada por laboratorio con patóg
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
 #, fuzzy
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
-msgstr "**Patógeno reconocido recuperado de un cultivo de sangre y/o de líquido cefalorraquídeo**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
+msgstr ""
+"**Patógeno reconocido recuperado de un cultivo de sangre y/o de líquido "
+"cefalorraquídeo**"
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:1
@@ -4077,8 +6124,12 @@ msgstr "NEC basado en síntomas"
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
 #, fuzzy
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
-msgstr "**Al menos UNO de los siguientes signos radiológicos (tecnologías de imagen: radiografía, TC, RM, ecografía):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
+msgstr ""
+"**Al menos UNO de los siguientes signos radiológicos (tecnologías de imagen: "
+"radiografía, TC, RM, ecografía):**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:8
@@ -4126,14 +6177,18 @@ msgstr "Decoloración abdominal o tono brillante/rojizo de la piel"
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
 #, fuzzy
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
-msgstr "Repetición de sangre oculta (prueba de guayaco) o visible en las heces (sin fisura anal)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgstr ""
+"Repetición de sangre oculta (prueba de guayaco) o visible en las heces (sin "
+"fisura anal)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:18
 #, fuzzy
 msgid "Increasing/pronounced vomiting (e.g. bilious or bloody)"
-msgstr "Vómitos crecientes/pronunciados (por ejemplo, biliosos o sanguinolentos)"
+msgstr ""
+"Vómitos crecientes/pronunciados (por ejemplo, biliosos o sanguinolentos)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:19
@@ -4163,7 +6218,8 @@ msgstr "Quirúrgico NEC"
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:28
 #, fuzzy
 msgid "**At least of ONE the following surgical or pathological findings:**"
-msgstr "**Al menos UNO de los siguientes hallazgos quirúrgicos o patológicos:**"
+msgstr ""
+"**Al menos UNO de los siguientes hallazgos quirúrgicos o patológicos:**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:30
@@ -4180,44 +6236,84 @@ msgstr "Órgano/espacio ISQ"
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
 #, fuzzy
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
-msgstr "**La infección afecta a cualquier parte del cuerpo más profunda que las capas fascial/muscular que se haya abierto o manipulado durante la intervención quirúrgica**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
+msgstr ""
+"**La infección afecta a cualquier parte del cuerpo más profunda que las "
+"capas fascial/muscular que se haya abierto o manipulado durante la "
+"intervención quirúrgica**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
 #, fuzzy
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
-msgstr "Drenaje purulento de un drenaje colocado en el órgano/espacio (por ejemplo, sistema cerrado de drenaje por succión, drenaje abierto, drenaje con tubo en T, drenaje guiado por TC)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
+msgstr ""
+"Drenaje purulento de un drenaje colocado en el órgano/espacio (por ejemplo, "
+"sistema cerrado de drenaje por succión, drenaje abierto, drenaje con tubo en "
+"T, drenaje guiado por TC)."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
 #, fuzzy
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
-msgstr "Organismo(s) identificado(s) a partir de líquido o tejido en el órgano/espacio mediante un método de análisis microbiológico basado o no en cultivo que se realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, cultivo/prueba de vigilancia no activa (ASC/AST))."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
+msgstr ""
+"Organismo(s) identificado(s) a partir de líquido o tejido en el órgano/"
+"espacio mediante un método de análisis microbiológico basado o no en cultivo "
+"que se realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, "
+"cultivo/prueba de vigilancia no activa (ASC/AST))."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
 #, fuzzy
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
-msgstr "Un absceso u otra evidencia de infección que afecte al órgano/espacio que se detectado en un examen anatómico o histopatológico macroscópico, o pruebas de imagen sugestivas de infección."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
+msgstr ""
+"Un absceso u otra evidencia de infección que afecte al órgano/espacio que se "
+"detectado en un examen anatómico o histopatológico macroscópico, o pruebas "
+"de imagen sugestivas de infección."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
 #, fuzzy
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
-msgstr "**Al menos UNO de los siguientes hallazgos de imagen (tecnologías de imagen: radiografía, TC, RM, ecografía) muestra nuevos cambios sugestivos de neumonía, como infiltrado, sombra, opacificación, aumento de densidad, líquido en la cavidad intrapleural o fisura interlobar**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
+msgstr ""
+"**Al menos UNO de los siguientes hallazgos de imagen (tecnologías de imagen: "
+"radiografía, TC, RM, ecografía) muestra nuevos cambios sugestivos de "
+"neumonía, como infiltrado, sombra, opacificación, aumento de densidad, "
+"líquido en la cavidad intrapleural o fisura interlobar**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
 #, fuzzy
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
-msgstr "**Nuevo inicio de asistencia respiratoria o aumento del nivel de asistencia respiratoria existente durante ≥ 2 días$$*$$ tras al menos 2 días de estabilidad o mejoría**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
+msgstr ""
+"**Nuevo inicio de asistencia respiratoria o aumento del nivel de asistencia "
+"respiratoria existente durante ≥ 2 días$$*$$ tras al menos 2 días de "
+"estabilidad o mejoría**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:11
 #, fuzzy
 msgid "**At least FOUR of the following clinical or laboratory criteria:**"
-msgstr "**Al menos CUATRO de los siguientes criterios clínicos o de laboratorio:**"
+msgstr ""
+"**Al menos CUATRO de los siguientes criterios clínicos o de laboratorio:**"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:12
@@ -4228,8 +6324,12 @@ msgstr "Organismos identificados^+^ de las vías respiratorias"
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
 #, fuzzy
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
-msgstr "Taquipnea nueva o más frecuente (>60/min) o apnea nueva o más frecuente (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
+msgstr ""
+"Taquipnea nueva o más frecuente (>60/min) o apnea nueva o más frecuente (> "
+"20 s)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:15
@@ -4240,7 +6340,9 @@ msgstr "Aspirado traqueal purulento"
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
 #, fuzzy
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
 msgstr ""
 "Síntomas nuevos o más frecuentes de dificultad respiratoria (retracción, "
 "aleteo nasal, gruñidos, hundimiento torácico)"
@@ -4254,14 +6356,21 @@ msgstr "Inestabilidad térmica o fiebre (>38 °C) o hipotermia (<36,5 °C)"
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
 #, fuzzy
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
-msgstr "Aumento de la secreción respiratoria (necesidad de aspiración endotraqueal más frecuente)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
+msgstr ""
+"Aumento de la secreción respiratoria (necesidad de aspiración endotraqueal "
+"más frecuente)"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
 #, fuzzy
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
-msgstr "PCR > 10 mg/L (> 1 mg/dL) o aumento de los niveles de interleucina (IL) 6 u 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgstr ""
+"PCR > 10 mg/L (> 1 mg/dL) o aumento de los niveles de interleucina (IL) 6 u "
+"8^#^"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:20
@@ -4272,13 +6381,19 @@ msgstr "Relación I/T > 0,2"
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
 #, fuzzy
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
-msgstr "Nuevo inicio de asistencia respiratoria o aumento del nivel existente de asistencia respiratoria que no mejora en menos de dos días:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
+msgstr ""
+"Nuevo inicio de asistencia respiratoria o aumento del nivel existente de "
+"asistencia respiratoria que no mejora en menos de dos días:"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
 #, fuzzy
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
 msgstr ""
 "Aumento de la necesidad de una FiO~2~ ≥ 0,25 (25 puntos) en un plazo de 24 "
 "horas (se deben tener en cuenta los valores mínimos diarios de FiO~2~)"
@@ -4286,38 +6401,63 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
 #, fuzzy
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
 msgstr "…that no mejora en menos de 2 días: Que no mejore en menos de 2 días."
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
 #, fuzzy
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
-msgstr "…después de al menos 2 días de estabilidad o mejoría: Se requiere un periodo basal de estabilidad o mejoría de al menos dos días antes de que se produzca la condición anterior."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
+msgstr ""
+"…después de al menos 2 días de estabilidad o mejoría: Se requiere un periodo "
+"basal de estabilidad o mejoría de al menos dos días antes de que se produzca "
+"la condición anterior."
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
 #, fuzzy
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
-msgstr "^+^Se ha identificado al menos un organismo (véase a continuación) en las vías respiratorias mediante un cultivo o un método de prueba microbiológica no basado en cultivos que se realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, cultivo/prueba de vigilancia NO activa (ASC/AST)):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgstr ""
+"^+^Se ha identificado al menos un organismo (véase a continuación) en las "
+"vías respiratorias mediante un cultivo o un método de prueba microbiológica "
+"no basado en cultivos que se realiza con fines de diagnóstico clínico o "
+"tratamiento (por ejemplo, cultivo/prueba de vigilancia NO activa (ASC/AST)):"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:41
 #, fuzzy
 msgid "Fungal or bacterial pathogen from secretions of lower respiratory tract"
-msgstr "Patógeno fúngico o bacteriano de secreciones del tracto respiratorio inferior"
+msgstr ""
+"Patógeno fúngico o bacteriano de secreciones del tracto respiratorio inferior"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
 #, fuzzy
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
-msgstr "Gen, antígeno o anticuerpo viral de secreciones del tracto respiratorio superior o inferior (por ejemplo, EIA, FAMA, ensayo en vial de concha, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgstr ""
+"Gen, antígeno o anticuerpo viral de secreciones del tracto respiratorio "
+"superior o inferior (por ejemplo, EIA, FAMA, ensayo en vial de concha, PCR)"
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
 #, fuzzy
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
-msgstr "^#^La interleucina debe utilizarse como parámetro cuando se cumplan las especificaciones del laboratorio para un valor patológico."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
+msgstr ""
+"^#^La interleucina debe utilizarse como parámetro cuando se cumplan las "
+"especificaciones del laboratorio para un valor patológico."
 
 #. type: Block title
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:1
@@ -4335,8 +6475,11 @@ msgstr ""
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
 #, fuzzy
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
-msgstr "**La infección afecta únicamente a la piel y al tejido subcutáneo de la incisión.**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
+msgstr ""
+"**La infección afecta únicamente a la piel y al tejido subcutáneo de la "
+"incisión.**"
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:13
@@ -4347,56 +6490,113 @@ msgstr "Secreción purulenta de la incisión superficial."
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
 #, fuzzy
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
-msgstr "Organismos identificados a partir de una muestra obtenida de forma aséptica de la incisión superficial o del tejido subcutáneo mediante un método de análisis microbiológico basado en cultivo o sin cultivo, que se realiza con fines de diagnóstico clínico o tratamiento (por ejemplo, no se incluye el cultivo/análisis de vigilancia activa [ASC/AST])."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
+msgstr ""
+"Organismos identificados a partir de una muestra obtenida de forma aséptica "
+"de la incisión superficial o del tejido subcutáneo mediante un método de "
+"análisis microbiológico basado en cultivo o sin cultivo, que se realiza con "
+"fines de diagnóstico clínico o tratamiento (por ejemplo, no se incluye el "
+"cultivo/análisis de vigilancia activa [ASC/AST])."
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
 #, fuzzy
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
-msgstr "Incisión superficial realizada deliberadamente por un cirujano, médico* o profesional sanitario designado, sin que se realicen cultivos ni pruebas basadas en cultivos de la incisión superficial o del tejido subcutáneo. Un cultivo o una prueba basada en cultivos de los tejidos blandos profundos de la incisión con resultado negativo no cumple este criterio."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
+msgstr ""
+"Incisión superficial realizada deliberadamente por un cirujano, médico* o "
+"profesional sanitario designado, sin que se realicen cultivos ni pruebas "
+"basadas en cultivos de la incisión superficial o del tejido subcutáneo. Un "
+"cultivo o una prueba basada en cultivos de los tejidos blandos profundos de "
+"la incisión con resultado negativo no cumple este criterio."
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
 #, fuzzy
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
-msgstr "El paciente presenta al menos uno de los siguientes signos o síntomas: dolor o sensibilidad localizados, hinchazón localizada, eritema o calor."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
+msgstr ""
+"El paciente presenta al menos uno de los siguientes signos o síntomas: dolor "
+"o sensibilidad localizados, hinchazón localizada, eritema o calor."
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
 #, fuzzy
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
-msgstr "Diagnóstico de una infección superficial de la herida quirúrgica por parte de un médico* o un profesional sanitario designado."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
+msgstr ""
+"Diagnóstico de una infección superficial de la herida quirúrgica por parte "
+"de un médico* o un profesional sanitario designado."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
 #, fuzzy
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
-msgstr "*El término «médico», a efectos de la aplicación de los criterios del NeoIPC SSI, puede interpretarse como cirujano, médico especialista en enfermedades infecciosas, médico de urgencias, otro médico que participe en el caso o persona designada por el médico (enfermero practicante o asistente médico)."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
+msgstr ""
+"*El término «médico», a efectos de la aplicación de los criterios del NeoIPC "
+"SSI, puede interpretarse como cirujano, médico especialista en enfermedades "
+"infecciosas, médico de urgencias, otro médico que participe en el caso o "
+"persona designada por el médico (enfermero practicante o asistente médico)."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
 #, fuzzy
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
-msgstr "Los siguientes no se consideran criterios para cumplir con la definición de ISQ incisional superficial"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
+msgstr ""
+"Los siguientes no se consideran criterios para cumplir con la definición de "
+"ISQ incisional superficial"
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
 #, fuzzy
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
-msgstr "El diagnóstico/tratamiento de la celulitis (enrojecimiento/calor/hinchazón), por sí solo, no cumple el criterio «d» de ISQ incisional superficial."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
+msgstr ""
+"El diagnóstico/tratamiento de la celulitis (enrojecimiento/calor/hinchazón), "
+"por sí solo, no cumple el criterio «d» de ISQ incisional superficial."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
 #, fuzzy
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
-msgstr "Un absceso de sutura aislado (inflamación mínima y secreción limitada a los puntos de penetración de la sutura)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
+msgstr ""
+"Un absceso de sutura aislado (inflamación mínima y secreción limitada a los "
+"puntos de penetración de la sutura)."
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
 #, fuzzy
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
-msgstr "Una herida punzante localizada o una infección en el lugar de la punción. Nota: El lugar de inserción del trocar laparoscópico se considera una incisión quirúrgica y no una herida punzante. Si un cirujano utiliza el lugar de inserción del trocar laparoscópico para colocar un drenaje al final de una intervención, esto se considera una incisión quirúrgica."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
+msgstr ""
+"Una herida punzante localizada o una infección en el lugar de la punción. "
+"Nota: El lugar de inserción del trocar laparoscópico se considera una "
+"incisión quirúrgica y no una herida punzante. Si un cirujano utiliza el "
+"lugar de inserción del trocar laparoscópico para colocar un drenaje al final "
+"de una intervención, esto se considera una incisión quirúrgica."
 
 #. type: Content of: <root><data><value>
 #: doc/protocol/resx/NeoIPC-Core-Decision-Flow.resx:10
@@ -4435,5 +6635,13 @@ msgid "Ineligible"
 msgstr "No elegible"
 
 #, fuzzy
-#~ msgid "Sepsis is classified as either culture negative or culture proven in the NeoIPC surveillance system.  As well, culture proven sepsis (LCBSI = \"Laboratory-confirmed bloodstream infection\") is classified into two categories based on the culture result."
-#~ msgstr "La sepsis se clasifica como cultivo negativo o cultivo comprobado en el sistema de vigilancia NeoIPC.  Asimismo, la sepsis probada por cultivo (LCBSI = \"Laboratory-confirmed bloodstream infection\") se clasifica en dos categorías en función del resultado del cultivo."
+#~ msgid ""
+#~ "Sepsis is classified as either culture negative or culture proven in the "
+#~ "NeoIPC surveillance system.  As well, culture proven sepsis (LCBSI = "
+#~ "\"Laboratory-confirmed bloodstream infection\") is classified into two "
+#~ "categories based on the culture result."
+#~ msgstr ""
+#~ "La sepsis se clasifica como cultivo negativo o cultivo comprobado en el "
+#~ "sistema de vigilancia NeoIPC.  Asimismo, la sepsis probada por cultivo "
+#~ "(LCBSI = \"Laboratory-confirmed bloodstream infection\") se clasifica en "
+#~ "dos categorías en función del resultado del cultivo."

--- a/po/documentation.et.po
+++ b/po/documentation.et.po
@@ -31,22 +31,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -63,12 +92,27 @@ msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
 msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
 msgstr ""
 
 #. type: Title ===
@@ -79,17 +123,30 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
@@ -99,22 +156,31 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
 msgstr ""
 
 #. type: Title ===
@@ -125,7 +191,24 @@ msgstr ""
 
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
 msgstr ""
 
 #. type: Title ===
@@ -136,22 +219,43 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -171,7 +275,9 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -191,22 +297,42 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
 msgstr ""
 
 #. type: Title ==
@@ -223,7 +349,16 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
 msgstr ""
 
 #. type: Title ====
@@ -234,7 +369,22 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
 msgstr ""
 
 #. type: Title ====
@@ -245,22 +395,49 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
 msgstr ""
 
 #. type: Title ===
@@ -271,47 +448,80 @@ msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
 msgstr ""
 
 #. type: Title ==
@@ -322,17 +532,41 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
 msgstr ""
 
 #. type: #data-collection
@@ -347,7 +581,9 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
 msgstr ""
 
 #. type: #data-collection
@@ -357,7 +593,10 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
 msgstr ""
 
 #. type: #data-collection
@@ -386,17 +625,25 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
 msgstr ""
 
 #. type: Title ===
@@ -427,7 +674,10 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
 msgstr ""
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -464,7 +714,9 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
 msgstr ""
 
 #. type: Title ===
@@ -475,7 +727,10 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
 msgstr ""
 
 #. type: Title ====
@@ -486,27 +741,57 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
 msgstr ""
 
 #. type: Block title
@@ -550,12 +835,25 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
 msgstr ""
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -581,17 +879,41 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
 msgstr ""
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -617,7 +939,17 @@ msgstr ""
 
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
 msgstr ""
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -643,27 +975,68 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
 msgstr ""
 
 #. type: Title ====
@@ -674,7 +1047,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -701,7 +1079,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -721,7 +1104,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -748,7 +1136,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -774,7 +1167,11 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
@@ -804,7 +1201,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
 msgstr ""
 
 #. type: Block title
@@ -829,12 +1231,18 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
 msgstr ""
 
 #. type: Title ====
@@ -845,17 +1253,26 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
 msgstr ""
 
 #. type: loweralpha
@@ -884,7 +1301,9 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
 msgstr ""
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -916,17 +1335,38 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
@@ -951,7 +1391,9 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
 msgstr ""
 
 #. type: Block title
@@ -975,32 +1417,65 @@ msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
 msgstr ""
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
@@ -1056,17 +1531,26 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1076,17 +1560,21 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1104,7 +1592,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1130,7 +1621,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
 msgstr ""
 
 #. type: Title ====
@@ -1141,7 +1634,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1152,7 +1647,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1163,7 +1660,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
 msgstr ""
 
 #. type: Title ==
@@ -1174,12 +1674,22 @@ msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
 msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1213,12 +1723,21 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
 msgstr ""
 
 #. type: Labeled list
@@ -1229,7 +1748,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
 msgstr ""
 
 #. type: Labeled list
@@ -1245,7 +1767,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
 msgstr ""
 
 #. type: Labeled list
@@ -1256,7 +1783,13 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
 msgstr ""
 
 #. type: Labeled list
@@ -1267,7 +1800,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
 msgstr ""
 
 #. type: Labeled list
@@ -1278,7 +1816,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
@@ -1341,7 +1882,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
 msgstr ""
 
 #. type: Title ====
@@ -1358,7 +1902,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
 msgstr ""
 
 #. type: Labeled list
@@ -1369,12 +1915,16 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
@@ -1395,7 +1945,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
 msgstr ""
 
 #. type: Title ====
@@ -1412,7 +1965,8 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
-msgid "The day the data collection and follow-up for the patient has been stopped."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
 msgstr ""
 
 #. type: Labeled list
@@ -1444,7 +1998,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
 msgstr ""
 
 #. type: Labeled list
@@ -1455,7 +2012,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1466,7 +2025,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1477,7 +2038,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1488,7 +2051,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1499,7 +2065,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
 msgstr ""
 
 #. type: Labeled list
@@ -1510,7 +2079,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
 msgstr ""
 
 #. type: Labeled list
@@ -1521,7 +2092,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
 msgstr ""
 
 #. type: Labeled list
@@ -1532,7 +2106,17 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
 msgstr ""
 
 #. type: Labeled list
@@ -1543,7 +2127,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
 msgstr ""
 
 #. type: Title ===
@@ -1571,7 +2157,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
 msgstr ""
 
 #. type: Labeled list
@@ -1582,7 +2171,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
 msgstr ""
 
 #. type: Labeled list
@@ -1593,7 +2187,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
 msgstr ""
 
 #. type: Labeled list
@@ -1604,7 +2201,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
 msgstr ""
 
 #. type: Labeled list
@@ -1615,7 +2214,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
 msgstr ""
 
 #. type: Labeled list
@@ -1626,7 +2229,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
 msgstr ""
 
 #. type: Labeled list
@@ -1637,7 +2246,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
 msgstr ""
 
 #. type: Labeled list
@@ -1648,7 +2262,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
 msgstr ""
 
 #. type: Labeled list
@@ -1659,7 +2277,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
 msgstr ""
 
 #. type: Labeled list
@@ -1670,7 +2292,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
 msgstr ""
 
 #. type: Labeled list
@@ -1714,7 +2339,8 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
-msgid "A patient with severe systemic disease that is a constant threat to life"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
 msgstr ""
 
 #. type: Labeled list
@@ -1730,7 +2356,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 msgstr ""
 
 #. type: Labeled list
@@ -1762,7 +2390,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -1773,7 +2403,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
@@ -1800,12 +2432,21 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
 msgstr ""
 
 #. type: Labeled list
@@ -1816,7 +2457,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
 msgstr ""
 
 #. type: Labeled list
@@ -1827,7 +2471,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
 msgstr ""
 
 #. type: Labeled list
@@ -1838,7 +2486,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
 msgstr ""
 
 #. type: Block title
@@ -1849,27 +2503,44 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
@@ -1879,12 +2550,19 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
 msgstr ""
 
 #. type: Title ===
@@ -1907,7 +2585,9 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
 msgstr ""
 
 #. type: Labeled list
@@ -1918,7 +2598,12 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
 msgstr ""
 
 #. type: Labeled list
@@ -1949,17 +2634,25 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -1969,17 +2662,22 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
 msgstr ""
 
 #. type: Labeled list
@@ -1990,22 +2688,36 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -2027,12 +2739,17 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2047,12 +2764,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2118,7 +2838,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2129,7 +2853,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2140,7 +2866,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
 msgstr ""
 
 #. type: Labeled list
@@ -2151,7 +2879,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
 msgstr ""
 
 #. type: Labeled list
@@ -2162,7 +2898,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2173,7 +2911,16 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Labeled list
@@ -2184,7 +2931,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2195,7 +2946,10 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
 msgstr ""
 
 #. type: Labeled list
@@ -2206,7 +2960,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
 msgstr ""
 
 #. type: Title ====
@@ -2246,7 +3002,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
 msgstr ""
 
 #. type: Plain text
@@ -2261,13 +3019,17 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
 msgstr ""
 
 #. type: Labeled list
@@ -2289,12 +3051,18 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
 msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2316,7 +3084,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2327,7 +3099,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2349,7 +3123,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2360,7 +3138,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2371,7 +3151,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Labeled list
@@ -2382,7 +3166,10 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
 msgstr ""
 
 #. type: Labeled list
@@ -2410,7 +3197,10 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -2422,12 +3212,17 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
 msgstr ""
 
 #. type: Labeled list
@@ -2438,27 +3233,44 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
 msgstr ""
 
 #. type: Labeled list
@@ -2469,7 +3281,11 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Title ==
@@ -2480,12 +3296,17 @@ msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
 msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
 msgstr ""
 
 #. type: #data-analysis
@@ -2522,27 +3343,38 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2553,47 +3385,76 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2604,22 +3465,33 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: Title ===
@@ -2636,22 +3508,32 @@ msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: Title ====
@@ -2662,42 +3544,70 @@ msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2708,7 +3618,18 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
@@ -2728,32 +3649,50 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
 msgstr ""
 
 #. type: Title ==
@@ -2770,7 +3709,9 @@ msgstr ""
 
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
 msgstr ""
 
 #. type: Labeled list
@@ -3257,7 +4198,9 @@ msgstr ""
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
 msgstr ""
 
 #. type: #imprint
@@ -3283,7 +4226,9 @@ msgstr ""
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3294,17 +4239,23 @@ msgstr ""
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3312,7 +4263,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:8
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3329,7 +4282,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:42
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3337,7 +4292,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3345,7 +4302,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:12
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3377,7 +4336,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:16
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3437,7 +4398,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3454,7 +4424,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3471,22 +4443,36 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
 msgstr ""
 
 #. type: Plain text
@@ -3497,7 +4483,11 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: Block title
@@ -3508,7 +4498,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
 msgstr ""
 
 #. type: Block title
@@ -3520,7 +4512,9 @@ msgstr ""
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3536,12 +4530,22 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3552,7 +4556,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: Block title
@@ -3563,7 +4569,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3604,7 +4612,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3651,32 +4660,51 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3691,7 +4719,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3701,7 +4731,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3711,12 +4743,15 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3726,27 +4761,40 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
 msgstr ""
 
 #. type: Plain text
@@ -3756,12 +4804,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
 msgstr ""
 
 #. type: Block title
@@ -3777,7 +4829,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
 msgstr ""
 
 #. type: loweralpha
@@ -3787,47 +4840,75 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
 msgstr ""
 
 #. type: Content of: <root><data><value>

--- a/po/documentation.fr.po
+++ b/po/documentation.fr.po
@@ -31,22 +31,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -63,12 +92,27 @@ msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
 msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
 msgstr ""
 
 #. type: Title ===
@@ -79,17 +123,30 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
@@ -99,22 +156,31 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
 msgstr ""
 
 #. type: Title ===
@@ -125,7 +191,24 @@ msgstr ""
 
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
 msgstr ""
 
 #. type: Title ===
@@ -136,22 +219,43 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -171,7 +275,9 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -191,22 +297,42 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
 msgstr ""
 
 #. type: Title ==
@@ -223,7 +349,16 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
 msgstr ""
 
 #. type: Title ====
@@ -234,7 +369,22 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
 msgstr ""
 
 #. type: Title ====
@@ -245,22 +395,49 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
 msgstr ""
 
 #. type: Title ===
@@ -271,47 +448,80 @@ msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
 msgstr ""
 
 #. type: Title ==
@@ -322,17 +532,41 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
 msgstr ""
 
 #. type: #data-collection
@@ -347,7 +581,9 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
 msgstr ""
 
 #. type: #data-collection
@@ -357,7 +593,10 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
 msgstr ""
 
 #. type: #data-collection
@@ -386,17 +625,25 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
 msgstr ""
 
 #. type: Title ===
@@ -427,7 +674,10 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
 msgstr ""
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -464,7 +714,9 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
 msgstr ""
 
 #. type: Title ===
@@ -475,7 +727,10 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
 msgstr ""
 
 #. type: Title ====
@@ -486,27 +741,57 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
 msgstr ""
 
 #. type: Block title
@@ -550,12 +835,25 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
 msgstr ""
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -581,17 +879,41 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
 msgstr ""
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -617,7 +939,17 @@ msgstr ""
 
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
 msgstr ""
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -643,27 +975,68 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
 msgstr ""
 
 #. type: Title ====
@@ -674,7 +1047,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -701,7 +1079,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -721,7 +1104,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -748,7 +1136,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -774,7 +1167,11 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
@@ -804,7 +1201,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
 msgstr ""
 
 #. type: Block title
@@ -829,12 +1231,18 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
 msgstr ""
 
 #. type: Title ====
@@ -845,17 +1253,26 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
 msgstr ""
 
 #. type: loweralpha
@@ -884,7 +1301,9 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
 msgstr ""
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -916,17 +1335,38 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
@@ -951,7 +1391,9 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
 msgstr ""
 
 #. type: Block title
@@ -975,32 +1417,65 @@ msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
 msgstr ""
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
@@ -1056,17 +1531,26 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1076,17 +1560,21 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1104,7 +1592,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1130,7 +1621,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
 msgstr ""
 
 #. type: Title ====
@@ -1141,7 +1634,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1152,7 +1647,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1163,7 +1660,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
 msgstr ""
 
 #. type: Title ==
@@ -1174,12 +1674,22 @@ msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
 msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1213,12 +1723,21 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
 msgstr ""
 
 #. type: Labeled list
@@ -1229,7 +1748,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
 msgstr ""
 
 #. type: Labeled list
@@ -1245,7 +1767,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
 msgstr ""
 
 #. type: Labeled list
@@ -1256,7 +1783,13 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
 msgstr ""
 
 #. type: Labeled list
@@ -1267,7 +1800,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
 msgstr ""
 
 #. type: Labeled list
@@ -1278,7 +1816,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
@@ -1341,7 +1882,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
 msgstr ""
 
 #. type: Title ====
@@ -1358,7 +1902,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
 msgstr ""
 
 #. type: Labeled list
@@ -1369,12 +1915,16 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
@@ -1395,7 +1945,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
 msgstr ""
 
 #. type: Title ====
@@ -1412,7 +1965,8 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
-msgid "The day the data collection and follow-up for the patient has been stopped."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
 msgstr ""
 
 #. type: Labeled list
@@ -1444,7 +1998,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
 msgstr ""
 
 #. type: Labeled list
@@ -1455,7 +2012,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1466,7 +2025,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1477,7 +2038,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1488,7 +2051,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1499,7 +2065,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
 msgstr ""
 
 #. type: Labeled list
@@ -1510,7 +2079,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
 msgstr ""
 
 #. type: Labeled list
@@ -1521,7 +2092,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
 msgstr ""
 
 #. type: Labeled list
@@ -1532,7 +2106,17 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
 msgstr ""
 
 #. type: Labeled list
@@ -1543,7 +2127,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
 msgstr ""
 
 #. type: Title ===
@@ -1571,7 +2157,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
 msgstr ""
 
 #. type: Labeled list
@@ -1582,7 +2171,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
 msgstr ""
 
 #. type: Labeled list
@@ -1593,7 +2187,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
 msgstr ""
 
 #. type: Labeled list
@@ -1604,7 +2201,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
 msgstr ""
 
 #. type: Labeled list
@@ -1615,7 +2214,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
 msgstr ""
 
 #. type: Labeled list
@@ -1626,7 +2229,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
 msgstr ""
 
 #. type: Labeled list
@@ -1637,7 +2246,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
 msgstr ""
 
 #. type: Labeled list
@@ -1648,7 +2262,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
 msgstr ""
 
 #. type: Labeled list
@@ -1659,7 +2277,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
 msgstr ""
 
 #. type: Labeled list
@@ -1670,7 +2292,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
 msgstr ""
 
 #. type: Labeled list
@@ -1714,7 +2339,8 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
-msgid "A patient with severe systemic disease that is a constant threat to life"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
 msgstr ""
 
 #. type: Labeled list
@@ -1730,7 +2356,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 msgstr ""
 
 #. type: Labeled list
@@ -1762,7 +2390,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -1773,7 +2403,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
@@ -1800,12 +2432,21 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
 msgstr ""
 
 #. type: Labeled list
@@ -1816,7 +2457,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
 msgstr ""
 
 #. type: Labeled list
@@ -1827,7 +2471,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
 msgstr ""
 
 #. type: Labeled list
@@ -1838,7 +2486,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
 msgstr ""
 
 #. type: Block title
@@ -1849,27 +2503,44 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
@@ -1879,12 +2550,19 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
 msgstr ""
 
 #. type: Title ===
@@ -1907,7 +2585,9 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
 msgstr ""
 
 #. type: Labeled list
@@ -1918,7 +2598,12 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
 msgstr ""
 
 #. type: Labeled list
@@ -1949,17 +2634,25 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -1969,17 +2662,22 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
 msgstr ""
 
 #. type: Labeled list
@@ -1990,22 +2688,36 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -2027,12 +2739,17 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2047,12 +2764,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2118,7 +2838,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2129,7 +2853,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2140,7 +2866,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
 msgstr ""
 
 #. type: Labeled list
@@ -2151,7 +2879,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
 msgstr ""
 
 #. type: Labeled list
@@ -2162,7 +2898,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2173,7 +2911,16 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Labeled list
@@ -2184,7 +2931,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2195,7 +2946,10 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
 msgstr ""
 
 #. type: Labeled list
@@ -2206,7 +2960,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
 msgstr ""
 
 #. type: Title ====
@@ -2246,7 +3002,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
 msgstr ""
 
 #. type: Plain text
@@ -2261,13 +3019,17 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
 msgstr ""
 
 #. type: Labeled list
@@ -2289,12 +3051,18 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
 msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2316,7 +3084,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2327,7 +3099,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2349,7 +3123,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2360,7 +3138,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2371,7 +3151,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Labeled list
@@ -2382,7 +3166,10 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
 msgstr ""
 
 #. type: Labeled list
@@ -2410,7 +3197,10 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -2422,12 +3212,17 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
 msgstr ""
 
 #. type: Labeled list
@@ -2438,27 +3233,44 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
 msgstr ""
 
 #. type: Labeled list
@@ -2469,7 +3281,11 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Title ==
@@ -2480,12 +3296,17 @@ msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
 msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
 msgstr ""
 
 #. type: #data-analysis
@@ -2522,27 +3343,38 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2553,47 +3385,76 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2604,22 +3465,33 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: Title ===
@@ -2636,22 +3508,32 @@ msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: Title ====
@@ -2662,42 +3544,70 @@ msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2708,7 +3618,18 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
@@ -2728,32 +3649,50 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
 msgstr ""
 
 #. type: Title ==
@@ -2770,7 +3709,9 @@ msgstr ""
 
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
 msgstr ""
 
 #. type: Labeled list
@@ -3257,7 +4198,9 @@ msgstr ""
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
 msgstr ""
 
 #. type: #imprint
@@ -3283,7 +4226,9 @@ msgstr ""
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3294,17 +4239,23 @@ msgstr ""
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3312,7 +4263,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:8
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3329,7 +4282,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:42
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3337,7 +4292,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3345,7 +4302,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:12
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3377,7 +4336,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:16
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3437,7 +4398,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3454,7 +4424,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3471,22 +4443,36 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
 msgstr ""
 
 #. type: Plain text
@@ -3497,7 +4483,11 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: Block title
@@ -3508,7 +4498,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
 msgstr ""
 
 #. type: Block title
@@ -3520,7 +4512,9 @@ msgstr ""
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3536,12 +4530,22 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3552,7 +4556,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: Block title
@@ -3563,7 +4569,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3604,7 +4612,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3651,32 +4660,51 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3691,7 +4719,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3701,7 +4731,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3711,12 +4743,15 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3726,27 +4761,40 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
 msgstr ""
 
 #. type: Plain text
@@ -3756,12 +4804,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
 msgstr ""
 
 #. type: Block title
@@ -3777,7 +4829,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
 msgstr ""
 
 #. type: loweralpha
@@ -3787,47 +4840,75 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
 msgstr ""
 
 #. type: Content of: <root><data><value>

--- a/po/documentation.it.po
+++ b/po/documentation.it.po
@@ -31,22 +31,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -63,12 +92,27 @@ msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
 msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
 msgstr ""
 
 #. type: Title ===
@@ -79,17 +123,30 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
@@ -99,22 +156,31 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
 msgstr ""
 
 #. type: Title ===
@@ -125,7 +191,24 @@ msgstr ""
 
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
 msgstr ""
 
 #. type: Title ===
@@ -136,22 +219,43 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -171,7 +275,9 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -191,22 +297,42 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
 msgstr ""
 
 #. type: Title ==
@@ -223,7 +349,16 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
 msgstr ""
 
 #. type: Title ====
@@ -234,7 +369,22 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
 msgstr ""
 
 #. type: Title ====
@@ -245,22 +395,49 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
 msgstr ""
 
 #. type: Title ===
@@ -271,47 +448,80 @@ msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
 msgstr ""
 
 #. type: Title ==
@@ -322,17 +532,41 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
 msgstr ""
 
 #. type: #data-collection
@@ -347,7 +581,9 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
 msgstr ""
 
 #. type: #data-collection
@@ -357,7 +593,10 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
 msgstr ""
 
 #. type: #data-collection
@@ -386,17 +625,25 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
 msgstr ""
 
 #. type: Title ===
@@ -427,7 +674,10 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
 msgstr ""
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -464,7 +714,9 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
 msgstr ""
 
 #. type: Title ===
@@ -475,7 +727,10 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
 msgstr ""
 
 #. type: Title ====
@@ -486,27 +741,57 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
 msgstr ""
 
 #. type: Block title
@@ -550,12 +835,25 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
 msgstr ""
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -581,17 +879,41 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
 msgstr ""
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -617,7 +939,17 @@ msgstr ""
 
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
 msgstr ""
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -643,27 +975,68 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
 msgstr ""
 
 #. type: Title ====
@@ -674,7 +1047,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -701,7 +1079,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -721,7 +1104,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -748,7 +1136,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -774,7 +1167,11 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
@@ -804,7 +1201,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
 msgstr ""
 
 #. type: Block title
@@ -829,12 +1231,18 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
 msgstr ""
 
 #. type: Title ====
@@ -845,17 +1253,26 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
 msgstr ""
 
 #. type: loweralpha
@@ -884,7 +1301,9 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
 msgstr ""
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -916,17 +1335,38 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
@@ -951,7 +1391,9 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
 msgstr ""
 
 #. type: Block title
@@ -975,32 +1417,65 @@ msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
 msgstr ""
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
@@ -1056,17 +1531,26 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1076,17 +1560,21 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1104,7 +1592,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1130,7 +1621,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
 msgstr ""
 
 #. type: Title ====
@@ -1141,7 +1634,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1152,7 +1647,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1163,7 +1660,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
 msgstr ""
 
 #. type: Title ==
@@ -1174,12 +1674,22 @@ msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
 msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1213,12 +1723,21 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
 msgstr ""
 
 #. type: Labeled list
@@ -1229,7 +1748,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
 msgstr ""
 
 #. type: Labeled list
@@ -1245,7 +1767,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
 msgstr ""
 
 #. type: Labeled list
@@ -1256,7 +1783,13 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
 msgstr ""
 
 #. type: Labeled list
@@ -1267,7 +1800,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
 msgstr ""
 
 #. type: Labeled list
@@ -1278,7 +1816,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
@@ -1341,7 +1882,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
 msgstr ""
 
 #. type: Title ====
@@ -1358,7 +1902,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
 msgstr ""
 
 #. type: Labeled list
@@ -1369,12 +1915,16 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
@@ -1395,7 +1945,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
 msgstr ""
 
 #. type: Title ====
@@ -1412,7 +1965,8 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
-msgid "The day the data collection and follow-up for the patient has been stopped."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
 msgstr ""
 
 #. type: Labeled list
@@ -1444,7 +1998,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
 msgstr ""
 
 #. type: Labeled list
@@ -1455,7 +2012,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1466,7 +2025,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1477,7 +2038,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1488,7 +2051,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1499,7 +2065,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
 msgstr ""
 
 #. type: Labeled list
@@ -1510,7 +2079,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
 msgstr ""
 
 #. type: Labeled list
@@ -1521,7 +2092,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
 msgstr ""
 
 #. type: Labeled list
@@ -1532,7 +2106,17 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
 msgstr ""
 
 #. type: Labeled list
@@ -1543,7 +2127,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
 msgstr ""
 
 #. type: Title ===
@@ -1571,7 +2157,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
 msgstr ""
 
 #. type: Labeled list
@@ -1582,7 +2171,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
 msgstr ""
 
 #. type: Labeled list
@@ -1593,7 +2187,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
 msgstr ""
 
 #. type: Labeled list
@@ -1604,7 +2201,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
 msgstr ""
 
 #. type: Labeled list
@@ -1615,7 +2214,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
 msgstr ""
 
 #. type: Labeled list
@@ -1626,7 +2229,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
 msgstr ""
 
 #. type: Labeled list
@@ -1637,7 +2246,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
 msgstr ""
 
 #. type: Labeled list
@@ -1648,7 +2262,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
 msgstr ""
 
 #. type: Labeled list
@@ -1659,7 +2277,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
 msgstr ""
 
 #. type: Labeled list
@@ -1670,7 +2292,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
 msgstr ""
 
 #. type: Labeled list
@@ -1714,7 +2339,8 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
-msgid "A patient with severe systemic disease that is a constant threat to life"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
 msgstr ""
 
 #. type: Labeled list
@@ -1730,7 +2356,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 msgstr ""
 
 #. type: Labeled list
@@ -1762,7 +2390,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -1773,7 +2403,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
@@ -1800,12 +2432,21 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
 msgstr ""
 
 #. type: Labeled list
@@ -1816,7 +2457,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
 msgstr ""
 
 #. type: Labeled list
@@ -1827,7 +2471,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
 msgstr ""
 
 #. type: Labeled list
@@ -1838,7 +2486,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
 msgstr ""
 
 #. type: Block title
@@ -1849,27 +2503,44 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
@@ -1879,12 +2550,19 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
 msgstr ""
 
 #. type: Title ===
@@ -1907,7 +2585,9 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
 msgstr ""
 
 #. type: Labeled list
@@ -1918,7 +2598,12 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
 msgstr ""
 
 #. type: Labeled list
@@ -1949,17 +2634,25 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -1969,17 +2662,22 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
 msgstr ""
 
 #. type: Labeled list
@@ -1990,22 +2688,36 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -2027,12 +2739,17 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2047,12 +2764,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2118,7 +2838,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2129,7 +2853,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2140,7 +2866,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
 msgstr ""
 
 #. type: Labeled list
@@ -2151,7 +2879,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
 msgstr ""
 
 #. type: Labeled list
@@ -2162,7 +2898,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2173,7 +2911,16 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Labeled list
@@ -2184,7 +2931,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2195,7 +2946,10 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
 msgstr ""
 
 #. type: Labeled list
@@ -2206,7 +2960,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
 msgstr ""
 
 #. type: Title ====
@@ -2246,7 +3002,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
 msgstr ""
 
 #. type: Plain text
@@ -2261,13 +3019,17 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
 msgstr ""
 
 #. type: Labeled list
@@ -2289,12 +3051,18 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
 msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2316,7 +3084,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2327,7 +3099,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2349,7 +3123,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2360,7 +3138,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2371,7 +3151,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Labeled list
@@ -2382,7 +3166,10 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
 msgstr ""
 
 #. type: Labeled list
@@ -2410,7 +3197,10 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -2422,12 +3212,17 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
 msgstr ""
 
 #. type: Labeled list
@@ -2438,27 +3233,44 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
 msgstr ""
 
 #. type: Labeled list
@@ -2469,7 +3281,11 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Title ==
@@ -2480,12 +3296,17 @@ msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
 msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
 msgstr ""
 
 #. type: #data-analysis
@@ -2522,27 +3343,38 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2553,47 +3385,76 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2604,22 +3465,33 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: Title ===
@@ -2636,22 +3508,32 @@ msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: Title ====
@@ -2662,42 +3544,70 @@ msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2708,7 +3618,18 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
@@ -2728,32 +3649,50 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
 msgstr ""
 
 #. type: Title ==
@@ -2770,7 +3709,9 @@ msgstr ""
 
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
 msgstr ""
 
 #. type: Labeled list
@@ -3257,7 +4198,9 @@ msgstr ""
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
 msgstr ""
 
 #. type: #imprint
@@ -3283,7 +4226,9 @@ msgstr ""
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3294,17 +4239,23 @@ msgstr ""
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3312,7 +4263,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:8
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3329,7 +4282,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:42
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3337,7 +4292,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3345,7 +4302,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:12
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3377,7 +4336,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:16
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3437,7 +4398,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3454,7 +4424,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3471,22 +4443,36 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
 msgstr ""
 
 #. type: Plain text
@@ -3497,7 +4483,11 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: Block title
@@ -3508,7 +4498,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
 msgstr ""
 
 #. type: Block title
@@ -3520,7 +4512,9 @@ msgstr ""
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3536,12 +4530,22 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3552,7 +4556,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: Block title
@@ -3563,7 +4569,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3604,7 +4612,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3651,32 +4660,51 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3691,7 +4719,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3701,7 +4731,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3711,12 +4743,15 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3726,27 +4761,40 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
 msgstr ""
 
 #. type: Plain text
@@ -3756,12 +4804,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
 msgstr ""
 
 #. type: Block title
@@ -3777,7 +4829,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
 msgstr ""
 
 #. type: loweralpha
@@ -3787,47 +4840,75 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
 msgstr ""
 
 #. type: Content of: <root><data><value>

--- a/po/documentation.ne.po
+++ b/po/documentation.ne.po
@@ -30,22 +30,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -62,12 +91,27 @@ msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
 msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
 msgstr ""
 
 #. type: Title ===
@@ -78,17 +122,30 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
@@ -98,22 +155,31 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
 msgstr ""
 
 #. type: Title ===
@@ -124,7 +190,24 @@ msgstr ""
 
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
 msgstr ""
 
 #. type: Title ===
@@ -135,22 +218,43 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -170,7 +274,9 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -190,22 +296,42 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
 msgstr ""
 
 #. type: Title ==
@@ -222,7 +348,16 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
 msgstr ""
 
 #. type: Title ====
@@ -233,7 +368,22 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
 msgstr ""
 
 #. type: Title ====
@@ -244,22 +394,49 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
 msgstr ""
 
 #. type: Title ===
@@ -270,47 +447,80 @@ msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
 msgstr ""
 
 #. type: Title ==
@@ -321,17 +531,41 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
 msgstr ""
 
 #. type: #data-collection
@@ -346,7 +580,9 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
 msgstr ""
 
 #. type: #data-collection
@@ -356,7 +592,10 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
 msgstr ""
 
 #. type: #data-collection
@@ -385,17 +624,25 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
 msgstr ""
 
 #. type: Title ===
@@ -426,7 +673,10 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
 msgstr ""
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -463,7 +713,9 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
 msgstr ""
 
 #. type: Title ===
@@ -474,7 +726,10 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
 msgstr ""
 
 #. type: Title ====
@@ -485,27 +740,57 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
 msgstr ""
 
 #. type: Block title
@@ -549,12 +834,25 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
 msgstr ""
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -580,17 +878,41 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
 msgstr ""
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -616,7 +938,17 @@ msgstr ""
 
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
 msgstr ""
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -642,27 +974,68 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
 msgstr ""
 
 #. type: Title ====
@@ -673,7 +1046,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -700,7 +1078,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -720,7 +1103,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -747,7 +1135,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -773,7 +1166,11 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
@@ -803,7 +1200,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
 msgstr ""
 
 #. type: Block title
@@ -828,12 +1230,18 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
 msgstr ""
 
 #. type: Title ====
@@ -844,17 +1252,26 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
 msgstr ""
 
 #. type: loweralpha
@@ -883,7 +1300,9 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
 msgstr ""
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -915,17 +1334,38 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
@@ -950,7 +1390,9 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
 msgstr ""
 
 #. type: Block title
@@ -974,32 +1416,65 @@ msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
 msgstr ""
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
@@ -1055,17 +1530,26 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1075,17 +1559,21 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1103,7 +1591,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1129,7 +1620,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
 msgstr ""
 
 #. type: Title ====
@@ -1140,7 +1633,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1151,7 +1646,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1162,7 +1659,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
 msgstr ""
 
 #. type: Title ==
@@ -1173,12 +1673,22 @@ msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
 msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1212,12 +1722,21 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
 msgstr ""
 
 #. type: Labeled list
@@ -1228,7 +1747,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
 msgstr ""
 
 #. type: Labeled list
@@ -1244,7 +1766,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
 msgstr ""
 
 #. type: Labeled list
@@ -1255,7 +1782,13 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
 msgstr ""
 
 #. type: Labeled list
@@ -1266,7 +1799,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
 msgstr ""
 
 #. type: Labeled list
@@ -1277,7 +1815,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
@@ -1340,7 +1881,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
 msgstr ""
 
 #. type: Title ====
@@ -1357,7 +1901,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
 msgstr ""
 
 #. type: Labeled list
@@ -1368,12 +1914,16 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
@@ -1394,7 +1944,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
 msgstr ""
 
 #. type: Title ====
@@ -1411,7 +1964,8 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
-msgid "The day the data collection and follow-up for the patient has been stopped."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
 msgstr ""
 
 #. type: Labeled list
@@ -1443,7 +1997,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
 msgstr ""
 
 #. type: Labeled list
@@ -1454,7 +2011,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1465,7 +2024,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1476,7 +2037,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1487,7 +2050,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1498,7 +2064,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
 msgstr ""
 
 #. type: Labeled list
@@ -1509,7 +2078,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
 msgstr ""
 
 #. type: Labeled list
@@ -1520,7 +2091,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
 msgstr ""
 
 #. type: Labeled list
@@ -1531,7 +2105,17 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
 msgstr ""
 
 #. type: Labeled list
@@ -1542,7 +2126,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
 msgstr ""
 
 #. type: Title ===
@@ -1570,7 +2156,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
 msgstr ""
 
 #. type: Labeled list
@@ -1581,7 +2170,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
 msgstr ""
 
 #. type: Labeled list
@@ -1592,7 +2186,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
 msgstr ""
 
 #. type: Labeled list
@@ -1603,7 +2200,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
 msgstr ""
 
 #. type: Labeled list
@@ -1614,7 +2213,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
 msgstr ""
 
 #. type: Labeled list
@@ -1625,7 +2228,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
 msgstr ""
 
 #. type: Labeled list
@@ -1636,7 +2245,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
 msgstr ""
 
 #. type: Labeled list
@@ -1647,7 +2261,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
 msgstr ""
 
 #. type: Labeled list
@@ -1658,7 +2276,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
 msgstr ""
 
 #. type: Labeled list
@@ -1669,7 +2291,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
 msgstr ""
 
 #. type: Labeled list
@@ -1713,7 +2338,8 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
-msgid "A patient with severe systemic disease that is a constant threat to life"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
 msgstr ""
 
 #. type: Labeled list
@@ -1729,7 +2355,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 msgstr ""
 
 #. type: Labeled list
@@ -1761,7 +2389,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -1772,7 +2402,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
@@ -1799,12 +2431,21 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
 msgstr ""
 
 #. type: Labeled list
@@ -1815,7 +2456,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
 msgstr ""
 
 #. type: Labeled list
@@ -1826,7 +2470,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
 msgstr ""
 
 #. type: Labeled list
@@ -1837,7 +2485,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
 msgstr ""
 
 #. type: Block title
@@ -1848,27 +2502,44 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
@@ -1878,12 +2549,19 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
 msgstr ""
 
 #. type: Title ===
@@ -1906,7 +2584,9 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
 msgstr ""
 
 #. type: Labeled list
@@ -1917,7 +2597,12 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
 msgstr ""
 
 #. type: Labeled list
@@ -1948,17 +2633,25 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -1968,17 +2661,22 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
 msgstr ""
 
 #. type: Labeled list
@@ -1989,22 +2687,36 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -2026,12 +2738,17 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2046,12 +2763,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2117,7 +2837,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2128,7 +2852,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2139,7 +2865,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
 msgstr ""
 
 #. type: Labeled list
@@ -2150,7 +2878,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
 msgstr ""
 
 #. type: Labeled list
@@ -2161,7 +2897,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2172,7 +2910,16 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Labeled list
@@ -2183,7 +2930,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2194,7 +2945,10 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
 msgstr ""
 
 #. type: Labeled list
@@ -2205,7 +2959,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
 msgstr ""
 
 #. type: Title ====
@@ -2245,7 +3001,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
 msgstr ""
 
 #. type: Plain text
@@ -2260,13 +3018,17 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
 msgstr ""
 
 #. type: Labeled list
@@ -2288,12 +3050,18 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
 msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2315,7 +3083,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2326,7 +3098,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2348,7 +3122,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2359,7 +3137,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2370,7 +3150,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Labeled list
@@ -2381,7 +3165,10 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
 msgstr ""
 
 #. type: Labeled list
@@ -2409,7 +3196,10 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -2421,12 +3211,17 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
 msgstr ""
 
 #. type: Labeled list
@@ -2437,27 +3232,44 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
 msgstr ""
 
 #. type: Labeled list
@@ -2468,7 +3280,11 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Title ==
@@ -2479,12 +3295,17 @@ msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
 msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
 msgstr ""
 
 #. type: #data-analysis
@@ -2521,27 +3342,38 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2552,47 +3384,76 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2603,22 +3464,33 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: Title ===
@@ -2635,22 +3507,32 @@ msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: Title ====
@@ -2661,42 +3543,70 @@ msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2707,7 +3617,18 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
@@ -2727,32 +3648,50 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
 msgstr ""
 
 #. type: Title ==
@@ -2769,7 +3708,9 @@ msgstr ""
 
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
 msgstr ""
 
 #. type: Labeled list
@@ -3256,7 +4197,9 @@ msgstr ""
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
 msgstr ""
 
 #. type: #imprint
@@ -3282,7 +4225,9 @@ msgstr ""
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3293,17 +4238,23 @@ msgstr ""
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3311,7 +4262,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:8
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3328,7 +4281,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:42
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3336,7 +4291,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3344,7 +4301,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:12
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3376,7 +4335,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:16
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3436,7 +4397,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3453,7 +4423,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3470,22 +4442,36 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
 msgstr ""
 
 #. type: Plain text
@@ -3496,7 +4482,11 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: Block title
@@ -3507,7 +4497,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
 msgstr ""
 
 #. type: Block title
@@ -3519,7 +4511,9 @@ msgstr ""
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3535,12 +4529,22 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3551,7 +4555,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: Block title
@@ -3562,7 +4568,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3603,7 +4611,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3650,32 +4659,51 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3690,7 +4718,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3700,7 +4730,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3710,12 +4742,15 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3725,27 +4760,40 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
 msgstr ""
 
 #. type: Plain text
@@ -3755,12 +4803,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
 msgstr ""
 
 #. type: Block title
@@ -3776,7 +4828,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
 msgstr ""
 
 #. type: loweralpha
@@ -3786,47 +4839,75 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
 msgstr ""
 
 #. type: Content of: <root><data><value>

--- a/po/documentation.tr.po
+++ b/po/documentation.tr.po
@@ -31,22 +31,51 @@ msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:10
-msgid "The text of this protocol is © The NeoIPC Project Consortium and is licensed under the Creative Commons https://creativecommons.org/licenses/by/4.0/[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list appendices are as follows:"
+msgid ""
+"The text of this protocol is © The NeoIPC Project Consortium and is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by/4.0/"
+"[Attribution 4.0 International (CC BY 4.0)] licence. Its two reference-list "
+"appendices are as follows:"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:12
-msgid "The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from the WHO https://www.who.int/publications/i/item/2021-aware-classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/2021.04), extended with systemic substances not in the AWaRe list. As an adaptation of the ShareAlike-licensed AWaRe classification it is licensed under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] licence. The ATC codes and group names it carries are reproduced verbatim from the WHO Collaborating Centre for Drug Statistics Methodology https://www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance names are International Nonproprietary Names."
+msgid ""
+"The *<<appendix-list-of-antibiotics>>* is a NeoIPC compilation derived from "
+"the WHO https://www.who.int/publications/i/item/2021-aware-"
+"classification[AWaRe classification of antibiotics, 2021] (WHO/MHP/HPS/EML/"
+"2021.04), extended with systemic substances not in the AWaRe list. As an "
+"adaptation of the ShareAlike-licensed AWaRe classification it is licensed "
+"under the Creative Commons https://creativecommons.org/licenses/by-nc-sa/3.0/"
+"igo/[Attribution-NonCommercial-ShareAlike 3.0 IGO (CC BY-NC-SA 3.0 IGO)] "
+"licence. The ATC codes and group names it carries are reproduced verbatim "
+"from the WHO Collaborating Centre for Drug Statistics Methodology https://"
+"www.whocc.no/[ATC/DDD index] (© World Health Organization); the substance "
+"names are International Nonproprietary Names."
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:14
-msgid "The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names and their taxonomic classification, compiled from the CDC https://www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only taxonomic facts, which are not subject to copyright, and is provided under this protocol's CC BY 4.0 licence with attribution to those sources. (The full infectious-agent ontology in the source repository, which incorporates more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
+msgid ""
+"The *<<appendix-list-of-list-of-infectious-agents>>* lists organism names "
+"and their taxonomic classification, compiled from the CDC https://"
+"www.cdc.gov/nhsn/index.html[NHSN Organism List], the https://lpsn.dsmz.de/"
+"[List of Prokaryotic names with Standing in Nomenclature (LPSN)], https://"
+"www.mycobank.org/[MycoBank] and the https://ictv.global/taxonomy/"
+"[International Committee on Taxonomy of Viruses (ICTV)]. It reproduces only "
+"taxonomic facts, which are not subject to copyright, and is provided under "
+"this protocol's CC BY 4.0 licence with attribution to those sources. (The "
+"full infectious-agent ontology in the source repository, which incorporates "
+"more than nomenclature, is separately licensed CC BY-NC-ND 4.0.)"
 msgstr ""
 
 #. type: #licensing-and-attribution
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:16
-msgid "Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF **as a whole** may be used and shared for **non-commercial purposes only**, and any adaptation of that list must be shared under the same terms (ShareAlike)."
+msgid ""
+"Because the List of Antibiotics is CC BY-NC-SA 3.0 IGO, the compiled PDF "
+"**as a whole** may be used and shared for **non-commercial purposes only**, "
+"and any adaptation of that list must be shared under the same terms "
+"(ShareAlike)."
 msgstr ""
 
 #. type: Title ==
@@ -63,12 +92,27 @@ msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:24
-msgid "This document is the surveillance protocol for the core module of the NeoIPC surveillance which covers surveillance of nosocomial infections in Very Low Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit for the surveillance of healthcare-associated infections (HAI) in neonatology that we developed within the NeoIPC project.  If you want to perform surveillance of early-onset infections or of healthcare-associated infections in infants with a birth weight above 1500 g and a gestational age greater than 32 weeks, the toolkit provides additional methods that are covered in separate protocols."
+msgid ""
+"This document is the surveillance protocol for the core module of the NeoIPC "
+"surveillance which covers surveillance of nosocomial infections in Very Low "
+"Birth Weight (VLBW)/ Very Preterm (VPT) Infants.  It is part of a toolkit "
+"for the surveillance of healthcare-associated infections (HAI) in "
+"neonatology that we developed within the NeoIPC project.  If you want to "
+"perform surveillance of early-onset infections or of healthcare-associated "
+"infections in infants with a birth weight above 1500 g and a gestational age "
+"greater than 32 weeks, the toolkit provides additional methods that are "
+"covered in separate protocols."
 msgstr ""
 
 #. type: #introduction-what-are-you-reading-here
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:27
-msgid "This protocol provides methodological reference and support for HAI surveillance in neonatal departments or for those planning to develop an HAI surveillance programme.  By adhering to the methods and definitions we specify here, you can ensure that the surveillance data you generate is comparable to the reference data in the NeoIPC project, even if you are not actively participating in the project."
+msgid ""
+"This protocol provides methodological reference and support for HAI "
+"surveillance in neonatal departments or for those planning to develop an HAI "
+"surveillance programme.  By adhering to the methods and definitions we "
+"specify here, you can ensure that the surveillance data you generate is "
+"comparable to the reference data in the NeoIPC project, even if you are not "
+"actively participating in the project."
 msgstr ""
 
 #. type: Title ===
@@ -79,17 +123,30 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:32
-msgid "Within the NeoIPC project, we want to support you with infection prevention and control (IPC) interventions and strategies in your neonatal intensive care unit, especially if you observe a high prevalence of hospital-acquired infections or multidrug-resistant (MDR) bacteria.  We are an international team of clinicians and scientists from 13 collaborating partner institutions with a proven record in the areas of neonatal intensive care, neonatal infection, infection prevention and control (IPC), implementation science, microbiology, and surveillance, who collaborate in this project to achieve two overarching goals:"
+msgid ""
+"Within the NeoIPC project, we want to support you with infection prevention "
+"and control (IPC) interventions and strategies in your neonatal intensive "
+"care unit, especially if you observe a high prevalence of hospital-acquired "
+"infections or multidrug-resistant (MDR) bacteria.  We are an international "
+"team of clinicians and scientists from 13 collaborating partner institutions "
+"with a proven record in the areas of neonatal intensive care, neonatal "
+"infection, infection prevention and control (IPC), implementation science, "
+"microbiology, and surveillance, who collaborate in this project to achieve "
+"two overarching goals:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:34
-msgid "Develop and implement an innovative approach towards the evaluation of IPC interventions in neonatology via:"
+msgid ""
+"Develop and implement an innovative approach towards the evaluation of IPC "
+"interventions in neonatology via:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:35
-msgid "Robust assessment of the effectiveness of interventions in a randomised controlled trial (RCT)"
+msgid ""
+"Robust assessment of the effectiveness of interventions in a randomised "
+"controlled trial (RCT)"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
@@ -99,22 +156,31 @@ msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:37
-msgid "Generate widely relevant and globally transferable outputs to improve IPC in neonatal care through:"
+msgid ""
+"Generate widely relevant and globally transferable outputs to improve IPC in "
+"neonatal care through:"
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:38
-msgid "Formation of a clinical practice network to support the implementation of IPC in neonatal care, including a variety of practice settings like neonatal intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
+msgid ""
+"Formation of a clinical practice network to support the implementation of "
+"IPC in neonatal care, including a variety of practice settings like neonatal "
+"intensive care unit (NICU), high care, special care, and kangaroo care (KC)."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:39
-msgid "Development of an open structure for targeted surveillance of IPC processes and outcomes across a large variety of settings."
+msgid ""
+"Development of an open structure for targeted surveillance of IPC processes "
+"and outcomes across a large variety of settings."
 msgstr ""
 
 #. type: #introduction-what-is-the-neo-ipc-project
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:41
-msgid "This project has received funding from the European Union’s Horizon 2020 research and innovation programme under grant agreement No. 965328."
+msgid ""
+"This project has received funding from the European Union’s Horizon 2020 "
+"research and innovation programme under grant agreement No. 965328."
 msgstr ""
 
 #. type: Title ===
@@ -125,7 +191,24 @@ msgstr ""
 
 #. type: #introduction-background
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:50
-msgid "Worldwide, neonates and especially preterm infants are among the patient groups with the highest incidence of nosocomial infections.  Some of these infections can be prevented by infection-prevention measures, which must be implemented in each individual neonatal department and adapted to the specific infection risks of the patients.  In many hospitals in Europe and worldwide, healthcare professionals do not have good data to assess the burden of healthcare-associated infections and the risk factors contributing to their development or to evaluate the effectiveness of infection prevention interventions.  Support for surveillance of healthcare-associated infections in neonates or reference data for benchmarking is not available in most countries.  Where national and supranational data collection systems exist, they frequently have a broad approach that is limited in its ability to assess the situation with respect to infection prevention and control.  In the short term, we aim to improve this situation by providing those interested in IPC surveillance in neonatology with tools and methods to get started, and in the longer term by potentially contributing to the formation of regional surveillance infrastructures."
+msgid ""
+"Worldwide, neonates and especially preterm infants are among the patient "
+"groups with the highest incidence of nosocomial infections.  Some of these "
+"infections can be prevented by infection-prevention measures, which must be "
+"implemented in each individual neonatal department and adapted to the "
+"specific infection risks of the patients.  In many hospitals in Europe and "
+"worldwide, healthcare professionals do not have good data to assess the "
+"burden of healthcare-associated infections and the risk factors contributing "
+"to their development or to evaluate the effectiveness of infection "
+"prevention interventions.  Support for surveillance of healthcare-associated "
+"infections in neonates or reference data for benchmarking is not available "
+"in most countries.  Where national and supranational data collection systems "
+"exist, they frequently have a broad approach that is limited in its ability "
+"to assess the situation with respect to infection prevention and control.  "
+"In the short term, we aim to improve this situation by providing those "
+"interested in IPC surveillance in neonatology with tools and methods to get "
+"started, and in the longer term by potentially contributing to the formation "
+"of regional surveillance infrastructures."
 msgstr ""
 
 #. type: Title ===
@@ -136,22 +219,43 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:55
-msgid "If you want to start collecting data using the NeoIPC surveillance methods and tools, you can just do so without asking us for permission or paying any fees.  All manuals and tools are free to use, and you can start using them right away if you think they will assist in quality improvement for infection control in your department."
+msgid ""
+"If you want to start collecting data using the NeoIPC surveillance methods "
+"and tools, you can just do so without asking us for permission or paying any "
+"fees.  All manuals and tools are free to use, and you can start using them "
+"right away if you think they will assist in quality improvement for "
+"infection control in your department."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:58
-msgid "By starting with paper forms and performing calculations with pen and paper or by using a spreadsheet, you have a very low barrier of entry, and it may even help you to gain a thorough understanding of the calculations that are performed internally by the more advanced tools.  If you want to keep things running effectively over an extended period and you have the necessary resources, you may want to benefit from those tools by using the advanced surveillance software locally or by participating in NeoIPC or a regional surveillance network based on its methods."
+msgid ""
+"By starting with paper forms and performing calculations with pen and paper "
+"or by using a spreadsheet, you have a very low barrier of entry, and it may "
+"even help you to gain a thorough understanding of the calculations that are "
+"performed internally by the more advanced tools.  If you want to keep things "
+"running effectively over an extended period and you have the necessary "
+"resources, you may want to benefit from those tools by using the advanced "
+"surveillance software locally or by participating in NeoIPC or a regional "
+"surveillance network based on its methods."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:62
-msgid "For long-term success in surveillance of nosocomial infections, collecting data and producing reliable and comparable information in your department over a long period of time will be crucial.  In order to facilitate the collection of such data, you may want to contribute data to the NeoIPC surveillance network.  This data could be used to generate reports and benchmark your neonatal department’s infection rates against others."
+msgid ""
+"For long-term success in surveillance of nosocomial infections, collecting "
+"data and producing reliable and comparable information in your department "
+"over a long period of time will be crucial.  In order to facilitate the "
+"collection of such data, you may want to contribute data to the NeoIPC "
+"surveillance network.  This data could be used to generate reports and "
+"benchmark your neonatal department’s infection rates against others."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:64
-msgid "If you collect and submit data, and are responsible for quality improvement, it is essential that you have a clear understanding of the following:"
+msgid ""
+"If you collect and submit data, and are responsible for quality improvement, "
+"it is essential that you have a clear understanding of the following:"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -171,7 +275,9 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:69
-msgid "Data security and data privacy (protection of information that might be used to identify a patient outside of your department or hospital)"
+msgid ""
+"Data security and data privacy (protection of information that might be used "
+"to identify a patient outside of your department or hospital)"
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
@@ -191,22 +297,42 @@ msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:75
-msgid "You should make sure that the whole data collection team in your centre accept the data definitions contained in this protocol and submit their data accordingly.  To be able to generate up-to-date reference reports on a regular schedule, NeoIPC requires participants to regularly submit data via the web-based interface and to ensure that their software and hardware systems meet the minimum requirements."
+msgid ""
+"You should make sure that the whole data collection team in your centre "
+"accept the data definitions contained in this protocol and submit their data "
+"accordingly.  To be able to generate up-to-date reference reports on a "
+"regular schedule, NeoIPC requires participants to regularly submit data via "
+"the web-based interface and to ensure that their software and hardware "
+"systems meet the minimum requirements."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:79
-msgid "Your center's policies and procedures must ensure patient privacy and data security.  It is important to protect patients' personal information and other information that can lead to their identification in accordance with the laws and policies applicable to your center.  Do not send patient personal information to the NeoIPC network."
+msgid ""
+"Your center's policies and procedures must ensure patient privacy and data "
+"security.  It is important to protect patients' personal information and "
+"other information that can lead to their identification in accordance with "
+"the laws and policies applicable to your center.  Do not send patient "
+"personal information to the NeoIPC network."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:81
-msgid "We will ensure to keep the disaggregated data submitted by each department strictly confidential and provide you with regular standardized and stratified reference reports that contain aggregated data so that no individual patient or department can be identified."
+msgid ""
+"We will ensure to keep the disaggregated data submitted by each department "
+"strictly confidential and provide you with regular standardized and "
+"stratified reference reports that contain aggregated data so that no "
+"individual patient or department can be identified."
 msgstr ""
 
 #. type: #introduction-advice-for-use-and-requirements-for-participation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:84
-msgid "To help you navigate and better utilize the tools provided, we offer surveillance manuals, datasheets and training materials at https://neoipc.org/surveillance/.  While our resources for personal interaction are limited, we will also try to support your team if you send your questions to neoipc-support@charite.de."
+msgid ""
+"To help you navigate and better utilize the tools provided, we offer "
+"surveillance manuals, datasheets and training materials at https://"
+"neoipc.org/surveillance/.  While our resources for personal interaction are "
+"limited, we will also try to support your team if you send your questions to "
+"neoipc-support@charite.de."
 msgstr ""
 
 #. type: Title ==
@@ -223,7 +349,16 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:92
-msgid "Routine surveillance of healthcare-associated infections is not research but is rather a way of performing quality assurance which is part of regular patient care.  Because of this, the associated data collection is typically covered by the regular hospital treatment contracts or special legislation that mandates it and does not need explicit consent from the affected patients or their legal guardians.  Nevertheless, you should make sure that this applies in your country before starting to collect any data and in addition adhere to some universal minimum standards that should apply irrespective of the legal framework."
+msgid ""
+"Routine surveillance of healthcare-associated infections is not research but "
+"is rather a way of performing quality assurance which is part of regular "
+"patient care.  Because of this, the associated data collection is typically "
+"covered by the regular hospital treatment contracts or special legislation "
+"that mandates it and does not need explicit consent from the affected "
+"patients or their legal guardians.  Nevertheless, you should make sure that "
+"this applies in your country before starting to collect any data and in "
+"addition adhere to some universal minimum standards that should apply "
+"irrespective of the legal framework."
 msgstr ""
 
 #. type: Title ====
@@ -234,7 +369,22 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-patient-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:100
-msgid "Healthcare information is among the most private categories of information about humans in most cultures and should be handled with special care.  When information that can lead to the identification of an individual patient is stored or transmitted, this should generally happen in a way that no unauthorized third party can access it.  While this is usually very clear for typical human identifiers like the combination of family name, given name, and birth date, in the case of neonates even a very rare birth weight or gestational age may lead to the identification of an individual patient if combined with enough other information like birth date or the hospital the patient is treated in.  Think about this special phenomenon whenever you publish data or information that results from your surveillance-related activities or transmit it to a system that is not approved by your hospital.  This may even apply to an externally maintained NeoIPC surveillance software if there are no contracts that govern the data processing and ownership."
+msgid ""
+"Healthcare information is among the most private categories of information "
+"about humans in most cultures and should be handled with special care.  When "
+"information that can lead to the identification of an individual patient is "
+"stored or transmitted, this should generally happen in a way that no "
+"unauthorized third party can access it.  While this is usually very clear "
+"for typical human identifiers like the combination of family name, given "
+"name, and birth date, in the case of neonates even a very rare birth weight "
+"or gestational age may lead to the identification of an individual patient "
+"if combined with enough other information like birth date or the hospital "
+"the patient is treated in.  Think about this special phenomenon whenever you "
+"publish data or information that results from your surveillance-related "
+"activities or transmit it to a system that is not approved by your "
+"hospital.  This may even apply to an externally maintained NeoIPC "
+"surveillance software if there are no contracts that govern the data "
+"processing and ownership."
 msgstr ""
 
 #. type: Title ====
@@ -245,22 +395,49 @@ msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:106
-msgid "Information about hospitals generally is not protected by laws but some information may be considered as company secret and in that case, as a member of staff, you are typically not allowed to disclose it.  Whether surveillance information (“hospital infection rates”) is a company secret or should be, is a matter of extensive debate and it is understandable that patient rights organizations advocate for transparency in that regard.  Nevertheless, the publication of surveillance data can have a detrimental effect on both the perception of the treatment quality of a hospital and the ability of the surveillance team to perform surveillance in an honest and self-critical way."
+msgid ""
+"Information about hospitals generally is not protected by laws but some "
+"information may be considered as company secret and in that case, as a "
+"member of staff, you are typically not allowed to disclose it.  Whether "
+"surveillance information (“hospital infection rates”) is a company secret or "
+"should be, is a matter of extensive debate and it is understandable that "
+"patient rights organizations advocate for transparency in that regard.  "
+"Nevertheless, the publication of surveillance data can have a detrimental "
+"effect on both the perception of the treatment quality of a hospital and the "
+"ability of the surveillance team to perform surveillance in an honest and "
+"self-critical way."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:110
-msgid "Being a self-assessment tool, surveillance cannot rule out all forms of subjectivity and dishonesty and public pressure tends to shift data collection towards an overly critical assessment of infection records leading to low rates that can no longer be acted upon.  In addition to the problem of pro-forma-surveillance, there may be very legitimate or even honourable reasons for high infection rates in a hospital, like treating those who have an especially high risk for infections, that can’t be adjusted for by the means of standardization or stratification of the collected data.  These reasons are notoriously hard to communicate to the public which can lead to oversimplification and political abuse."
+msgid ""
+"Being a self-assessment tool, surveillance cannot rule out all forms of "
+"subjectivity and dishonesty and public pressure tends to shift data "
+"collection towards an overly critical assessment of infection records "
+"leading to low rates that can no longer be acted upon.  In addition to the "
+"problem of pro-forma-surveillance, there may be very legitimate or even "
+"honourable reasons for high infection rates in a hospital, like treating "
+"those who have an especially high risk for infections, that can’t be "
+"adjusted for by the means of standardization or stratification of the "
+"collected data.  These reasons are notoriously hard to communicate to the "
+"public which can lead to oversimplification and political abuse."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:112
-msgid "Since there is no easy solution for these problems NeoIPC will not disclose the identity of individual participating hospitals and make sure that publications and reports will not contain information that may lead to the identification of an individual hospital."
+msgid ""
+"Since there is no easy solution for these problems NeoIPC will not disclose "
+"the identity of individual participating hospitals and make sure that "
+"publications and reports will not contain information that may lead to the "
+"identification of an individual hospital."
 msgstr ""
 
 #. type: #data-management-data-protection-and-security-hospital-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:114
-msgid "When publishing data yourself or as a regional network you should carefully consider the potential effects of including hospital-level information and do so in close coordination with your stakeholders."
+msgid ""
+"When publishing data yourself or as a regional network you should carefully "
+"consider the potential effects of including hospital-level information and "
+"do so in close coordination with your stakeholders."
 msgstr ""
 
 #. type: Title ===
@@ -271,47 +448,80 @@ msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:118
-msgid "As stated xref:introduction-advice-for-use-and-requirements-for-participation[above], you can use the tools and methods developed by the NeoIPC project to perform surveillance of nosocomial infections in your neonatology department without submitting any information to the NeoIPC project or a regional network."
+msgid ""
+"As stated xref:introduction-advice-for-use-and-requirements-for-"
+"participation[above], you can use the tools and methods developed by the "
+"NeoIPC project to perform surveillance of nosocomial infections in your "
+"neonatology department without submitting any information to the NeoIPC "
+"project or a regional network."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:120
-msgid "If you decide to submit data, however, we strongly advise you to use the web-based reporting system we have developed based on the https://dhis2.org/[DHIS2] health information management system."
+msgid ""
+"If you decide to submit data, however, we strongly advise you to use the web-"
+"based reporting system we have developed based on the https://dhis2.org/"
+"[DHIS2] health information management system."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:122
-msgid "Since DHIS2 is a freely available open source system, you have multiple options to use it:"
+msgid ""
+"Since DHIS2 is a freely available open source system, you have multiple "
+"options to use it:"
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:124
-msgid "Deploy it locally at your hospital and use it for the NeoIPC data collection within your hospital as well as for other potential use cases."
+msgid ""
+"Deploy it locally at your hospital and use it for the NeoIPC data collection "
+"within your hospital as well as for other potential use cases."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:125
-msgid "Deploy it nationally or regionally (or use an existing national or regional deployment) to form a national or regional network of units performing surveillance."
+msgid ""
+"Deploy it nationally or regionally (or use an existing national or regional "
+"deployment) to form a national or regional network of units performing "
+"surveillance."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:126
-msgid "Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system which is currently operated by the team at the German National Reference Centre for Surveillance of Nosocomial Infections at Charité's Institute for Hygiene and Environmental Medicine."
+msgid ""
+"Use the NeoIPC project's https://neoipc.charite.de/[instance] of the system "
+"which is currently operated by the team at the German National Reference "
+"Centre for Surveillance of Nosocomial Infections at Charité's Institute for "
+"Hygiene and Environmental Medicine."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:128
-msgid "One of the advantages of using the web-based reporting system is the fact that you can use it to create standardised department-based reports at any time with a few clicks and compare them to the NeoIPC reference reports that are published annually."
+msgid ""
+"One of the advantages of using the web-based reporting system is the fact "
+"that you can use it to create standardised department-based reports at any "
+"time with a few clicks and compare them to the NeoIPC reference reports that "
+"are published annually."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:132
-msgid "To create the reference report, we carry out a calculation at a specified time every year using the data available in the NeoIPC database at that point in time.  In order to make this possible, you must have completed all data entry and addition of missing information from the previous year within 6 weeks after the end of a calendar year.  This applies to patients whose surveillance period ended in the previous year."
+msgid ""
+"To create the reference report, we carry out a calculation at a specified "
+"time every year using the data available in the NeoIPC database at that "
+"point in time.  In order to make this possible, you must have completed all "
+"data entry and addition of missing information from the previous year within "
+"6 weeks after the end of a calendar year.  This applies to patients whose "
+"surveillance period ended in the previous year."
 msgstr ""
 
 #. type: #data-management-data-submission
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:134
-msgid "If the web-based reporting system is temporarily unavailable (e.g. due to maintenance or technical problems), please use the paper-based datasheets for documentation during this period and remember to enter this data into the web platform as soon as possible once it becomes available again."
+msgid ""
+"If the web-based reporting system is temporarily unavailable (e.g. due to "
+"maintenance or technical problems), please use the paper-based datasheets "
+"for documentation during this period and remember to enter this data into "
+"the web platform as soon as possible once it becomes available again."
 msgstr ""
 
 #. type: Title ==
@@ -322,17 +532,41 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:138
-msgid "The primary aim of the methods used by NeoIPC surveillance system is to support internal quality assurance standards, to make valid statements about the frequency of healthcare-associated infections in eligible infants during their inpatient stay and to promote implementation of IPC strategies in a neonatal department."
+msgid ""
+"The primary aim of the methods used by NeoIPC surveillance system is to "
+"support internal quality assurance standards, to make valid statements about "
+"the frequency of healthcare-associated infections in eligible infants during "
+"their inpatient stay and to promote implementation of IPC strategies in a "
+"neonatal department."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:144
-msgid "Based on our experience, we anticipate that you will collect data both through the review of medical charts as well as through the interaction with the colleagues who are involved in treatment and care of the patient under surveillance.  For this reason, your data collection should ideally occur at the patient's bedside, to maximize the amount of information available (by allowing attending clinicians to clarify unclear or incomplete chart entries), and to minimize the amount of time involved in tracking down medical records once the patient has left the hospital.  You will typically identify patients with healthcare-associated infections through the regular examination of existing departmental patient records, including laboratory results.  The success of your participation in NeoIPC surveillance will very much depend on the close communication between those who perform the surveillance (typically infection prevention and control professionals) and those who care for the patient (typically neonatology professionals).  Since the collected data will ultimately need to be entered into a computer, by combining data collection and data entry into a single procedure you have the potential to save time and reduce the risk of data copying errors."
+msgid ""
+"Based on our experience, we anticipate that you will collect data both "
+"through the review of medical charts as well as through the interaction with "
+"the colleagues who are involved in treatment and care of the patient under "
+"surveillance.  For this reason, your data collection should ideally occur at "
+"the patient's bedside, to maximize the amount of information available (by "
+"allowing attending clinicians to clarify unclear or incomplete chart "
+"entries), and to minimize the amount of time involved in tracking down "
+"medical records once the patient has left the hospital.  You will typically "
+"identify patients with healthcare-associated infections through the regular "
+"examination of existing departmental patient records, including laboratory "
+"results.  The success of your participation in NeoIPC surveillance will very "
+"much depend on the close communication between those who perform the "
+"surveillance (typically infection prevention and control professionals) and "
+"those who care for the patient (typically neonatology professionals).  Since "
+"the collected data will ultimately need to be entered into a computer, by "
+"combining data collection and data entry into a single procedure you have "
+"the potential to save time and reduce the risk of data copying errors."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:146
-msgid "There are two patient data collection sheets that must be fulfilled for all eligible patients for the NeoIPC surveillance programme:"
+msgid ""
+"There are two patient data collection sheets that must be fulfilled for all "
+"eligible patients for the NeoIPC surveillance programme:"
 msgstr ""
 
 #. type: #data-collection
@@ -347,7 +581,9 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:151
-msgid "A third data collection sheet must also be fulfilled, if the patient undergoes a surgical procedure:"
+msgid ""
+"A third data collection sheet must also be fulfilled, if the patient "
+"undergoes a surgical procedure:"
 msgstr ""
 
 #. type: #data-collection
@@ -357,7 +593,10 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:155
-msgid "In addition, if an eligible infant develops a healthcare-associated infection within the NeoIPC follow-up period, the corresponding infection data collection sheet/sheets should also be fulfilled:"
+msgid ""
+"In addition, if an eligible infant develops a healthcare-associated "
+"infection within the NeoIPC follow-up period, the corresponding infection "
+"data collection sheet/sheets should also be fulfilled:"
 msgstr ""
 
 #. type: #data-collection
@@ -386,17 +625,25 @@ msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:162
-msgid "Only these infections acquired in participating neonatology departments should be recorded."
+msgid ""
+"Only these infections acquired in participating neonatology departments "
+"should be recorded."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:164
-msgid "All eligible infants should be observed until the end of the surveillance period, defined as the time when the infant dies, is transferred, or is discharged from the hospital."
+msgid ""
+"All eligible infants should be observed until the end of the surveillance "
+"period, defined as the time when the infant dies, is transferred, or is "
+"discharged from the hospital."
 msgstr ""
 
 #. type: #data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:167
-msgid "Patients are additionally followed up for SSIs in case of a surgical procedure for 30 or 90 days, depending on whether an implant is present.  For detailed information, see Surgical site infections."
+msgid ""
+"Patients are additionally followed up for SSIs in case of a surgical "
+"procedure for 30 or 90 days, depending on whether an implant is present.  "
+"For detailed information, see Surgical site infections."
 msgstr ""
 
 #. type: Title ===
@@ -427,7 +674,10 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:179
-msgid "admitted to a ward in your neonatal department **within 120 days of birth** is eligible for inclusion in the Core Module of the NeoIPC Surveillance Programme."
+msgid ""
+"admitted to a ward in your neonatal department **within 120 days of birth** "
+"is eligible for inclusion in the Core Module of the NeoIPC Surveillance "
+"Programme."
 msgstr ""
 
 #. type: Positional ($1) AttributeList argument for macro 'image'
@@ -464,7 +714,9 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:196
-msgid "An infant that is not eligible in the core module may still be eligible in another NeoIPC Surveillance module."
+msgid ""
+"An infant that is not eligible in the core module may still be eligible in "
+"another NeoIPC Surveillance module."
 msgstr ""
 
 #. type: Title ===
@@ -475,7 +727,10 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:200
-msgid "Whenever an eligible patient is admitted or readmitted to one of the wards in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted to one of the wards "
+"in your neonatology department, you should enrol this patient, preferably "
+"directly into the online reporting platform."
 msgstr ""
 
 #. type: Title ====
@@ -486,27 +741,57 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:206
-msgid "If you have a legal or other requirement to unambiguously identify patients in the online reporting platform, you must assign each patient a NeoIPC-ID at the time of enrolment.  The NeoIPC-ID is a unique random identifier, which allows you to identify that patient within your department.  This makes it possible for you to use the anonymous data stored in the system to refer to specific patients, e.g. in case of readmission or data correction, but makes it impossible for third parties to do the same."
+msgid ""
+"If you have a legal or other requirement to unambiguously identify patients "
+"in the online reporting platform, you must assign each patient a NeoIPC-ID "
+"at the time of enrolment.  The NeoIPC-ID is a unique random identifier, "
+"which allows you to identify that patient within your department.  This "
+"makes it possible for you to use the anonymous data stored in the system to "
+"refer to specific patients, e.g. in case of readmission or data correction, "
+"but makes it impossible for third parties to do the same."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:209
-msgid "Each patient can only have one NeoIPC identification number.  When a patient is discharged and then readmitted, the initial follow-up ends at the time of discharge, and a new enrolment must be made using the same NeoIPC ID number when the patient is readmitted."
+msgid ""
+"Each patient can only have one NeoIPC identification number.  When a patient "
+"is discharged and then readmitted, the initial follow-up ends at the time of "
+"discharge, and a new enrolment must be made using the same NeoIPC ID number "
+"when the patient is readmitted."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:214
-msgid "You are responsible for organizing patient data retrieval based on unique ids.  We advise you to generate a pseudonymisation list that contains NeoIPC ID (unique random numbers) together with other identifying information (name, birthdate, patient id from the hospital information system) or to note that information on the paper-based patient surveillance master data sheet.  You must store the pseudonymisation list and the paper sheets under the same conditions you store secret patient healthcare data and destroy it or the contained information in a secure way as soon as it is no longer needed.  To ensure data privacy, you should never use an identifier that is used in any context other than the NeoIPC Surveillance and that you do not fully control (e.g. do **not** use the patient id from your hospital information system, the patient name, or any unique identifier that is used elsewhere) while creating NeoIPC ID."
+msgid ""
+"You are responsible for organizing patient data retrieval based on unique "
+"ids.  We advise you to generate a pseudonymisation list that contains NeoIPC "
+"ID (unique random numbers) together with other identifying information "
+"(name, birthdate, patient id from the hospital information system) or to "
+"note that information on the paper-based patient surveillance master data "
+"sheet.  You must store the pseudonymisation list and the paper sheets under "
+"the same conditions you store secret patient healthcare data and destroy it "
+"or the contained information in a secure way as soon as it is no longer "
+"needed.  To ensure data privacy, you should never use an identifier that is "
+"used in any context other than the NeoIPC Surveillance and that you do not "
+"fully control (e.g. do **not** use the patient id from your hospital "
+"information system, the patient name, or any unique identifier that is used "
+"elsewhere) while creating NeoIPC ID."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:216
-msgid "For the generation of reference reports, NeoIPC does not need to track individual patients and the IDs you assign will not be used by NeoIPC in any way."
+msgid ""
+"For the generation of reference reports, NeoIPC does not need to track "
+"individual patients and the IDs you assign will not be used by NeoIPC in any "
+"way."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-pseudonymisation-table
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:218
-msgid "To create a pseudonymisation list you can use the templates (excel spreadsheet and paper datasheet) available in the https://neoipc.org/surveillance/resources/[resources section] of our website."
+msgid ""
+"To create a pseudonymisation list you can use the templates (excel "
+"spreadsheet and paper datasheet) available in the https://neoipc.org/"
+"surveillance/resources/[resources section] of our website."
 msgstr ""
 
 #. type: Block title
@@ -550,12 +835,25 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:236
-msgid "Whenever an eligible patient is admitted or readmitted in your neonatology department, you should enrol this patient, preferably directly into the online reporting platform.  After enrolling a patient, you must enter admission information and keep collecting the follow-up data using patient progress charts.  When the patient is discharged, transferred to another hospital or dies, you must end the follow-up for this patient, total the data recorded in the xref:patient-progress-chart[patient progress chart] and transfer it to the master data sheet or enter it directly into the online data entry system."
+msgid ""
+"Whenever an eligible patient is admitted or readmitted in your neonatology "
+"department, you should enrol this patient, preferably directly into the "
+"online reporting platform.  After enrolling a patient, you must enter "
+"admission information and keep collecting the follow-up data using patient "
+"progress charts.  When the patient is discharged, transferred to another "
+"hospital or dies, you must end the follow-up for this patient, total the "
+"data recorded in the xref:patient-progress-chart[patient progress chart] and "
+"transfer it to the master data sheet or enter it directly into the online "
+"data entry system."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-master-data-collection-sheet
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:239
-msgid "You can use the master data collection sheet to save enrolment, admission information and surveillance end data locally.  However, if you submit data to NeoIPC, the information you collect on the master data collection sheet must ultimately be entered into the online data entry system."
+msgid ""
+"You can use the master data collection sheet to save enrolment, admission "
+"information and surveillance end data locally.  However, if you submit data "
+"to NeoIPC, the information you collect on the master data collection sheet "
+"must ultimately be entered into the online data entry system."
 msgstr ""
 
 #. image::NeoIPC-Core-Master-Data-Collection-Sheet-Image.svg[Master data collection sheet for patient data collection,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -581,17 +879,41 @@ msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:253
-msgid "Eligible patients who have been enrolled in the system must be followed up using patient progress charts until death, transfer, or discharge.  Cumulative risk and protective factors such as patient days, device days, and antibiotic days are recorded in the chart, if possible on a daily basis.  This chart must be kept at your facility and to simplify data collection and patient follow-up.  You must maintain patient progress chart(s) for every eligible infant during the surveillance period.  It is possible to enter up to six different antibiotic substances in one chart.  If your patient has received more than six types of antibiotics, please use an additional chart to document them."
+msgid ""
+"Eligible patients who have been enrolled in the system must be followed up "
+"using patient progress charts until death, transfer, or discharge.  "
+"Cumulative risk and protective factors such as patient days, device days, "
+"and antibiotic days are recorded in the chart, if possible on a daily "
+"basis.  This chart must be kept at your facility and to simplify data "
+"collection and patient follow-up.  You must maintain patient progress "
+"chart(s) for every eligible infant during the surveillance period.  It is "
+"possible to enter up to six different antibiotic substances in one chart.  "
+"If your patient has received more than six types of antibiotics, please use "
+"an additional chart to document them."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:257
-msgid "When a patient is discharged, transferred to another hospital, or dies, you need to end the follow-up for that patient and the sum data in the patient progress charts will be the patient's surveillance end data.  This data must be ultimately entered into the online reporting platform under the event “surveillance end”.  You can use the master data collection sheet to save this data locally."
+msgid ""
+"When a patient is discharged, transferred to another hospital, or dies, you "
+"need to end the follow-up for that patient and the sum data in the patient "
+"progress charts will be the patient's surveillance end data.  This data must "
+"be ultimately entered into the online reporting platform under the event "
+"“surveillance end”.  You can use the master data collection sheet to save "
+"this data locally."
 msgstr ""
 
 #. type: #data-collection-patient-data-collection-patient-progress-chart
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:262
-msgid "For simplicity, patients who leave their department for up to two days (i.e., for surgery) are not considered transferred or discharged.  You should record the data for days not spent in the department upon re-admission.  If there are more than 48 hours between transfer and re-admission, you must end data collection for that patient and select \"transfer\" as the reason for the end of surveillance.  In this case, any readmission should be recorded as a new admission, and the admission type must be selected as “transferred to your centre ≥ 24h postnatal”."
+msgid ""
+"For simplicity, patients who leave their department for up to two days "
+"(i.e., for surgery) are not considered transferred or discharged.  You "
+"should record the data for days not spent in the department upon re-"
+"admission.  If there are more than 48 hours between transfer and re-"
+"admission, you must end data collection for that patient and select "
+"\"transfer\" as the reason for the end of surveillance.  In this case, any "
+"readmission should be recorded as a new admission, and the admission type "
+"must be selected as “transferred to your centre ≥ 24h postnatal”."
 msgstr ""
 
 #. image::NeoIPC-Core-Patient-Progress-Chart-Image.svg[Patient progress chart for patient data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -617,7 +939,17 @@ msgstr ""
 
 #. type: #data-collection-surgical-procedure-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:274
-msgid "Whenever surgery must happen in neonates and especially in VLBW/VPT infants it is an indicator for a complicated course and an additional risk factor for nosocomial infections and the occurrence of multidrug-resistant pathogens.  For this reason, every surgical procedure that is performed on an eligible infant is recorded in NeoIPC.  You can use the surgical procedure paper sheet for local documentation or enter the respective information directly into the reporting system.  In addition to the recording of the procedure, you need to start following up the concerned infant for surgical site infections for 30 or 90 days depending on whether an implant has been left in place during the procedure."
+msgid ""
+"Whenever surgery must happen in neonates and especially in VLBW/VPT infants "
+"it is an indicator for a complicated course and an additional risk factor "
+"for nosocomial infections and the occurrence of multidrug-resistant "
+"pathogens.  For this reason, every surgical procedure that is performed on "
+"an eligible infant is recorded in NeoIPC.  You can use the surgical "
+"procedure paper sheet for local documentation or enter the respective "
+"information directly into the reporting system.  In addition to the "
+"recording of the procedure, you need to start following up the concerned "
+"infant for surgical site infections for 30 or 90 days depending on whether "
+"an implant has been left in place during the procedure."
 msgstr ""
 
 #. image::NeoIPC-Core-Surgical-Procedure-Data-Collection-Sheet-Image.svg[Surgical procedure data collection sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -643,27 +975,68 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:282
-msgid "Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site infections in eligible patients should be documented until the end of the surveillance period."
+msgid ""
+"Hospital-acquired bloodstream infections, pneumonia, NEC, and surgical site "
+"infections in eligible patients should be documented until the end of the "
+"surveillance period."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:291
-msgid "Neonatal infections can broadly be separated into early-onset and late-onset infections.  Most of the early-onset infections result from pregnancy- and delivery-associated risks where the causative pathogens typically affect the mother in the form of microbial colonisation or infection before causing an infection in the child.  Most of the late-onset infections, in contrast, result from healthcare-associated risks, and the pathogens causing these infections typically stem from persons or inanimate surfaces that get in close contact with the infant during neonatal care.  Since only the latter are immediately actionable for the healthcare professionals working on neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset infections but tries to also support you, when trying to perform surveillance of early-onset infections.  Although a fixed time-based cut-off value does not exactly capture whether an infection was acquired from the NICU environment, there is a relatively broad international consensus that a 72-hour cut-off value serves as a good estimator for nosocomial infections in neonatology.  For this reason, infections, where the first symptoms occur within a 72-hour window after birth, should not be considered nosocomial infections and therefore should not be recorded in the NeoIPC core module.  It is, however, possible to record them separately as early-onset infections if you opt into the NeoIPC early-onset infection module.  If an infection begins before 72 hours and is clearly hospital-acquired (i.e., there are clear signs of infection on the catheter entry site) or starts after 72 hours and is clearly vertical (e.g., all transplacental infections that are not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), this cut-off value can be ignored."
+msgid ""
+"Neonatal infections can broadly be separated into early-onset and late-onset "
+"infections.  Most of the early-onset infections result from pregnancy- and "
+"delivery-associated risks where the causative pathogens typically affect the "
+"mother in the form of microbial colonisation or infection before causing an "
+"infection in the child.  Most of the late-onset infections, in contrast, "
+"result from healthcare-associated risks, and the pathogens causing these "
+"infections typically stem from persons or inanimate surfaces that get in "
+"close contact with the infant during neonatal care.  Since only the latter "
+"are immediately actionable for the healthcare professionals working on "
+"neonatology wards, NeoIPC puts a focus on those “nosocomial” late-onset "
+"infections but tries to also support you, when trying to perform "
+"surveillance of early-onset infections.  Although a fixed time-based cut-off "
+"value does not exactly capture whether an infection was acquired from the "
+"NICU environment, there is a relatively broad international consensus that a "
+"72-hour cut-off value serves as a good estimator for nosocomial infections "
+"in neonatology.  For this reason, infections, where the first symptoms occur "
+"within a 72-hour window after birth, should not be considered nosocomial "
+"infections and therefore should not be recorded in the NeoIPC core module.  "
+"It is, however, possible to record them separately as early-onset infections "
+"if you opt into the NeoIPC early-onset infection module.  If an infection "
+"begins before 72 hours and is clearly hospital-acquired (i.e., there are "
+"clear signs of infection on the catheter entry site) or starts after 72 "
+"hours and is clearly vertical (e.g., all transplacental infections that are "
+"not evident at birth, like toxoplasmosis, CMV, HIV, rubella, and syphilis), "
+"this cut-off value can be ignored."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:294
-msgid "For patients that are transferred or re-admitted to a ward in your neonatology department, there is an additional cut-off value that needs to be applied.  In this case, an infection is only considered a nosocomial infection if the day of symptom onset is greater than or equal to day 3 of the patient’s hospital stay, where the day of admission is regarded as day 1."
+msgid ""
+"For patients that are transferred or re-admitted to a ward in your "
+"neonatology department, there is an additional cut-off value that needs to "
+"be applied.  In this case, an infection is only considered a nosocomial "
+"infection if the day of symptom onset is greater than or equal to day 3 of "
+"the patient’s hospital stay, where the day of admission is regarded as day 1."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:296
-msgid "NeoIPC guidelines do not offer a strict timeframe for elements of definitions to occur but usually, all elements required to meet an infection definition usually occur within a 7-10 day timeframe with typically no more than 2-3 days between elements."
+msgid ""
+"NeoIPC guidelines do not offer a strict timeframe for elements of "
+"definitions to occur but usually, all elements required to meet an infection "
+"definition usually occur within a 7-10 day timeframe with typically no more "
+"than 2-3 days between elements."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:299
-msgid "In the presence of a previously recorded infection, when a new pathogen is isolated in the same organ system, we cannot record this as a new infection.  A minimum of 14 days and a period without any relevant symptoms of infection are required to register the same type of infection again."
+msgid ""
+"In the presence of a previously recorded infection, when a new pathogen is "
+"isolated in the same organ system, we cannot record this as a new "
+"infection.  A minimum of 14 days and a period without any relevant symptoms "
+"of infection are required to register the same type of infection again."
 msgstr ""
 
 #. type: Title ====
@@ -674,7 +1047,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-primary-sepsis-bsi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:304
-msgid "If an eligible infant develops a hospital-acquired primary sepsis/bloodstream infection according to the NeoIPC surveillance criteria (see Infection Definitions: Primary sepsis/bloodstream infection) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired primary sepsis/"
+"bloodstream infection according to the NeoIPC surveillance criteria (see "
+"Infection Definitions: Primary sepsis/bloodstream infection) during the "
+"surveillance period, you should record and submit the required data using "
+"the data collection sheet below and/or via the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Primary-Sepsis-BSI-Reporting-Sheet-Image.svg[Primary sepsis/BSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -701,7 +1079,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:313
-msgid "If an eligible infant develops a necrotizing enterocolitis according to the NeoIPC surveillance criteria (see Infection Definitions: Necrotising Enterocolitis (NEC)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a necrotizing enterocolitis according to the "
+"NeoIPC surveillance criteria (see Infection Definitions: Necrotising "
+"Enterocolitis (NEC)) during the surveillance period, you should record and "
+"submit the required data using the data collection sheet below and/or via "
+"the online reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-NEC-Reporting-Sheet-Image.svg[NEC reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -721,7 +1104,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:322
-msgid "If an eligible infant develops a hospital-acquired pneumonia according to the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a hospital-acquired pneumonia according to "
+"the NeoIPC surveillance criteria (see Infection Definitions: Pneumonia) "
+"during the surveillance period, you should record and submit the required "
+"data using the data collection sheet below and/or via the online reporting "
+"platform."
 msgstr ""
 
 #. image::NeoIPC-Core-Pneumonia-Reporting-Sheet-Image.svg[Pneumonia reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -748,7 +1136,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:331
-msgid "If an eligible infant develops a surgical site infection according to the NeoIPC surveillance criteria (see Definitions: Surgical Site Infection (SSI)) during the surveillance period, you should record and submit the required data using the data collection sheet below and/or via the online reporting platform."
+msgid ""
+"If an eligible infant develops a surgical site infection according to the "
+"NeoIPC surveillance criteria (see Definitions: Surgical Site Infection "
+"(SSI)) during the surveillance period, you should record and submit the "
+"required data using the data collection sheet below and/or via the online "
+"reporting platform."
 msgstr ""
 
 #. image::NeoIPC-Core-SSI-Reporting-Sheet-Image.svg[SSI reporting sheet,{full-width},pdfwidth=75%,opts=inline,align="center"]
@@ -774,7 +1167,11 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:341
-msgid "Intravenous therapy and mechanical ventilation are established risk factors for nosocomial infections in neonatology.  These kinds of infections are typically considered device-associated infections and are recorded in association with medical devices like vascular catheters or intubation."
+msgid ""
+"Intravenous therapy and mechanical ventilation are established risk factors "
+"for nosocomial infections in neonatology.  These kinds of infections are "
+"typically considered device-associated infections and are recorded in "
+"association with medical devices like vascular catheters or intubation."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
@@ -804,7 +1201,12 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-device-associated-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:351
-msgid "Since the establishment of a causative relationship between a device and a hospital-acquired infection is difficult and infeasible in many neonatology settings, NeoIPC focuses on a time-based association only.  To create an association between a device and infection, the device must have been in use for a defined period prior to infection."
+msgid ""
+"Since the establishment of a causative relationship between a device and a "
+"hospital-acquired infection is difficult and infeasible in many neonatology "
+"settings, NeoIPC focuses on a time-based association only.  To create an "
+"association between a device and infection, the device must have been in use "
+"for a defined period prior to infection."
 msgstr ""
 
 #. type: Block title
@@ -829,12 +1231,18 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:366
-msgid "If a patient developing a bloodstream infection meets the criteria for both, PVC and CVC association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"If a patient developing a bloodstream infection meets the criteria for both, "
+"PVC and CVC association, the CVC is considered as the device with the "
+"relatively higher infection risk and the BSI should be recorded as CVC-"
+"associated BSI."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:368
-msgid "If both invasive and non-invasive ventilation were used intermittently, pneumonia should be recorded as INV-associated pneumonia."
+msgid ""
+"If both invasive and non-invasive ventilation were used intermittently, "
+"pneumonia should be recorded as INV-associated pneumonia."
 msgstr ""
 
 #. type: Title ====
@@ -845,17 +1253,26 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:374
-msgid "Within NeoIPC surveillance, it is possible to record bloodstream infections secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is optional; therefore, it is possible to select **“No follow-up”** if you are not following patients for secondary BSI."
+msgid ""
+"Within NeoIPC surveillance, it is possible to record bloodstream infections "
+"secondary to pneumonia, NEC, and SSIs.  Collecting data on secondary BSI is "
+"optional; therefore, it is possible to select **“No follow-up”** if you are "
+"not following patients for secondary BSI."
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:376
-msgid "To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, the following criteria must be met:"
+msgid ""
+"To assign a secondary bloodstream infection to a pneumonia, NEC, or an SSI, "
+"the following criteria must be met:"
 msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:378
-msgid "The blood specimen is collected in the period between 3 days prior and 13 days after the day of primary infection (day of primary infection=first symptoms or first positive culture at the primary infection site)."
+msgid ""
+"The blood specimen is collected in the period between 3 days prior and 13 "
+"days after the day of primary infection (day of primary infection=first "
+"symptoms or first positive culture at the primary infection site)."
 msgstr ""
 
 #. type: loweralpha
@@ -884,7 +1301,9 @@ msgstr ""
 
 #. type: #data-collection-infection-data-collection-secondary-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:381
-msgid "At least one organism from the blood specimen matches an organism identified from the primary infection site."
+msgid ""
+"At least one organism from the blood specimen matches an organism identified "
+"from the primary infection site."
 msgstr ""
 
 #. image::NeoIPC-Core-Secondary-BSI-Image.svg[Secondary BSI data collection,{full-width},pdfwidth=100%,opts=inline,align="center"]
@@ -916,17 +1335,38 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:393
-msgid "Blood culture diagnostics in neonates face two inherent challenges.  First, the small blood volumes obtainable from very low birth weight infants limit the sensitivity of cultures, meaning that a negative culture result does not rule out a bloodstream infection.  Second, the technical difficulty of venipuncture in very small infants increases the risk of skin flora contamination, which reduces the specificity of a positive culture when common commensal organisms are grown."
+msgid ""
+"Blood culture diagnostics in neonates face two inherent challenges.  First, "
+"the small blood volumes obtainable from very low birth weight infants limit "
+"the sensitivity of cultures, meaning that a negative culture result does not "
+"rule out a bloodstream infection.  Second, the technical difficulty of "
+"venipuncture in very small infants increases the risk of skin flora "
+"contamination, which reduces the specificity of a positive culture when "
+"common commensal organisms are grown."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:396
-msgid "To account for these limitations, sepsis is classified as either culture negative (clinical sepsis) or culture proven (Laboratory-confirmed bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI is further classified into two categories based on the culture result, distinguishing recognised pathogens from common commensals, because for the latter it is often unclear whether growth represents true infection or contamination, and NeoIPC therefore applies additional criteria to improve the specificity of surveillance in this category (see <<infection-definitions-lcbsi-caused-by-common-commensals>>)."
+msgid ""
+"To account for these limitations, sepsis is classified as either culture "
+"negative (clinical sepsis) or culture proven (Laboratory-confirmed "
+"bloodstream infection = LCBSI) in the NeoIPC surveillance system.  A LCBSI "
+"is further classified into two categories based on the culture result, "
+"distinguishing recognised pathogens from common commensals, because for the "
+"latter it is often unclear whether growth represents true infection or "
+"contamination, and NeoIPC therefore applies additional criteria to improve "
+"the specificity of surveillance in this category (see <<infection-"
+"definitions-lcbsi-caused-by-common-commensals>>)."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:399
-msgid "Infections caused by microorganisms that enter the bloodstream from a primary infection site (except for catheter-associated infections) are not counted in this section.  For detailed information, please see xref:data-collection-infection-data-collection-secondary-bloodstream-infection[Secondary Bloodstream Infection]."
+msgid ""
+"Infections caused by microorganisms that enter the bloodstream from a "
+"primary infection site (except for catheter-associated infections) are not "
+"counted in this section.  For detailed information, please see xref:data-"
+"collection-infection-data-collection-secondary-bloodstream-"
+"infection[Secondary Bloodstream Infection]."
 msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
@@ -951,7 +1391,9 @@ msgstr ""
 
 #. type: #infection-definitions-primary-sepsis-bloodstream-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:406
-msgid "*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious Agents]"
+msgid ""
+"*See xref:appendix-list-of-list-of-infectious-agents[List of Infectious "
+"Agents]"
 msgstr ""
 
 #. type: Block title
@@ -975,32 +1417,65 @@ msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:422
-msgid "If blood cultures show growth of one or multiple common commensals (e.g., coagulase-negative staphylococci), it is unclear in many cases, if the detected bacteria are the causative agent of a suspected infection or if a contamination leads to a wrong diagnosis.  There have been multiple approaches to solve this issue by adapting surveillance definitions to this fact.  Unfortunately, all these approaches are limited by diagnostic habits and availability of resources, rendering comparison of data from different settings close to impossible."
+msgid ""
+"If blood cultures show growth of one or multiple common commensals (e.g., "
+"coagulase-negative staphylococci), it is unclear in many cases, if the "
+"detected bacteria are the causative agent of a suspected infection or if a "
+"contamination leads to a wrong diagnosis.  There have been multiple "
+"approaches to solve this issue by adapting surveillance definitions to this "
+"fact.  Unfortunately, all these approaches are limited by diagnostic habits "
+"and availability of resources, rendering comparison of data from different "
+"settings close to impossible."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:425
-msgid "Since NeoIPC aims at providing tools and definitions that work in a wide range of different settings we offer 3 different definitions for LCBSI caused by common commensals that can be used in a wide range of settings.  As the tools collect the raw data leading to the diagnosis of an infection it is possible to assess the application of different definitions in various settings and possibly assess the effect on calculated incidences."
+msgid ""
+"Since NeoIPC aims at providing tools and definitions that work in a wide "
+"range of different settings we offer 3 different definitions for LCBSI "
+"caused by common commensals that can be used in a wide range of settings.  "
+"As the tools collect the raw data leading to the diagnosis of an infection "
+"it is possible to assess the application of different definitions in various "
+"settings and possibly assess the effect on calculated incidences."
 msgstr ""
 
 #. type: #infection-definitions-lcbsi-caused-by-common-commensals
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:427
-msgid "In any case, because of this fact, you should be very careful when comparing rates of LCBSI caused by common commensals across different settings."
+msgid ""
+"In any case, because of this fact, you should be very careful when comparing "
+"rates of LCBSI caused by common commensals across different settings."
 msgstr ""
 
 #. type: #infection-definitions-necrotising-enterocolitis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:436
-msgid "Necrotising Enterocolitis (NEC) surveillance criteria consist of either a combination of radiological findings and clinical signs or a diagnosis based on surgical and/or pathological evidence.  The NEC dataset includes information on whether the patient has an intestinal perforation.  However, this is not one of the surveillance definition criteria.  This means that you should not report cases where you have surgical evidence of intestinal perforation without evidence of primary necrosis or pneumatosis intestinalis (e.g. spontaneous bowel perforation) as NEC."
+msgid ""
+"Necrotising Enterocolitis (NEC) surveillance criteria consist of either a "
+"combination of radiological findings and clinical signs or a diagnosis based "
+"on surgical and/or pathological evidence.  The NEC dataset includes "
+"information on whether the patient has an intestinal perforation.  However, "
+"this is not one of the surveillance definition criteria.  This means that "
+"you should not report cases where you have surgical evidence of intestinal "
+"perforation without evidence of primary necrosis or pneumatosis intestinalis "
+"(e.g. spontaneous bowel perforation) as NEC."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:442
-msgid "Pneumonia in neonates is an entity that is very difficult to define for surveillance purposes as one can infer from the fact that many surveillance systems abstain from recording it at all, while others record ventilator-associated events where surveillance is limited to ventilated patients and pneumonia is only one of the entities captured by the definition."
+msgid ""
+"Pneumonia in neonates is an entity that is very difficult to define for "
+"surveillance purposes as one can infer from the fact that many surveillance "
+"systems abstain from recording it at all, while others record ventilator-"
+"associated events where surveillance is limited to ventilated patients and "
+"pneumonia is only one of the entities captured by the definition."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:447
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts).  The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts).  The earliest date of the event "
+"is day 3 of ventilation."
 msgstr ""
 
 #. type: #infection-definitions-pneumonia
@@ -1056,17 +1531,26 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:478
-msgid "A wound infection that occurs at the incision or surgical site is recorded as a surgical site infection (SSI) if it occurs in a certain time window after a surgical procedure that was also recorded in the NeoIPC surveillance system."
+msgid ""
+"A wound infection that occurs at the incision or surgical site is recorded "
+"as a surgical site infection (SSI) if it occurs in a certain time window "
+"after a surgical procedure that was also recorded in the NeoIPC surveillance "
+"system."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:480
-msgid "SSIs occurring in patients without a surgical procedure record in the NeoIPC surveillance system (e.g. a patient transferred to your centre after a surgical procedure performed at another centre) are not eligible."
+msgid ""
+"SSIs occurring in patients without a surgical procedure record in the NeoIPC "
+"surveillance system (e.g. a patient transferred to your centre after a "
+"surgical procedure performed at another centre) are not eligible."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:482
-msgid "The following surveillance times apply in detail (day 1 = the procedure date):"
+msgid ""
+"The following surveillance times apply in detail (day 1 = the procedure "
+"date):"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1076,17 +1560,21 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:485
-msgid "Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Deep incisional SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:486
-msgid "Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
+msgid ""
+"Organ/Space SSI: 30 days or 90 days if an implant has been left in place"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:488
-msgid "Follow-up for SSIs can be terminated preliminarily for a surgical procedure for two reasons:"
+msgid ""
+"Follow-up for SSIs can be terminated preliminarily for a surgical procedure "
+"for two reasons:"
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1104,7 +1592,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:495
-msgid "Minor interventions such as simple punctures of hematoma/seroma do not count as revision procedures.  Surveillance cannot be terminated by such minor procedures, and they do not start a new follow-up period."
+msgid ""
+"Minor interventions such as simple punctures of hematoma/seroma do not count "
+"as revision procedures.  Surveillance cannot be terminated by such minor "
+"procedures, and they do not start a new follow-up period."
 msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
@@ -1130,7 +1621,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:506
-msgid "The patient must not be deceased (e.g., post-mortem surgery in case of organ donation is excluded)."
+msgid ""
+"The patient must not be deceased (e.g., post-mortem surgery in case of organ "
+"donation is excluded)."
 msgstr ""
 
 #. type: Title ====
@@ -1141,7 +1634,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-superficial-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:510
-msgid "Surgical site infections involving only the skin and subcutaneous tissue belong to this category."
+msgid ""
+"Surgical site infections involving only the skin and subcutaneous tissue "
+"belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1152,7 +1647,9 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-deep-incisional-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:516
-msgid "Surgical site infections involving deep soft tissues of the incision (for example, fascial and muscle layers) belong to this category."
+msgid ""
+"Surgical site infections involving deep soft tissues of the incision (for "
+"example, fascial and muscle layers) belong to this category."
 msgstr ""
 
 #. type: Title ====
@@ -1163,7 +1660,10 @@ msgstr ""
 
 #. type: #infection-definitions-surgical-site-infection-organ-space-ssi
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:522
-msgid "Surgical site infections involving any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure belong to this category."
+msgid ""
+"Surgical site infections involving any part of the body deeper than the "
+"fascial/muscle layers that is opened or manipulated during the operative "
+"procedure belong to this category."
 msgstr ""
 
 #. type: Title ==
@@ -1174,12 +1674,22 @@ msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:529
-msgid "The following data items appear in the NeoIPC documentation sheets or in the reporting platform.  Some of them (e.g., patient id and patient name) are used for your local documentation only and not used in the central NeoIPC software tools."
+msgid ""
+"The following data items appear in the NeoIPC documentation sheets or in the "
+"reporting platform.  Some of them (e.g., patient id and patient name) are "
+"used for your local documentation only and not used in the central NeoIPC "
+"software tools."
 msgstr ""
 
 #. type: #data-dictionary
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:531
-msgid "A companion machine-readable *data dictionary* — a spreadsheet listing every collected variable with its data type and whether it is required or repeatable, together with the full code lists (including the complete pathogen and antimicrobial-substance lists) — is generated automatically from the same NeoIPC metadata and is available as a companion to this protocol."
+msgid ""
+"A companion machine-readable *data dictionary* — a spreadsheet listing every "
+"collected variable with its data type and whether it is required or "
+"repeatable, together with the full code lists (including the complete "
+"pathogen and antimicrobial-substance lists) — is generated automatically "
+"from the same NeoIPC metadata and is available as a companion to this "
+"protocol."
 msgstr ""
 
 #. type: Title ===
@@ -1213,12 +1723,21 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:539
-msgid "The unique id you assign to the patient for tracking in the reporting platform.  We advise you to store this information in a pseudonymisation list."
+msgid ""
+"The unique id you assign to the patient for tracking in the reporting "
+"platform.  We advise you to store this information in a pseudonymisation "
+"list."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:544
-msgid "Use this identifier to uniquely identify a patient in the system.  Ideally use a unique random string of characters.  If you have a requirement to identify a patient you have entered here, you can use this identifier as the NeoIPC key for pseudonymisation.  NEVER use an identifier that is used anywhere else and that you do not fully control (e.g. do NOT use the patient id from your hospital information system)."
+msgid ""
+"Use this identifier to uniquely identify a patient in the system.  Ideally "
+"use a unique random string of characters.  If you have a requirement to "
+"identify a patient you have entered here, you can use this identifier as the "
+"NeoIPC key for pseudonymisation.  NEVER use an identifier that is used "
+"anywhere else and that you do not fully control (e.g. do NOT use the patient "
+"id from your hospital information system)."
 msgstr ""
 
 #. type: Labeled list
@@ -1229,7 +1748,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:546
-msgid "The unique id of the patient in the hospital, which most of the time comes from the hospital information system (HIS) or the patient data management system (PDMS)."
+msgid ""
+"The unique id of the patient in the hospital, which most of the time comes "
+"from the hospital information system (HIS) or the patient data management "
+"system (PDMS)."
 msgstr ""
 
 #. type: Labeled list
@@ -1245,7 +1767,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:550
-msgid "The patient ID and the patient name are not part of the NeoIPC dataset and must not be submitted to the data collection platform (e.g., do NOT use any of them as NeoIPC-ID).  They are available on the data collection paper sheets so that you can identify the patient within the hospital and to look up the file in the hospital information system."
+msgid ""
+"The patient ID and the patient name are not part of the NeoIPC dataset and "
+"must not be submitted to the data collection platform (e.g., do NOT use any "
+"of them as NeoIPC-ID).  They are available on the data collection paper "
+"sheets so that you can identify the patient within the hospital and to look "
+"up the file in the hospital information system."
 msgstr ""
 
 #. type: Labeled list
@@ -1256,7 +1783,13 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:553
-msgid "The gestational age, expressed in completed weeks and days (e.g., 25 weeks and 4 days: 25+4) at the time of birth.  Typically this refers to the gestational age as it was calculated or estimated by the mother's obstetrician but where this is not available (e.g. in unobserved pregnancies) the gestational age assesed by the treating physician (e.g. via the Ballard score) may be recorded."
+msgid ""
+"The gestational age, expressed in completed weeks and days (e.g., 25 weeks "
+"and 4 days: 25+4) at the time of birth.  Typically this refers to the "
+"gestational age as it was calculated or estimated by the mother's "
+"obstetrician but where this is not available (e.g. in unobserved "
+"pregnancies) the gestational age assesed by the treating physician (e.g. via "
+"the Ballard score) may be recorded."
 msgstr ""
 
 #. type: Labeled list
@@ -1267,7 +1800,12 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:555
-msgid "The infant’s weight immediately after birth in grams.  Typically this value is based on a measurement but in case the birth weigth is unknown or has a highly pathological value that does not reflect the maturity of the infant (e.g. hydrops fetalis) you can enter the birth weight that is estimated by the treating physician."
+msgid ""
+"The infant’s weight immediately after birth in grams.  Typically this value "
+"is based on a measurement but in case the birth weigth is unknown or has a "
+"highly pathological value that does not reflect the maturity of the infant "
+"(e.g. hydrops fetalis) you can enter the birth weight that is estimated by "
+"the treating physician."
 msgstr ""
 
 #. type: Labeled list
@@ -1278,7 +1816,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:557
-msgid "Typically the phenotypic sex of the patient.  If sex cannot be determined from the patient's phenotype or genotype, or if the genotype is neither XX nor XY, it is considered undetermined for purposes of surveillance."
+msgid ""
+"Typically the phenotypic sex of the patient.  If sex cannot be determined "
+"from the patient's phenotype or genotype, or if the genotype is neither XX "
+"nor XY, it is considered undetermined for purposes of surveillance."
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
@@ -1341,7 +1882,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-enrolment
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:570
-msgid "The number of infants delivered from the (multiple) pregnancy this infant belongs to.  Please report the total number of infants including the one you are recording here."
+msgid ""
+"The number of infants delivered from the (multiple) pregnancy this infant "
+"belongs to.  Please report the total number of infants including the one you "
+"are recording here."
 msgstr ""
 
 #. type: Title ====
@@ -1358,7 +1902,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:575
-msgid "The day the patient is admitted to the hospital.  For infants born in your hospital this is the same as the date of birth."
+msgid ""
+"The day the patient is admitted to the hospital.  For infants born in your "
+"hospital this is the same as the date of birth."
 msgstr ""
 
 #. type: Labeled list
@@ -1369,12 +1915,16 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:576
-msgid "Describes if the infant was born in your hospital or if it was admitted after birth and if so, how long after birth:"
+msgid ""
+"Describes if the infant was born in your hospital or if it was admitted "
+"after birth and if so, how long after birth:"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:578
-msgid "Admitted from delivery room (initial admission for infants delivered in your hospital)"
+msgid ""
+"Admitted from delivery room (initial admission for infants delivered in your "
+"hospital)"
 msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
@@ -1395,7 +1945,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-admission-information
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:582
-msgid "For infants that have not been delivered in your own hospital, record the infant's day of life on the day of admission (Day of birth = Day of Life 1.  The next day, starting at 00:00, is the second day of life.)"
+msgid ""
+"For infants that have not been delivered in your own hospital, record the "
+"infant's day of life on the day of admission (Day of birth = Day of Life 1.  "
+"The next day, starting at 00:00, is the second day of life.)"
 msgstr ""
 
 #. type: Title ====
@@ -1412,7 +1965,8 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:586
-msgid "The day the data collection and follow-up for the patient has been stopped."
+msgid ""
+"The day the data collection and follow-up for the patient has been stopped."
 msgstr ""
 
 #. type: Labeled list
@@ -1444,7 +1998,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:592
-msgid "The cumulative number of days the patient stayed in the department, including the day of admission and the day of discharge/transfer/death (no minimum duration of stay)."
+msgid ""
+"The cumulative number of days the patient stayed in the department, "
+"including the day of admission and the day of discharge/transfer/death (no "
+"minimum duration of stay)."
 msgstr ""
 
 #. type: Labeled list
@@ -1455,7 +2012,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:593
-msgid "The cumulative number of days when a central venous catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a central venous catheter was in place "
+"for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1466,7 +2025,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:594
-msgid "The cumulative number of days when a peripheral vascular catheter was in place for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when a peripheral vascular catheter was in "
+"place for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1477,7 +2038,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:595
-msgid "The cumulative number of days when the infant was on invasive ventilation (intubated) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on invasive ventilation "
+"(intubated) for at least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1488,7 +2051,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:596
-msgid "The cumulative number of days when the infant was on non-invasive ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at least 12 hours/day."
+msgid ""
+"The cumulative number of days when the infant was on non-invasive "
+"ventilation (not intubated; e.g. high flow nasal cannulae or CPAP) for at "
+"least 12 hours/day."
 msgstr ""
 
 #. type: Labeled list
@@ -1499,7 +2065,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:598
-msgid "The cumulative number of days the patient’s enteral feeding exclusively consists of (own mother’s or donor) breast milk.  Fortified breast milk is considered as breast milk."
+msgid ""
+"The cumulative number of days the patient’s enteral feeding exclusively "
+"consists of (own mother’s or donor) breast milk.  Fortified breast milk is "
+"considered as breast milk."
 msgstr ""
 
 #. type: Labeled list
@@ -1510,7 +2079,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:599
-msgid "The cumulative number of days the patient received kangaroo care (intensive skin-to-skin-contact) for at least 2 hours."
+msgid ""
+"The cumulative number of days the patient received kangaroo care (intensive "
+"skin-to-skin-contact) for at least 2 hours."
 msgstr ""
 
 #. type: Labeled list
@@ -1521,7 +2092,10 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:600
-msgid "The cumulative number of days the patient receives an oral probiotic containing at least one of Lactobacillus spp. or Bifidobacterium spp., regardless of the amount."
+msgid ""
+"The cumulative number of days the patient receives an oral probiotic "
+"containing at least one of Lactobacillus spp. or Bifidobacterium spp., "
+"regardless of the amount."
 msgstr ""
 
 #. type: Labeled list
@@ -1532,7 +2106,17 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:604
-msgid "The cumulative number of daysfootnote:ab-days-comment[The day of the first dose and the day of the last dose of an antibiotic therapy as well as all the days in between are counted.  Days where no doses were applied between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose was applied.  Days after the last dose are not counted irrespective of the measured or assumed drug level in the patient.] when the infant received (any) systemic antibiotics.  Only one antibiotic day can be recorded per day, which means that a day when the patient received multiple antibiotics is still counted as one antibiotic day."
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[The day of the first "
+"dose and the day of the last dose of an antibiotic therapy as well as all "
+"the days in between are counted.  Days where no doses were applied between "
+"the first and the last dose (e.g., skipped doses because of high drug levels "
+"in therapeutic drug monitoring) are counted as if a dose was applied.  Days "
+"after the last dose are not counted irrespective of the measured or assumed "
+"drug level in the patient.] when the infant received (any) systemic "
+"antibiotics.  Only one antibiotic day can be recorded per day, which means "
+"that a day when the patient received multiple antibiotics is still counted "
+"as one antibiotic day."
 msgstr ""
 
 #. type: Labeled list
@@ -1543,7 +2127,9 @@ msgstr ""
 
 #. type: #data-dictionary-patient-master-data-surveillance-end
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:606
-msgid "The cumulative number of daysfootnote:ab-days-comment[] when the infant received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
+msgid ""
+"The cumulative number of daysfootnote:ab-days-comment[] when the infant "
+"received a specified systemic antibiotic substance.  Exp.: Gentamicin days"
 msgstr ""
 
 #. type: Title ===
@@ -1571,7 +2157,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:611
-msgid "A human-readable name or description of the surgical procedure as it is typically called by surgeons in your institution (e.g.; ligation of patent arterial duct)."
+msgid ""
+"A human-readable name or description of the surgical procedure as it is "
+"typically called by surgeons in your institution (e.g.; ligation of patent "
+"arterial duct)."
 msgstr ""
 
 #. type: Labeled list
@@ -1582,7 +2171,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:614
-msgid "The International Classification of Health Interventions (ICHI) code of the main procedure performed.  If multiple different procedures are performed during one surgery, the surgeon decides which one is the main procedure (typically the most complex procedure or the one causing the highest risk for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"main procedure performed.  If multiple different procedures are performed "
+"during one surgery, the surgeon decides which one is the main procedure "
+"(typically the most complex procedure or the one causing the highest risk "
+"for infection).  Please visit https://icd.who.int/dev11/l-ichi/en"
 msgstr ""
 
 #. type: Labeled list
@@ -1593,7 +2187,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:616
-msgid "The International Classification of Health Interventions (ICHI) code of the side procedure(s) performed.  It is possible to capture up to two side procedures."
+msgid ""
+"The International Classification of Health Interventions (ICHI) code of the "
+"side procedure(s) performed.  It is possible to capture up to two side "
+"procedures."
 msgstr ""
 
 #. type: Labeled list
@@ -1604,7 +2201,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:617
-msgid "The duration of the surgical procedure in minutes (incision-to-suture time if available)."
+msgid ""
+"The duration of the surgical procedure in minutes (incision-to-suture time "
+"if available)."
 msgstr ""
 
 #. type: Labeled list
@@ -1615,7 +2214,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:620
-msgid "An assessment of the degree of contamination of a surgical wound at the time of the surgical procedure according to the CDC Guidelines.  It is assigned by a person involved in the surgical procedure (for example, surgeon, circulating nurse, etc.).  The four wound classifications are:"
+msgid ""
+"An assessment of the degree of contamination of a surgical wound at the time "
+"of the surgical procedure according to the CDC Guidelines.  It is assigned "
+"by a person involved in the surgical procedure (for example, surgeon, "
+"circulating nurse, etc.).  The four wound classifications are:"
 msgstr ""
 
 #. type: Labeled list
@@ -1626,7 +2229,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:623
-msgid "An uninfected operative wound in which no inflammation is encountered, and the respiratory, alimentary, genital, or uninfected urinary tract is not entered.  In addition, clean wounds are primarily closed and, if necessary, drained with closed drainage.  Operative incisional wounds that follow no penetrating (blunt) trauma should be included in this category if they meet the criteria."
+msgid ""
+"An uninfected operative wound in which no inflammation is encountered, and "
+"the respiratory, alimentary, genital, or uninfected urinary tract is not "
+"entered.  In addition, clean wounds are primarily closed and, if necessary, "
+"drained with closed drainage.  Operative incisional wounds that follow no "
+"penetrating (blunt) trauma should be included in this category if they meet "
+"the criteria."
 msgstr ""
 
 #. type: Labeled list
@@ -1637,7 +2246,12 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:625
-msgid "An operative wound in which the respiratory, alimentary, genital, or urinary tracts are entered under controlled conditions and without unusual contamination.  Specifically, operations involving the biliary tract, appendix, vagina, and oropharynx are included in this category, provided no evidence of infection or major break in a sterile technique is encountered."
+msgid ""
+"An operative wound in which the respiratory, alimentary, genital, or urinary "
+"tracts are entered under controlled conditions and without unusual "
+"contamination.  Specifically, operations involving the biliary tract, "
+"appendix, vagina, and oropharynx are included in this category, provided no "
+"evidence of infection or major break in a sterile technique is encountered."
 msgstr ""
 
 #. type: Labeled list
@@ -1648,7 +2262,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:627
-msgid "Open, fresh, accidental wounds.  In addition, operations with major breaks in a sterile technique (eg, open cardiac massage) or gross spillage from the gastrointestinal tract, and incisions in which acute or no purulent inflammation is encountered are included in this category."
+msgid ""
+"Open, fresh, accidental wounds.  In addition, operations with major breaks "
+"in a sterile technique (eg, open cardiac massage) or gross spillage from the "
+"gastrointestinal tract, and incisions in which acute or no purulent "
+"inflammation is encountered are included in this category."
 msgstr ""
 
 #. type: Labeled list
@@ -1659,7 +2277,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:629
-msgid "Old traumatic wounds with retained devitalized tissue and those that involve existing clinical infection or perforated viscera.  This definition suggests that the organisms causing postoperative infection were present in the operative field before the operation."
+msgid ""
+"Old traumatic wounds with retained devitalized tissue and those that involve "
+"existing clinical infection or perforated viscera.  This definition suggests "
+"that the organisms causing postoperative infection were present in the "
+"operative field before the operation."
 msgstr ""
 
 #. type: Labeled list
@@ -1670,7 +2292,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:631
-msgid "The American Society of Anesthesiologists' (ASA) Physical Status Classification System to assess and communicate a patient’s pre-anesthesia medical co-morbidities:"
+msgid ""
+"The American Society of Anesthesiologists' (ASA) Physical Status "
+"Classification System to assess and communicate a patient’s pre-anesthesia "
+"medical co-morbidities:"
 msgstr ""
 
 #. type: Labeled list
@@ -1714,7 +2339,8 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:637
-msgid "A patient with severe systemic disease that is a constant threat to life"
+msgid ""
+"A patient with severe systemic disease that is a constant threat to life"
 msgstr ""
 
 #. type: Labeled list
@@ -1730,7 +2356,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:641
-msgid "Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-physical-status-classification-system."
+msgid ""
+"Visit https://www.asahq.org/standards-and-guidelines/statement-on-asa-"
+"physical-status-classification-system."
 msgstr ""
 
 #. type: Labeled list
@@ -1762,7 +2390,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:644
-msgid "The procedure was performed open or endoscopically assisted, or switched to an open technique during an endoscopic procedure."
+msgid ""
+"The procedure was performed open or endoscopically assisted, or switched to "
+"an open technique during an endoscopic procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -1773,7 +2403,9 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:646
-msgid "A procedure that is documented per the facility’s protocol to be an Emergency or Urgent procedure."
+msgid ""
+"A procedure that is documented per the facility’s protocol to be an "
+"Emergency or Urgent procedure."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
@@ -1800,12 +2432,21 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:651
-msgid "The closure of the skin level during the original surgery, regardless of the presence of wires, wicks, drains, or other devices or objects extruding through the incision.  This category includes surgeries where the skin is closed by some means.  Thus, if any portion of the incision is closed at the skin level, by any manner, a designation of primary closure should be assigned to the surgery."
+msgid ""
+"The closure of the skin level during the original surgery, regardless of the "
+"presence of wires, wicks, drains, or other devices or objects extruding "
+"through the incision.  This category includes surgeries where the skin is "
+"closed by some means.  Thus, if any portion of the incision is closed at the "
+"skin level, by any manner, a designation of primary closure should be "
+"assigned to the surgery."
 msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:653
-msgid "If a procedure has multiple incision/laparoscopic trocar sites and any of the incisions are closed primarily then the procedure technique is recorded as primary closed."
+msgid ""
+"If a procedure has multiple incision/laparoscopic trocar sites and any of "
+"the incisions are closed primarily then the procedure technique is recorded "
+"as primary closed."
 msgstr ""
 
 #. type: Labeled list
@@ -1816,7 +2457,10 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:656
-msgid "Revision procedures are follow-up, replacement or corrective procedures after an initial procedure.  A revision procedure terminates the follow-up for the primary procedure and starts a new follow-up period."
+msgid ""
+"Revision procedures are follow-up, replacement or corrective procedures "
+"after an initial procedure.  A revision procedure terminates the follow-up "
+"for the primary procedure and starts a new follow-up period."
 msgstr ""
 
 #. type: Labeled list
@@ -1827,7 +2471,11 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:657
-msgid "An implant is a foreign body of non-human origin that is permanently placed into a patient during an operation and is not routinely manipulated for diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, wires, meshes)."
+msgid ""
+"An implant is a foreign body of non-human origin that is permanently placed "
+"into a patient during an operation and is not routinely manipulated for "
+"diagnostic or therapeutic purposes (e.g., vascular prostheses, screws, "
+"wires, meshes)."
 msgstr ""
 
 #. type: Labeled list
@@ -1838,7 +2486,13 @@ msgstr ""
 
 #. type: #data-dictionary-surgical-procedure
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:660
-msgid "Complete this field if signs of infection were identified during the surgical procedure.  The signs of infection must be noted intraoperatively and documented in the narrative part of the operation note or report of surgery.  If a surgical site infection occurs, this information will be used to determine if the signs listed in this section can be interpreted as \"Infection present at time of surgery\"."
+msgid ""
+"Complete this field if signs of infection were identified during the "
+"surgical procedure.  The signs of infection must be noted intraoperatively "
+"and documented in the narrative part of the operation note or report of "
+"surgery.  If a surgical site infection occurs, this information will be used "
+"to determine if the signs listed in this section can be interpreted as "
+"\"Infection present at time of surgery\"."
 msgstr ""
 
 #. type: Block title
@@ -1849,27 +2503,44 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:665
-msgid "Examples that indicate evidence of infection include but are not limited to: abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A ruptured/perforated appendix is evidence of infection at the organ/space level."
+msgid ""
+"Examples that indicate evidence of infection include but are not limited to: "
+"abscess, infection, purulence/pus, phlegmon, or “feculent peritonitis”.  A "
+"ruptured/perforated appendix is evidence of infection at the organ/space "
+"level."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:666
-msgid "Examples of verbiage that is not considered evidence of infection include but are not limited to: colon perforation, contamination, necrosis, gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or documentation of inflammation."
+msgid ""
+"Examples of verbiage that is not considered evidence of infection include "
+"but are not limited to: colon perforation, contamination, necrosis, "
+"gangrene, fecal spillage, nicked bowel during procedure, murky fluid, or "
+"documentation of inflammation."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:667
-msgid "The use of the ending “itis” in an operative note/report of surgery does not automatically count as evidence of infection, as it may only reflect inflammation which is not infectious in nature (for example, diverticulitis, peritonitis, and appendicitis)."
+msgid ""
+"The use of the ending “itis” in an operative note/report of surgery does not "
+"automatically count as evidence of infection, as it may only reflect "
+"inflammation which is not infectious in nature (for example, diverticulitis, "
+"peritonitis, and appendicitis)."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:668
-msgid "Pathology report findings and imaging test findings cannot be used as evidence of infection."
+msgid ""
+"Pathology report findings and imaging test findings cannot be used as "
+"evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:669
-msgid "Identification of an organism using culture or non-culture based microbiologic testing method or on a pathology report from a surgical specimen cannot be used as evidence of infection."
+msgid ""
+"Identification of an organism using culture or non-culture based "
+"microbiologic testing method or on a pathology report from a surgical "
+"specimen cannot be used as evidence of infection."
 msgstr ""
 
 #. type: delimited block = 4
@@ -1879,12 +2550,19 @@ msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:672
-msgid "Trauma resulting in a contaminated case does not automatically count as evidence of infection.  For example, a fresh gunshot wound to the abdomen may be a trauma with a high wound class but there would not be time for infection to develop."
+msgid ""
+"Trauma resulting in a contaminated case does not automatically count as "
+"evidence of infection.  For example, a fresh gunshot wound to the abdomen "
+"may be a trauma with a high wound class but there would not be time for "
+"infection to develop."
 msgstr ""
 
 #. type: delimited block = 4
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:673
-msgid "Procedural complications such as bowel perforation during surgery cannot be used as evidence of infection since there was no infection present at time of surgery."
+msgid ""
+"Procedural complications such as bowel perforation during surgery cannot be "
+"used as evidence of infection since there was no infection present at time "
+"of surgery."
 msgstr ""
 
 #. type: Title ===
@@ -1907,7 +2585,9 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:681
-msgid "The day the first infection symptoms appeared.  If no symptoms occur, the day of first positive culture at the primary infection site."
+msgid ""
+"The day the first infection symptoms appeared.  If no symptoms occur, the "
+"day of first positive culture at the primary infection site."
 msgstr ""
 
 #. type: Labeled list
@@ -1918,7 +2598,12 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:685
-msgid "A type of micro-organism (e.g., coagulase-negative staphylococci), that is commonly present on epithelium-covered body surfaces (e.g., skin).  When one or multiple of these species grow in a blood culture, a contamination is more likely than when a recognised pathogen grows.  See Master Organism List on https://neoipc.org/surveillance/resources/"
+msgid ""
+"A type of micro-organism (e.g., coagulase-negative staphylococci), that is "
+"commonly present on epithelium-covered body surfaces (e.g., skin).  When one "
+"or multiple of these species grow in a blood culture, a contamination is "
+"more likely than when a recognised pathogen grows.  See Master Organism List "
+"on https://neoipc.org/surveillance/resources/"
 msgstr ""
 
 #. type: Labeled list
@@ -1949,17 +2634,25 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:691
-msgid "3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd generation Cephalosporins according to own lab’s cut-off values (refers to phenotypic resistance or ESBL-producing organisms)"
+msgid ""
+"3GCR: Multi drug resistant gram-negative pathogen resistant to 3rd "
+"generation Cephalosporins according to own lab’s cut-off values (refers to "
+"phenotypic resistance or ESBL-producing organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:692
-msgid "Carbapenem resistant: Resistant to at least one of the following (Imipenem, Meropenem, Ertapenem) according to own lab's cut-off values (refers to phenotypic resistance or carbapenemase-producing organisms.)"
+msgid ""
+"Carbapenem resistant: Resistant to at least one of the following (Imipenem, "
+"Meropenem, Ertapenem) according to own lab's cut-off values (refers to "
+"phenotypic resistance or carbapenemase-producing organisms.)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:693
-msgid "Colistin resistant: Resistant to colistin according to own lab's cut-off values."
+msgid ""
+"Colistin resistant: Resistant to colistin according to own lab's cut-off "
+"values."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -1969,17 +2662,22 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:697
-msgid "Yes: the isolated organism is resistant to the specified antibiotic group(s)."
+msgid ""
+"Yes: the isolated organism is resistant to the specified antibiotic group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:698
-msgid "No: the isolated organism is not resistant to the specified antibiotic group(s)."
+msgid ""
+"No: the isolated organism is not resistant to the specified antibiotic "
+"group(s)."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:699
-msgid "Not tested: the isolated organism was not tested for resistance to the specified antibiotic group(s)."
+msgid ""
+"Not tested: the isolated organism was not tested for resistance to the "
+"specified antibiotic group(s)."
 msgstr ""
 
 #. type: Labeled list
@@ -1990,22 +2688,36 @@ msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:702
-msgid "A BSI that is seeded from a site-specific infection at another body site (except for vascular catheter-associated infections).  A BSI can be attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a 17-day period that includes the day of infection (=first symptoms of site-specific infection), 3 days prior, and 13 days after."
+msgid ""
+"A BSI that is seeded from a site-specific infection at another body site "
+"(except for vascular catheter-associated infections).  A BSI can be "
+"attributed to a site-specific infection (NEC, PN or SSI) if it occurs in a "
+"17-day period that includes the day of infection (=first symptoms of site-"
+"specific infection), 3 days prior, and 13 days after."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:705
-msgid "Collecting data about the secondary BSI is optional; therefore, it is possible to select “No follow-up” if you are not following patients for secondary BSI.  For detailed information, please see Secondary bloodstream infection."
+msgid ""
+"Collecting data about the secondary BSI is optional; therefore, it is "
+"possible to select “No follow-up” if you are not following patients for "
+"secondary BSI.  For detailed information, please see Secondary bloodstream "
+"infection."
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:707
-msgid "Yes: if you are following patients for secondary BSI and the patient has developed a secondary sepsis that meets the definition of NeoIPC (activates a field below where you can enter identified organisms)"
+msgid ""
+"Yes: if you are following patients for secondary BSI and the patient has "
+"developed a secondary sepsis that meets the definition of NeoIPC (activates "
+"a field below where you can enter identified organisms)"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:708
-msgid "No: if you are following patients for secondary BSI and the patient has not developed a secondary sepsis that meets the definition of NeoIPC"
+msgid ""
+"No: if you are following patients for secondary BSI and the patient has not "
+"developed a secondary sepsis that meets the definition of NeoIPC"
 msgstr ""
 
 #. type: #data-dictionary-general-infection-data
@@ -2027,12 +2739,17 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:713
-msgid "An intravascular catheter that terminates at or close to the heart or in one of the great vessels which is used for infusion, withdrawal of blood, or hemodynamic monitoring."
+msgid ""
+"An intravascular catheter that terminates at or close to the heart or in one "
+"of the great vessels which is used for infusion, withdrawal of blood, or "
+"hemodynamic monitoring."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:716
-msgid "Central venous catheter (CVC), including non-tunnelled, tunnelled and implanted central venous catheters."
+msgid ""
+"Central venous catheter (CVC), including non-tunnelled, tunnelled and "
+"implanted central venous catheters."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2047,12 +2764,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:720
-msgid "Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
+msgid ""
+"Extracorporeal membrane oxygenation (ECMO) and arterial catheters (except "
+"pulmonary artery, aorta, or umbilical artery) are NOT considered as CVC."
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:722
-msgid "The following are considered great vessels for the purpose of reporting CVCs:"
+msgid ""
+"The following are considered great vessels for the purpose of reporting CVCs:"
 msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
@@ -2118,7 +2838,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:737
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-associated if the CVC has been in place for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_cvc,CVC>>-"
+"associated if the CVC has been in place for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2129,7 +2853,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:739
-msgid "A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_cvc,CVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2140,7 +2866,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:741
-msgid "A PVC is a catheter placed into a peripheral vein and does not reach one of the great vessels mentioned under CVC."
+msgid ""
+"A PVC is a catheter placed into a peripheral vein and does not reach one of "
+"the great vessels mentioned under CVC."
 msgstr ""
 
 #. type: Labeled list
@@ -2151,7 +2879,15 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:744
-msgid "A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-associated if the PVC has been present for at least three consecutive days on the day of infection (=first symptoms or first positive diagnostic test; e.g. culture) or the day before and does not meet the criteria for CVC-associated BSI.  That means, if a patient developing a bloodstream infection meets the criteria for both, PVC- and CVC-association, the CVC is considered as the device with the relatively higher infection risk and the BSI should be recorded as CVC-associated BSI."
+msgid ""
+"A primary bloodstream infection is considered <<bsi-specific-data_pvc,PVC>>-"
+"associated if the PVC has been present for at least three consecutive days "
+"on the day of infection (=first symptoms or first positive diagnostic test; "
+"e.g. culture) or the day before and does not meet the criteria for CVC-"
+"associated BSI.  That means, if a patient developing a bloodstream infection "
+"meets the criteria for both, PVC- and CVC-association, the CVC is considered "
+"as the device with the relatively higher infection risk and the BSI should "
+"be recorded as CVC-associated BSI."
 msgstr ""
 
 #. type: Labeled list
@@ -2162,7 +2898,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:746
-msgid "A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient had a <<bsi-specific-data_pvc,PVC>> placed for at "
+"least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2173,7 +2911,16 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:752
-msgid "Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Labeled list
@@ -2184,7 +2931,11 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:754
-msgid "New or increased frequency of episodes of apnea lasting more than 20 seconds, or an increase in the amount of oxygen required to maintain adequate oxygenation, or an escalation of ventilatory support, such as increased flow with high-flow therapy or intubation for invasive ventilation."
+msgid ""
+"New or increased frequency of episodes of apnea lasting more than 20 "
+"seconds, or an increase in the amount of oxygen required to maintain "
+"adequate oxygenation, or an escalation of ventilatory support, such as "
+"increased flow with high-flow therapy or intubation for invasive ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2195,7 +2946,10 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:756
-msgid "Enteral feeding intolerance, abdominal distension or ileus without imaging findings or surgical findings that would otherwise suggest a necrotizing entrocolitis or a spontaneous intestinal perforation."
+msgid ""
+"Enteral feeding intolerance, abdominal distension or ileus without imaging "
+"findings or surgical findings that would otherwise suggest a necrotizing "
+"entrocolitis or a spontaneous intestinal perforation."
 msgstr ""
 
 #. type: Labeled list
@@ -2206,7 +2960,9 @@ msgstr ""
 
 #. type: #data-dictionary-bsi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:758
-msgid "Unexplained metabolic acidosis with a base deficit greater (more negative) than 10 mmol/L (10 mEq/L)."
+msgid ""
+"Unexplained metabolic acidosis with a base deficit greater (more negative) "
+"than 10 mmol/L (10 mEq/L)."
 msgstr ""
 
 #. type: Title ====
@@ -2246,7 +3002,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:771
-msgid "Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum FiO2 values must be taken into account here)"
+msgid ""
+"Increase in need for FiO2 ≥ 0.25 (25 points) within 24 hours (daily minimum "
+"FiO2 values must be taken into account here)"
 msgstr ""
 
 #. type: Plain text
@@ -2261,13 +3019,17 @@ msgstr ""
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:774
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:28
-msgid "begin of non-invasive ventilatory support (excluding switch from invasive ventilation)"
+msgid ""
+"begin of non-invasive ventilatory support (excluding switch from invasive "
+"ventilation)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:777
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:31
-msgid "begin of invasive mechanical ventilation (including switch from non-invasive ventilatory support)"
+msgid ""
+"begin of invasive mechanical ventilation (including switch from non-invasive "
+"ventilatory support)"
 msgstr ""
 
 #. type: Labeled list
@@ -2289,12 +3051,18 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:781
-msgid "A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"A stable or improving baseline period of at least two days is required "
+"before the above condition occurs."
 msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:783
-msgid "To meet the criteria of device associated hospital-acquired pneumonia, patients must be ventilated for at least 4 calendar days (day 1 is the day invasive/non-invasive ventilation starts). The earliest date of the event is day 3 of ventilation."
+msgid ""
+"To meet the criteria of device associated hospital-acquired pneumonia, "
+"patients must be ventilated for at least 4 calendar days (day 1 is the day "
+"invasive/non-invasive ventilation starts). The earliest date of the event is "
+"day 3 of ventilation."
 msgstr ""
 
 #. type: Labeled list
@@ -2316,7 +3084,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:788
-msgid "A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the patient had an endotracheal or tracheostomy tube for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_inv,INV>> if the "
+"patient had an endotracheal or tracheostomy tube for at least 3 consecutive "
+"days on the day of infection (=first symptoms or first positive culture) or "
+"on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2327,7 +3099,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:790
-msgid "A day in which the patient was ventilated invasively via endotracheal or tracheostomy tube for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient was ventilated invasively via endotracheal or "
+"tracheostomy tube for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2349,7 +3123,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:794
-msgid "A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the patient received non-invasive ventilatory support (e.g., CPAP or High-Flow Nasal Cannula) for at least 3 consecutive days on the day of infection (=first symptoms or first positive culture) or on the day before."
+msgid ""
+"A pneumonia is associated with <<pneumonia-specific-data_niv,NIV>> if the "
+"patient received non-invasive ventilatory support (e.g., CPAP or High-Flow "
+"Nasal Cannula) for at least 3 consecutive days on the day of infection "
+"(=first symptoms or first positive culture) or on the day before."
 msgstr ""
 
 #. type: Labeled list
@@ -2360,7 +3138,9 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:796
-msgid "A day in which the patient received non-invasive ventilatory support via CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
+msgid ""
+"A day in which the patient received non-invasive ventilatory support via "
+"CPAP or High-Flow Nasal Cannula for at least 12 hours cumulatively."
 msgstr ""
 
 #. type: Labeled list
@@ -2371,7 +3151,11 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:798
-msgid "At least one organism has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from respiratory tract by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Labeled list
@@ -2382,7 +3166,10 @@ msgstr ""
 
 #. type: #data-dictionary-pneumonia-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:800
-msgid "Select if fungal, bacterial or viral pathogens (viral gene, antigen or antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower respiratory tract."
+msgid ""
+"Select if fungal, bacterial or viral pathogens (viral gene, antigen or "
+"antibody via e.g. EIA, FAMA, shell vial assay, PCR) are detected in lower "
+"respiratory tract."
 msgstr ""
 
 #. type: Labeled list
@@ -2410,7 +3197,10 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:805
-msgid "Select YES, only if the sign of infection identified during the surgical procedure applies to the depth of the SSI that is being attributed to the procedure."
+msgid ""
+"Select YES, only if the sign of infection identified during the surgical "
+"procedure applies to the depth of the SSI that is being attributed to the "
+"procedure."
 msgstr ""
 
 #. type: Labeled list
@@ -2422,12 +3212,17 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:809
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with an organ/space SSI = YES."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with an organ/space SSI = YES."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:810
-msgid "If a patient has documentation of an intra-abdominal infection at time of surgery and then later returns with a superficial or deep incisional SSI = NO."
+msgid ""
+"If a patient has documentation of an intra-abdominal infection at time of "
+"surgery and then later returns with a superficial or deep incisional SSI = "
+"NO."
 msgstr ""
 
 #. type: Labeled list
@@ -2438,27 +3233,44 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:816
-msgid "A superficial incisional SSI involves only skin and subcutaneous tissue of the incision and first symptoms occur within 30 days after the operation."
+msgid ""
+"A superficial incisional SSI involves only skin and subcutaneous tissue of "
+"the incision and first symptoms occur within 30 days after the operation."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:817
-msgid "A deep incisional SSI involves deep soft tissues of the incision (for example, fascial and muscle layers) and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"A deep incisional SSI involves deep soft tissues of the incision (for "
+"example, fascial and muscle layers) and first symptoms occur within 30 days "
+"after the operation or 90 days after the operation when an implant was left "
+"in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:818
-msgid "An organ/space SSI involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure and first symptoms occur within 30 days after the operation or 90 days after the operation when an implant was left in place."
+msgid ""
+"An organ/space SSI involves any part of the body deeper than the fascial/"
+"muscle layers that is opened or manipulated during the operative procedure "
+"and first symptoms occur within 30 days after the operation or 90 days after "
+"the operation when an implant was left in place."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:820
-msgid "The SSI reported must reflect the deepest tissue level where SSI criteria are met during the surveillance period."
+msgid ""
+"The SSI reported must reflect the deepest tissue level where SSI criteria "
+"are met during the surveillance period."
 msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:825
-msgid "If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance period and then a week later (Day 17) meets criteria for an organ/space SSI.  You must report it as organ/space SSI regardless of superficial or deep tissue involvement.  The day of infection in this case would be “Day 17”."
+msgid ""
+"If a SSI started as a deep incisional SSI on day 10 of the SSI surveillance "
+"period and then a week later (Day 17) meets criteria for an organ/space "
+"SSI.  You must report it as organ/space SSI regardless of superficial or "
+"deep tissue involvement.  The day of infection in this case would be “Day "
+"17”."
 msgstr ""
 
 #. type: Labeled list
@@ -2469,7 +3281,11 @@ msgstr ""
 
 #. type: #data-dictionary-ssi-specific-data
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:828
-msgid "At least one organism has been identified from surgical site by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"At least one organism has been identified from surgical site by a culture or "
+"non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, NOT Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: Title ==
@@ -2480,12 +3296,17 @@ msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:832
-msgid "The following rates are calculated both for the departments’ reports and for the reference reports and can serve as starting point for further analyses and discussions in your department."
+msgid ""
+"The following rates are calculated both for the departments’ reports and for "
+"the reference reports and can serve as starting point for further analyses "
+"and discussions in your department."
 msgstr ""
 
 #. type: #data-analysis
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:834
-msgid "For the core module, the rates are generally stratified into 4 groups according to the birth weight of the infants:"
+msgid ""
+"For the core module, the rates are generally stratified into 4 groups "
+"according to the birth weight of the infants:"
 msgstr ""
 
 #. type: #data-analysis
@@ -2522,27 +3343,38 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:846
-msgid "A device utilization rate describes the percentage of patient days on which a specific device was used.  It is calculated by dividing the number of device days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A device utilization rate describes the percentage of patient days on which "
+"a specific device was used.  It is calculated by dividing the number of "
+"device days by the number of patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:848
-msgid "stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"CVC Utilisation Rate\" = \"Total CVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:850
-msgid "stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"PVC Utilisation Rate\" = \"Total PVC Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:852
-msgid "stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" xx 100 ]"
+msgid ""
+"stem:[\"INV Utilisation Rate\" = \"Total INV Days\" / \"Total Patient Days\" "
+"xx 100 ]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-device-utilization
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:854
-msgid "stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"NIV Utilisation Rate\" = \"Total NIV Days\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2553,47 +3385,76 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:859
-msgid "Antibiotic use rate describes the percentage of patient days on which systemic antibiotics were used in relation to the total patient days.  It is calculated by dividing the number of antibiotic days by the number of patient days and multiplying the result by 100."
+msgid ""
+"Antibiotic use rate describes the percentage of patient days on which "
+"systemic antibiotics were used in relation to the total patient days.  It is "
+"calculated by dividing the number of antibiotic days by the number of "
+"patient days and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:861
-msgid "stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Antibiotic Use Rate\" = \"Total Antibiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:863
-msgid "In addition to the overall antibiotic use rate, antibiotic use rates and proportions of patients receiving a substance are calculated for individual substances and groups of substances."
+msgid ""
+"In addition to the overall antibiotic use rate, antibiotic use rates and "
+"proportions of patients receiving a substance are calculated for individual "
+"substances and groups of substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:867
-msgid "The substances and groups are derived from the Anatomical Therapeutic Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
+msgid ""
+"The substances and groups are derived from the Anatomical Therapeutic "
+"Chemical (ATC) Classificationfootnote:[Anatomical Therapeutic Chemical "
+"Classificationpass:p[ +] https://www.who.int/tools/atc-ddd-toolkit/atc-"
+"classification] as published in the most recent ATC/DDD Indexfootnote:[ATC/"
+"DDD Indexpass:p[ +] https://www.whocc.no/atc_ddd_index/]."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:869
-msgid "Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping substances."
+msgid ""
+"Currently the ATC 1st, 2nd, 4th and 5th level are used for grouping "
+"substances."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:871
-msgid "Since the numbers in the individual groups usually get very small, the substance and group specific use rates are calculated by dividing the number of substance (group) days by the number of patient days and multiplying the result by 1000."
+msgid ""
+"Since the numbers in the individual groups usually get very small, the "
+"substance and group specific use rates are calculated by dividing the number "
+"of substance (group) days by the number of patient days and multiplying the "
+"result by 1000."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:873
-msgid "stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Substance Group Use Rate\" = \"Total Therapy Days for Substance "
+"Group\" / \"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:875
-msgid "The proportion of patients receiving any specific substance(s) of a substance group is calculated as ratio between the total number of patients receiving a specific substance or group of antibiotics and the total number of patients receiving any kind of antibiotic multiplied by 100."
+msgid ""
+"The proportion of patients receiving any specific substance(s) of a "
+"substance group is calculated as ratio between the total number of patients "
+"receiving a specific substance or group of antibiotics and the total number "
+"of patients receiving any kind of antibiotic multiplied by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-antibiotic-use
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:877
-msgid "stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = \"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Proportion of Patients Receiving an AB Substance or Group\" = "
+"\"Total Therapy Days for that Substance or Group\" / \"Total Patient Days\" "
+"xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2604,22 +3465,33 @@ msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:882
-msgid "A protective factor utilization rate describes the percentage of patient days on which a patient received a specific protective factor, such as breast milk, probiotic or kangaroo mother care.  It is calculated by dividing the number of protective factor days by the number of patient days and multiplying the result by 100."
+msgid ""
+"A protective factor utilization rate describes the percentage of patient "
+"days on which a patient received a specific protective factor, such as "
+"breast milk, probiotic or kangaroo mother care.  It is calculated by "
+"dividing the number of protective factor days by the number of patient days "
+"and multiplying the result by 100."
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:884
-msgid "stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Breast Milk Intake Rate\" = \"Total Breast Milk Days\" / \"Total "
+"Patient Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:886
-msgid "stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Probiotic Usage Rate\" = \"Total Probiotic Days\" / \"Total Patient "
+"Days\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-risk-factors-and-protective-factors-protective-factor-implementation
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:888
-msgid "stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / \"Total Patient Days\" xx 100]"
+msgid ""
+"stem:[\"Kangaroo Care Implementation Rate\" = \"Total Kangaroo Care Days\" / "
+"\"Total Patient Days\" xx 100]"
 msgstr ""
 
 #. type: Title ===
@@ -2636,22 +3508,32 @@ msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:895
-msgid "Since a substantial proportion of infections cannot be linked to a specific risk factor, incidence densities are calculated for bloodstream infections, pneumonia, NEC.  The risk factor here represents the cumulative number of patient days and is standardized as 1000 patient days."
+msgid ""
+"Since a substantial proportion of infections cannot be linked to a specific "
+"risk factor, incidence densities are calculated for bloodstream infections, "
+"pneumonia, NEC.  The risk factor here represents the cumulative number of "
+"patient days and is standardized as 1000 patient days."
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:897
-msgid "stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"BSI Incidence Density\" = \"Total BSI Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:899
-msgid "stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"Pneumonia Incidence Density\" = \"Total Pneumonia Cases\" / \"Total "
+"Patient Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-incidence-densities
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:901
-msgid "stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient Days\" xx 1000]"
+msgid ""
+"stem:[\"NEC Incidence Density\" = \"Total NEC Cases\" / \"Total Patient "
+"Days\" xx 1000]"
 msgstr ""
 
 #. type: Title ====
@@ -2662,42 +3544,70 @@ msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:906
-msgid "A device-associated infection rate is an important quality management metric and describes how many device-associated infections occur per 1000 device days.  In this process called standardization, infections (e.g., BSI) occurring in the presence of a certain risk factor (e.g., CVC) are associated with the total number of days at risk (e.g., CVC Days) and the result is multiplied by 1000."
+msgid ""
+"A device-associated infection rate is an important quality management metric "
+"and describes how many device-associated infections occur per 1000 device "
+"days.  In this process called standardization, infections (e.g., BSI) "
+"occurring in the presence of a certain risk factor (e.g., CVC) are "
+"associated with the total number of days at risk (e.g., CVC Days) and the "
+"result is multiplied by 1000."
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:908
-msgid "stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With CVC\" / \"Total CVC Days\" xx 1000]"
+msgid ""
+"stem:[\"CVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"CVC\" / \"Total CVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:910
-msgid "stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With PVC\" / \"Total PVC Days\" xx 1000]"
+msgid ""
+"stem:[\"PVC-associated BSI Rate\" = \"Total BSI Cases in Patients With "
+"PVC\" / \"Total PVC Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:912
-msgid "stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With INV\" / \"Total INV Days\" xx 1000]"
+msgid ""
+"stem:[\"INV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With INV\" / \"Total INV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-device-associated-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:914
-msgid "stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in Patients With NIV\" / \"Total NIV Days\" xx 1000]"
+msgid ""
+"stem:[\"NIV-associated Pneumonia Rate\" = \"Total Pneumonia Cases in "
+"Patients With NIV\" / \"Total NIV Days\" xx 1000]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:921
-msgid "Surgical site infection (SSI) rates define the percentage of SSI that occur during the observation period after an operative procedure.  It is calculated by dividing the number of SSIs occurring after a surgical procedure by the number of surgical procedures and multiplying the result by 100.  Since the risk of developing a SSI depends on the type of surgical procedure, multiple SSI rates are calculated for groups of similar procedures.  Nevertheless, an overall SSI rate will be calculated to account for the fact that surgery in VLBW/VPT infants is less frequent than in adults and grouping procedures may result in very low procedure counts per group."
+msgid ""
+"Surgical site infection (SSI) rates define the percentage of SSI that occur "
+"during the observation period after an operative procedure.  It is "
+"calculated by dividing the number of SSIs occurring after a surgical "
+"procedure by the number of surgical procedures and multiplying the result by "
+"100.  Since the risk of developing a SSI depends on the type of surgical "
+"procedure, multiple SSI rates are calculated for groups of similar "
+"procedures.  Nevertheless, an overall SSI rate will be calculated to account "
+"for the fact that surgery in VLBW/VPT infants is less frequent than in "
+"adults and grouping procedures may result in very low procedure counts per "
+"group."
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:923
-msgid "stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of Surgeries\" xx 100]"
+msgid ""
+"stem:[\"Overall SSI Rate\" = \"Total SSI Cases\" / \"Total Number of "
+"Surgeries\" xx 100]"
 msgstr ""
 
 #. type: #data-analysis-infections-surgical-site-infections
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:925
-msgid "stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
+msgid ""
+"stem:[\"Grouped SSI Rate\" = \"Total SSI Cases Observed After the Procedures "
+"in This Group\" / \"Total Number of Procedures in This Group\" xx 100]"
 msgstr ""
 
 #. type: Title ====
@@ -2708,7 +3618,18 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:931
-msgid "With the infection rates described above, it is possible to observe risk factors and infections for the 3 birthweight classes in detail.  However, 500 g birth weight is a relatively crude stratification for neonatal infection risk, and it also does not account the fact that infants may be transferred to other departments (e.g., for surgery or to a department closer to the parents’ home) long before they would normally be discharged and that the high-risk days of the stabilization phase would accumulate in some neonatology departments while others would accumulate the low risk days of already stabilized infants.  To account for this, NeoIPC calculates a standardized infection rate (SIR) , which compares infection frequencies between departments based on their patient population composition."
+msgid ""
+"With the infection rates described above, it is possible to observe risk "
+"factors and infections for the 3 birthweight classes in detail.  However, "
+"500 g birth weight is a relatively crude stratification for neonatal "
+"infection risk, and it also does not account the fact that infants may be "
+"transferred to other departments (e.g., for surgery or to a department "
+"closer to the parents’ home) long before they would normally be discharged "
+"and that the high-risk days of the stabilization phase would accumulate in "
+"some neonatology departments while others would accumulate the low risk days "
+"of already stabilized infants.  To account for this, NeoIPC calculates a "
+"standardized infection rate (SIR) , which compares infection frequencies "
+"between departments based on their patient population composition."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
@@ -2728,32 +3649,50 @@ msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:938
-msgid "From the reference database, the average risk of BSI or pneumonia for a certain day of life of an infant with a certain birth weight is calculated."
+msgid ""
+"From the reference database, the average risk of BSI or pneumonia for a "
+"certain day of life of an infant with a certain birth weight is calculated."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:940
-msgid "After this, the number of expected infections (cumulated risk) for a department is calculated by summing the average risks of the infants and the respective days they spent in the department."
+msgid ""
+"After this, the number of expected infections (cumulated risk) for a "
+"department is calculated by summing the average risks of the infants and the "
+"respective days they spent in the department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:942
-msgid "The SIR represents the ratio of observed infections to expected infections in a department and can give a general overview of the infection risk in a department."
+msgid ""
+"The SIR represents the ratio of observed infections to expected infections "
+"in a department and can give a general overview of the infection risk in a "
+"department."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:945
-msgid "stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / \"Total infections expected\"] When the standardized infection rate is greater than one, you observed more infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"stem:[\"Standardized Infection Rate\" = \"Total Infections Observed\" / "
+"\"Total infections expected\"] When the standardized infection rate is "
+"greater than one, you observed more infections than you would expect from "
+"your patient composition when compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:947
-msgid "When the standardized infection rate equals one, you observed the same number of infections as you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate equals one, you observed the same "
+"number of infections as you would expect from your patient composition when "
+"compared to the reference data."
 msgstr ""
 
 #. type: #data-analysis-infections-standardized-infection-rate
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:949
-msgid "When the standardized infection rate is less than one, you observed less infections than you would expect from your patient composition when compared to the reference data."
+msgid ""
+"When the standardized infection rate is less than one, you observed less "
+"infections than you would expect from your patient composition when compared "
+"to the reference data."
 msgstr ""
 
 #. type: Title ==
@@ -2770,7 +3709,9 @@ msgstr ""
 
 #. type: horizontal
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:954
-msgid "Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation Cephalosporins"
+msgid ""
+"Multi drug resistant gram-negative pathogen resistant to 3^rd^ generation "
+"Cephalosporins"
 msgstr ""
 
 #. type: Labeled list
@@ -3257,7 +4198,9 @@ msgstr ""
 
 #. type: #imprint
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1012
-msgid "To learn more about the NeoDeco Trial and the Clinical Practice Network, write to:"
+msgid ""
+"To learn more about the NeoDeco Trial and the Clinical Practice Network, "
+"write to:"
 msgstr ""
 
 #. type: #imprint
@@ -3283,7 +4226,9 @@ msgstr ""
 
 #. type: #appendix-list-of-antibiotics
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1024
-msgid "_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
+msgid ""
+"_Derived from the WHO AWaRe classification and the WHOCC ATC/DDD index. "
+"Licensed under CC BY-NC-SA 3.0 IGO — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: Title ==
@@ -3294,17 +4239,23 @@ msgstr ""
 
 #. type: #appendix-list-of-list-of-infectious-agents
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1032
-msgid "_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV (taxonomic facts) — see <<licensing-and-attribution>>._"
+msgid ""
+"_Organism names and taxonomy compiled from NHSN, LPSN, MycoBank and ICTV "
+"(taxonomic facts) — see <<licensing-and-attribution>>._"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:5
-msgid "**Absence of positive microbiological blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Absence of positive microbiological blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:8
-msgid "**Treatment with FIVE or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with FIVE or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3312,7 +4263,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:8
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:40
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:61
-msgid "**Patient has at least TWO of the following clinical or laboratory features of generalized infection:**"
+msgid ""
+"**Patient has at least TWO of the following clinical or laboratory features "
+"of generalized infection:**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3329,7 +4282,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:42
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:63
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:13
-msgid "New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia (>200/min)"
+msgid ""
+"New/more frequent bradycardia episodes (<80/min) or unexplained tachycardia "
+"(>200/min)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3337,7 +4292,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:11
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:43
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:64
-msgid "Impaired peripheral perfusion (Capillary refill time of > 3s or skin mottling or core/peripheral temperature gap > 2 °C)"
+msgid ""
+"Impaired peripheral perfusion (Capillary refill time of > 3s or skin "
+"mottling or core/peripheral temperature gap > 2 °C)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3345,7 +4302,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:12
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:44
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:65
-msgid "New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or ventilatory support"
+msgid ""
+"New/more frequent episodes of apnoea (>20s) or increase in oxygen demand or "
+"ventilatory support"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3377,7 +4336,9 @@ msgstr ""
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:16
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:48
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:69
-msgid "New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
+msgid ""
+"New and unexplained hyperglycaemia (> 140 mg/dl; > 7.8 mmol/L) or "
+"hypoglycaemia (< 40 mg/dl; <2.2 mmol/L)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3437,7 +4398,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Clinical-Sepsis-Definition.adoc:32
-msgid "*Antibiotic treatment for at least five days was initiated.  The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*Antibiotic treatment for at least five days was initiated.  The day of the "
+"first dose and the day of the last dose are counted.  Days where no dose was "
+"administered between the first and the last dose (e.g., skipped doses "
+"because of high drug levels in therapeutic drug monitoring) are counted as "
+"if a dose had been administered.  Days after the last dose are not counted "
+"regardless of the patient's measured or assumed drug level.  If the infant "
+"died, was discharged, or transferred before the end of the five-day course "
+"of intravenous antibiotics, this condition is met if treatment was scheduled "
+"for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3454,7 +4424,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves deep soft tissues of the incision (for example, fascial and muscle layers)**"
+msgid ""
+"**Infection involves deep soft tissues of the incision (for example, fascial "
+"and muscle layers)**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3471,22 +4443,36 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:13
-msgid "A deep incision that spontaneously dehisces, or is deliberately opened or aspirated by a surgeon, physician* or physician designee"
+msgid ""
+"A deep incision that spontaneously dehisces, or is deliberately opened or "
+"aspirated by a surgeon, physician* or physician designee"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:17
-msgid "Organism(s) identified from the deep soft tissues of the incision by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based microbiologic testing method is not performed. A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Organism(s) identified from the deep soft tissues of the incision by a "
+"culture or non-culture based microbiologic testing method which is performed "
+"for purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST)) or culture or non-culture based "
+"microbiologic testing method is not performed. A culture or non-culture-"
+"based test from the deep soft tissues of the incision that has a negative "
+"finding does not meet this criterion."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:21
-msgid "Patient has at least one of the following signs or symptoms: Temperature instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or tenderness."
+msgid ""
+"Patient has at least one of the following signs or symptoms: Temperature "
+"instability, fever (> 38 °C) or hypothermia (< 36.5 °C); localized pain or "
+"tenderness."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:22
-msgid "An abscess or other evidence of infection involving the deep incision that is detected on gross anatomical or histopathologic exam, or imaging test."
+msgid ""
+"An abscess or other evidence of infection involving the deep incision that "
+"is detected on gross anatomical or histopathologic exam, or imaging test."
 msgstr ""
 
 #. type: Plain text
@@ -3497,7 +4483,11 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Deep-Incisional-SSI-Definition.adoc:26
-msgid "*The term physician for the purpose of application of the NHSN SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NHSN SSI criteria "
+"may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: Block title
@@ -3508,7 +4498,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:5
-msgid "**The same common commensal is recovered from at least TWO blood and/or CSF culture specimen collected on separate occasions**"
+msgid ""
+"**The same common commensal is recovered from at least TWO blood and/or CSF "
+"culture specimen collected on separate occasions**"
 msgstr ""
 
 #. type: Block title
@@ -3520,7 +4512,9 @@ msgstr ""
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:29
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:55
-msgid "**A common commensal is recovered from ONE blood culture and/or CSF culture specimen**"
+msgid ""
+"**A common commensal is recovered from ONE blood culture and/or CSF culture "
+"specimen**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3536,12 +4530,22 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:58
-msgid "**Treatment with five or more days of intravenous antibiotics was initiated$$*$$**"
+msgid ""
+"**Treatment with five or more days of intravenous antibiotics was initiated$"
+"$*$$**"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Common-Commensal-Definition.adoc:81
-msgid "*The day of the first dose and the day of the last dose are counted.  Days where no dose was administered between the first and the last dose (e.g., skipped doses because of high drug levels in therapeutic drug monitoring) are counted as if a dose had been administered.  Days after the last dose are not counted regardless of the patient's measured or assumed drug level.  If the infant died, was discharged, or transferred before the end of the five-day course of intravenous antibiotics, this condition is met if treatment was scheduled for five days or more."
+msgid ""
+"*The day of the first dose and the day of the last dose are counted.  Days "
+"where no dose was administered between the first and the last dose (e.g., "
+"skipped doses because of high drug levels in therapeutic drug monitoring) "
+"are counted as if a dose had been administered.  Days after the last dose "
+"are not counted regardless of the patient's measured or assumed drug level.  "
+"If the infant died, was discharged, or transferred before the end of the "
+"five-day course of intravenous antibiotics, this condition is met if "
+"treatment was scheduled for five days or more."
 msgstr ""
 
 #. type: Block title
@@ -3552,7 +4556,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-LCBSI-With-Recognised-Pathogen-Definition.adoc:5
-msgid "**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid culture**"
+msgid ""
+"**Recognised pathogen is recovered from a blood and/or cerebrospinal fluid "
+"culture**"
 msgstr ""
 
 #. type: Block title
@@ -3563,7 +4569,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:5
-msgid "**At least of ONE the following radiological signs (imaging technologies: X-ray, CT, MRI, ultrasound):**"
+msgid ""
+"**At least of ONE the following radiological signs (imaging technologies: X-"
+"ray, CT, MRI, ultrasound):**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3604,7 +4612,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Necrotising-Enterocolitis-Definition.adoc:17
-msgid "Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
+msgid ""
+"Repeated occult (guaiac test) or visible blood in stool (no anal fissure)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3651,32 +4660,51 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:8
-msgid "**Infection involves any part of the body deeper than the fascial/muscle layers that is opened or manipulated during the operative procedure**"
+msgid ""
+"**Infection involves any part of the body deeper than the fascial/muscle "
+"layers that is opened or manipulated during the operative procedure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:12
-msgid "Purulent drainage from a drain that is placed into the organ/space (for example, closed suction drainage system, open drain, T-tube drain, CT-guided drainage)."
+msgid ""
+"Purulent drainage from a drain that is placed into the organ/space (for "
+"example, closed suction drainage system, open drain, T-tube drain, CT-guided "
+"drainage)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:13
-msgid "Organism(s) identified from fluid or tissue in the organ/space by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from fluid or tissue in the organ/space by a culture "
+"or non-culture based microbiologic testing method which is performed for "
+"purposes of clinical diagnosis or treatment (for example, not Active "
+"Surveillance Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Organ-Space-SSI-Definition.adoc:14
-msgid "An abscess or other evidence of infection involving the organ/space that is detected on gross anatomical or histopathologic exam, or imaging test evidence suggestive of infection."
+msgid ""
+"An abscess or other evidence of infection involving the organ/space that is "
+"detected on gross anatomical or histopathologic exam, or imaging test "
+"evidence suggestive of infection."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:5
-msgid "**At least ONE of the following imaging findings (imaging technologies: X-ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as infiltrate, shadowing, opacification, increased density, fluid in the intrapleural cavity or interlobar fissure**"
+msgid ""
+"**At least ONE of the following imaging findings (imaging technologies: X-"
+"ray, CT, MRI, ultrasound) shows new changes suggestive of pneumonia, such as "
+"infiltrate, shadowing, opacification, increased density, fluid in the "
+"intrapleural cavity or interlobar fissure**"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:8
-msgid "**New initiation of respiratory support or escalation of existing level of respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or improvement**"
+msgid ""
+"**New initiation of respiratory support or escalation of existing level of "
+"respiratory support for ≥ 2 days$$*$$ after at least 2 days of stability or "
+"improvement**"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3691,7 +4719,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:14
-msgid "New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> 20 s)"
+msgid ""
+"New or more frequent tachypnoea (>60/min) or new or more frequent apnoea (> "
+"20 s)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3701,7 +4731,9 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:16
-msgid "New or more frequent symptoms of respiratory distress (retraction, nasal flaring, grunting, chest indrawing)"
+msgid ""
+"New or more frequent symptoms of respiratory distress (retraction, nasal "
+"flaring, grunting, chest indrawing)"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3711,12 +4743,15 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:18
-msgid "Increased respiratory secretion (more frequent endotracheal suctioning required)"
+msgid ""
+"Increased respiratory secretion (more frequent endotracheal suctioning "
+"required)"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:19
-msgid "CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
+msgid ""
+"CRP > 10 mg/L (> 1 mg/dL) or increased levels of interleukin (IL) 6 or 8^#^"
 msgstr ""
 
 #. type: delimited block * 4
@@ -3726,27 +4761,40 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:23
-msgid "*New initiation of respiratory support or escalation of existing level of respiratory support that does not improve within less than two days:"
+msgid ""
+"*New initiation of respiratory support or escalation of existing level of "
+"respiratory support that does not improve within less than two days:"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:25
-msgid "Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily minimum FiO~2~ values must be taken into account)"
+msgid ""
+"Increase in need for FiO~2~ ≥ 0.25 (25 points) within 24 hours (daily "
+"minimum FiO~2~ values must be taken into account)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:33
-msgid "…that does not improve within less than 2 days: The above-mentioned condition should not improve within two days."
+msgid ""
+"…that does not improve within less than 2 days: The above-mentioned "
+"condition should not improve within two days."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:35
-msgid "…after at least 2 days of stability or improvement: A stable or improving baseline period of at least two days is required before the above condition occurs."
+msgid ""
+"…after at least 2 days of stability or improvement: A stable or improving "
+"baseline period of at least two days is required before the above condition "
+"occurs."
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:39
-msgid "^+^At least one organism (see below) has been identified from respiratory tract by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, NOT Active Surveillance Culture/Testing (ASC/AST)):"
+msgid ""
+"^+^At least one organism (see below) has been identified from respiratory "
+"tract by a culture or non-culture based microbiologic testing method which "
+"is performed for purposes of clinical diagnosis or treatment (for example, "
+"NOT Active Surveillance Culture/Testing (ASC/AST)):"
 msgstr ""
 
 #. type: Plain text
@@ -3756,12 +4804,16 @@ msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:44
-msgid "Viral gene, antigen or antibody from secretions of upper or lower respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
+msgid ""
+"Viral gene, antigen or antibody from secretions of upper or lower "
+"respiratory tract (e.g. EIA, FAMA, shell vial assay, PCR)"
 msgstr ""
 
 #. type: Plain text
 #: doc/protocol/definitions/NeoIPC-Core-Pneumonia-Definition.adoc:46
-msgid "^#^Interleukin should be used as a parameter when laboratory specifications for a pathological value have been fulfilled."
+msgid ""
+"^#^Interleukin should be used as a parameter when laboratory specifications "
+"for a pathological value have been fulfilled."
 msgstr ""
 
 #. type: Block title
@@ -3777,7 +4829,8 @@ msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:8
-msgid "**Infection involves only skin and subcutaneous tissue of the incision**"
+msgid ""
+"**Infection involves only skin and subcutaneous tissue of the incision**"
 msgstr ""
 
 #. type: loweralpha
@@ -3787,47 +4840,75 @@ msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:14
-msgid "Organism(s) identified from an aseptically obtained specimen from the superficial incision or subcutaneous tissue by a culture or non-culture based microbiologic testing method which is performed for purposes of clinical diagnosis or treatment (for example, not Active Surveillance Culture/Testing (ASC/AST))."
+msgid ""
+"Organism(s) identified from an aseptically obtained specimen from the "
+"superficial incision or subcutaneous tissue by a culture or non-culture "
+"based microbiologic testing method which is performed for purposes of "
+"clinical diagnosis or treatment (for example, not Active Surveillance "
+"Culture/Testing (ASC/AST))."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:16
-msgid "Superficial incision that is deliberately opened by a surgeon, physician* or physician designee and culture or non-culture-based testing of the superficial incision or subcutaneous tissue is not performed.  A culture or non-culture-based test from the deep soft tissues of the incision that has a negative finding does not meet this criterion."
+msgid ""
+"Superficial incision that is deliberately opened by a surgeon, physician* or "
+"physician designee and culture or non-culture-based testing of the "
+"superficial incision or subcutaneous tissue is not performed.  A culture or "
+"non-culture-based test from the deep soft tissues of the incision that has a "
+"negative finding does not meet this criterion."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:20
-msgid "Patient has at least one of the following signs or symptoms: localized pain or tenderness, localized swelling, erythema or heat."
+msgid ""
+"Patient has at least one of the following signs or symptoms: localized pain "
+"or tenderness, localized swelling, erythema or heat."
 msgstr ""
 
 #. type: loweralpha
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:21
-msgid "Diagnosis of a superficial incisional SSI by a physician* or physician designee."
+msgid ""
+"Diagnosis of a superficial incisional SSI by a physician* or physician "
+"designee."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:24
-msgid "*The term physician for the purpose of application of the NeoIPC SSI criteria may be interpreted to mean a surgeon, infectious disease physician, emergency physician, another physician on the case, or physician’s designee (nurse practitioner or physician’s assistant)."
+msgid ""
+"*The term physician for the purpose of application of the NeoIPC SSI "
+"criteria may be interpreted to mean a surgeon, infectious disease physician, "
+"emergency physician, another physician on the case, or physician’s designee "
+"(nurse practitioner or physician’s assistant)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:26
-msgid "The following do not qualify as criteria for meeting the definition of superficial incisional SSI"
+msgid ""
+"The following do not qualify as criteria for meeting the definition of "
+"superficial incisional SSI"
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:28
-msgid "Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does not meet superficial incisional SSI criterion ‘d’."
+msgid ""
+"Diagnosis/treatment of cellulitis (redness/warmth/swelling), by itself, does "
+"not meet superficial incisional SSI criterion ‘d’."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:29
-msgid "A stitch abscess alone (minimal inflammation and discharge confined to the points of suture penetration)."
+msgid ""
+"A stitch abscess alone (minimal inflammation and discharge confined to the "
+"points of suture penetration)."
 msgstr ""
 
 #. type: delimited block * 4
 #: doc/protocol/definitions/NeoIPC-Core-Superficial-Incisional-SSI-Definition.adoc:30
-msgid "A localized stab wound or pin site infection. Note: A laparoscopic trocar site is considered a surgical incision and not a stab wound.  If a surgeon uses a laparoscopic trocar site to place a drain at the end of a procedure this is considered a surgical incision."
+msgid ""
+"A localized stab wound or pin site infection. Note: A laparoscopic trocar "
+"site is considered a surgical incision and not a stab wound.  If a surgeon "
+"uses a laparoscopic trocar site to place a drain at the end of a procedure "
+"this is considered a surgical incision."
 msgstr ""
 
 #. type: Content of: <root><data><value>


### PR DESCRIPTION
Catalogue maintenance only — the msgmerge add-on re-wraps the long single-line entries to the
component's configured line width.

No translation content changes: every `msgid` and `msgstr` is byte-identical after unwrapping, which
is why insertions outnumber deletions roughly five to one.
