### PR TITLE
Give the toolkit a README that orients a newcomer, and state the metadata package's real limits

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 The NeoIPC Project Consortium
+Copyright (c) The NeoIPC Project Consortium
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,122 @@
-# Surveillance-Toolkit
-This repository contains the surveillance toolkit of the NeoIPC Project
+# NeoIPC Surveillance Toolkit
+
+[![Build](https://github.com/NeoIPC/Surveillance-Toolkit/actions/workflows/build.yml/badge.svg)](https://github.com/NeoIPC/Surveillance-Toolkit/actions/workflows/build.yml)
+[![Translation status](https://hosted.weblate.org/widgets/neoipc/-/svg-badge.svg)](https://hosted.weblate.org/engage/neoipc/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
+Everything a neonatal department needs in order to take part in NeoIPC surveillance, and everything
+the project needs in order to analyse what they collect: the surveillance protocol and its case
+definitions, the DHIS2 configuration that gathers the data, the reference lists of infectious agents
+and antimicrobial substances, and the reports that give each participating department its results.
+
+[NeoIPC](https://neoipc.org) works to reduce the transmission of resistant bacteria in neonatal
+intensive care across Europe and globally. Its
+[surveillance system](https://neoipc.org/surveillance/) collects healthcare-associated infection and
+antimicrobial-use data from neonatal departments so that a department can compare itself against the
+network. This repository is the **normative source** for that surveillance: when a case definition
+changes here, the change propagates to the data-collection forms, the analysis code and the reports.
+Where code and the definitions in this repository disagree, the definitions win.
+
+## What's in here
+
+| Path | Contents |
+|------|----------|
+| [`doc/protocol/`](doc/protocol/) | The **NeoIPC Core Surveillance Protocol** in AsciiDoc, including the eight normative case definitions under [`definitions/`](doc/protocol/definitions/) — clinical sepsis, the two laboratory-confirmed bloodstream-infection variants, the three surgical-site-infection depths, necrotising enterocolitis and pneumonia. |
+| [`metadata/`](metadata/) | The **canonical DHIS2 configuration** for the `NEOIPC_CORE` tracker program — data elements, option sets, program rules, tracked-entity attributes and the organisation-unit scaffold — authored as reviewable per-type CSVs plus externalised expression files rather than one opaque JSON blob. See [`metadata/common/README.md`](metadata/common/README.md). |
+| [`metadata/common/infectious-agents/`](metadata/common/infectious-agents/) | The **NeoIPC Infectious Agent List** — a pragmatic ontology of organisms with their synonyms and phenotypic resistance categories, named from LPSN, MycoBank and ICTV. Licensed separately; see below. |
+| [`metadata/common/antibiotics/`](metadata/common/antibiotics/) | The **NeoIPC Antibiotics List** — substances, groups and WHO AWaRe categories. Licensed separately; see below. |
+| [`reports/`](reports/) | Five **Quarto reports**, drawing their data from the [neoipcr](https://github.com/NeoIPC/neoipcr) R package: the Partner Report a department receives, the network-wide Reference Report, a Validation Report that flags data-quality problems, a Partner Certificate, and a Patient Data Report answering data-subject access requests. |
+| [`po/`](po/) | The **gettext catalogues** behind every localized artifact, managed with [po4a](https://po4a.org/) and translated on Weblate. |
+| [`glossary.yaml`](glossary.yaml) | The controlled vocabulary the reports and translators share, so one concept reads the same way everywhere. |
+| [`scripts/`](scripts/) | PowerShell entry points — `Build-*.ps1` render an artifact, `Test-*.ps1` check an invariant, `Invoke-Localization.ps1` drives the translation pipeline. Shared logic lives in the [`NeoIPC-Tools`](scripts/modules/NeoIPC-Tools/README.md) module. |
+| [`docs/`](docs/) | Design references for the pieces whose reasoning does not fit in a source comment — the metadata pipeline, the infectious-agent ontology, the Weblate component contract. |
+
+## Products and releases
+
+The repository publishes **five independently versioned products** from one shared history, each with
+its own version file, tag stream and releases:
+
+| Product | Tag prefix |
+|---------|-----------|
+| NeoIPC Core Surveillance Protocol | `protocol-v*` |
+| NeoIPC DHIS2 Metadata Package | `metadata-v*` |
+| NeoIPC Surveillance Reports | `reports-v*` |
+| NeoIPC Infectious Agent List | `infectious-agents-v*` |
+| NeoIPC Antibiotics List | `antibiotics-v*` |
+
+The infectious-agent and antibiotics lists are shared inputs: the protocol compiles them and the
+metadata package embeds them as option sets, so both declare the exact list release they incorporate
+and CI refuses a release that would ship unreleased list content. [`RELEASING.md`](RELEASING.md) has
+the full mechanics.
+
+To install NeoIPC into a DHIS2 instance you want the **metadata package** — an importable JSON
+release asset, with a synthetic play variant for test instances. It is a generated artifact and is
+deliberately not committed; [`metadata/dist/README.md`](metadata/dist/README.md) explains where to
+get it and how to import it.
+
+**That package is alpha — expect to adapt it rather than deploy it.** It is version `0.0.1-alpha`.
+It does not yet follow the WHO `dhis2-package-exporter` sharing and manifest conventions: it imports
+because DHIS2 ignores the manifest key it does not recognise, not because it conforms. It also
+attaches the program to no organisation units, so the hierarchy is yours to build and connect.
+
+It has been verified against DHIS2 **2.40.12** and **2.41.9** only — earlier 2.40 patches are not
+supported, `2.40.3.2` in particular carrying a confirmed defect that was fixed in `2.40.4`. On
+**2.42 and 2.43** an import
+intermittently drops the members of owned ordered collections — an option-group set arrives holding
+none of its groups — and reports no error while doing so. The failure is non-deterministic but sticks
+to an instance: it recurs identically there, while a freshly created instance may take the same
+package cleanly. The cause is open and there is no workaround short of rebuilding the instance, so on
+those versions **verify what actually landed instead of trusting a successful-looking import**. The
+running NeoIPC deployment is unaffected — it is on 2.41 or older.
+
+## Working with the toolkit
+
+The tooling is PowerShell 7.6 or newer plus, depending on what you are building, R and Quarto (reports),
+Asciidoctor PDF and Pandoc (protocol), or po4a (translations). Every script carries comment-based
+help, so `Get-Help ./scripts/Build-PartnerReport.ps1 -Full` is the reference for its arguments.
+
+```powershell
+git clone --recurse-submodules https://github.com/NeoIPC/Surveillance-Toolkit.git
+cd Surveillance-Toolkit
+```
+
+The `--recurse-submodules` matters only for translation work: [`tools/po4a`](tools/po4a) is a
+submodule, and the localization pipeline needs it.
+
+[`doc/README.md`](doc/README.md) lists the prerequisites for building the protocol documents and how
+to install them on Windows and Ubuntu. On Windows, po4a runs under the Windows Subsystem for Linux —
+it does not run natively.
+
+## Part of the NeoIPC surveillance system
+
+| Repository | Role |
+|------------|------|
+| **Surveillance-Toolkit** | *(this repository)* The protocol, the case definitions, the DHIS2 metadata and the report sources |
+| [neoipcr](https://github.com/NeoIPC/neoipcr) | R package that reads NeoIPC data out of DHIS2 and computes the surveillance indicators |
+| [NeoIPC-Reporting](https://github.com/NeoIPC/NeoIPC-Reporting) | Service that renders this repository's reports on demand and serves them over HTTP |
+| [neoipc-app](https://github.com/NeoIPC/neoipc-app) | DHIS2 application through which people request reports and administer reference data |
+
+Surveillance data itself is collected in a DHIS2 instance configured from the metadata package above.
+The deployment configuration for the NeoIPC network's own instances is maintained privately and
+contains no part of the definitions — those are all here.
+
+## Contributing
+
+Contributions are welcome. Much of this repository is incomplete or thin on documentation, because
+the tools and the partner network are being built at the same time; issues and pull requests that
+sharpen either are useful.
+
+Two things are worth knowing before you start. Case definitions are normative — a pull request that
+changes one is a scientific change, not an editorial one, so raise an issue first. And the reports'
+translated text lives in gettext catalogues, not in the source files: change the English string and
+regenerate, never hand-edit a generated localized file.
+
+**Translations.** The protocol, the report text, the infectious-agent names and the DHIS2 metadata
+are translated on [Weblate](https://hosted.weblate.org/projects/neoipc/), who support this project's
+translation effort with their software, expertise and free hosting. Contributions in any language are
+welcome, and no git knowledge is needed — translating in the web interface is enough. Feedback on a
+translation belongs in Weblate's per-string comments, where the person who wrote it will see it,
+rather than on a pull request.
 
 ## Licensing
 
@@ -14,4 +131,9 @@ Two data directories compile content from upstream sources whose terms are stric
 
 The two directories land on different Creative Commons terms because their upstream licences differ. The infectious-agent list is **no-derivatives** — its MycoBank source is CC BY-NC-ND, incorporated with permission. The antibiotic list is a **derivative** of the WHO AWaRe classification (CC BY-NC-SA 3.0 IGO); ShareAlike requires a derivative to keep the same licence, so it is CC BY-NC-SA 3.0 IGO (the ATC codes, substance names and group descriptions it also carries are reproduced unchanged from the WHOCC ATC/DDD index, not adapted). We apply the licence the upstream terms require, no stricter.
 
-The gettext translation catalogues under [`po/`](po/) each declare, in their header, the license of the content they localize: MIT for the reports and scripts, CC BY 4.0 for the protocol documentation and the DHIS2 metadata, and the licenses above for the two data lists.
+The gettext translation catalogues under [`po/`](po/) declare their licence in their own headers. Two of them are mid-correction and currently disagree with their templates: the translated `reports` and `infectious_agents` catalogues still carry MIT and CC BY-NC-ND 4.0 respectively, while both `.pot` templates declare CC BY 4.0. The templates carry the intended terms — a catalogue of extracted strings is not automatically bound by the licence of the directory it was extracted from, and a no-derivatives term cannot govern a translation, which *is* a derivative work. The translated files are written by the translation platform rather than by this repository, so that correction is applied there and not here.
+
+## Funding
+
+The NeoIPC project has received funding from the European Union's Horizon 2020 research and
+innovation programme under grant agreement No 965328.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -93,4 +93,4 @@ and metadata products for validation but publishes nothing.
 - The **metadata** packages are **generated build artifacts**, never committed (see
   `metadata/dist/README.md`); they exist only as Release assets and CI build artifacts. The **reports**
   product has **no** generated package: its render-ready sources ship in the tag's auto source archive
-  (a slimmer bundle is deferred — see `ToDo.md`), alongside the attached `compatibility.yml`.
+  (a slimmer, render-ready bundle is deferred), alongside the attached `compatibility.yml`.

--- a/metadata/dist/README.md
+++ b/metadata/dist/README.md
@@ -39,8 +39,44 @@ manifest key it does not recognise — but they do **not** yet follow the WHO `d
 manifest conventions. A standards-compliant package, together with the user-group / role / permission model it
 depends on, will supersede them.
 
+## Supported DHIS2 versions — 2.40 and 2.41
+
+The packages are generated for, and verified against, **2.40.12.0** and **2.41.9.0**; the manifest declares
+`2.40.12.0`. On those two the two-pass import described below connects reliably, every time.
+
+Earlier 2.40 patches are **not** supported: `2.40.3.2` carries a confirmed defect, fixed in `2.40.4`, and nothing
+between `2.40.4` and `2.40.12.0` is currently exercised — so the declared version names a currently-verified
+release rather than the lowest that might work.
+
+**On 2.42 and 2.43 the import is not reliable.** There, a metadata import intermittently drops the members of
+owned ordered collections: an `optionGroupSet` declaring 34 `optionGroups` arrives holding 0, and the import
+summary reports nothing wrong. The behaviour is non-deterministic *across* instances but **sticky within one** —
+a given instance reproduces the same outcome on every retry, so re-importing never clears it and only a freshly
+created instance gives a different draw. The evidence points inside DHIS2's own import path rather than at
+anything the package can encode around: the database itself ends up wrong on a bad draw, and the server caches
+have been ruled out empirically. The root cause is not pinned.
+
+The practical consequence on 2.42+ is that a successful-looking import is not evidence of a correct one. **Read
+the option-group sets back and check their member counts** before treating the instance as provisioned. The
+NeoIPC deployment runs 2.41 or older and is unaffected.
+
 ## Importing
 
 Import into a target instance with `idScheme=UID` and a dry run first (via the DHIS2 **Import/Export** app, or a
 metadata-import `POST` with `importMode=VALIDATE` then `COMMIT`). The install base assigns the program to no org
 units — assign it to your hierarchy after import. The play package targets a fresh/empty instance.
+
+**Apply the package twice.** This is not optional and not a retry: DHIS2 does not link an object's *owned*
+reference collections to objects created in the **same** payload, so a single import leaves
+`optionGroupSet.optionGroups`, `programRule.programRuleActions` and `userGroup.managedGroups` members-less —
+**while reporting `status=OK`**. The second, identical import runs when every referenced object already exists,
+and connects them. (Nested collections such as `optionGroup.options` link on the first pass; it is specific to
+those three.) Skip it and you get an instance whose AWaRe and ATC option-group sets are empty and whose program
+rules carry no actions, with nothing in either import summary to say so.
+
+The toolkit's own importer does this for you — `Import-NeoIPCMetadataPackage -ConnectReferences` — and
+`Test-NeoIPCMetadataImport` is the authoritative check that the collections actually linked. A second `status=OK`
+is **not** that proof; on 2.42+ the second pass reports OK and still drops them (above).
+
+After importing, verify rather than assume: read the option-group sets back and check their member counts. That
+advice is essential on 2.42+, where the drop is silent and sticky, and cheap everywhere else.

--- a/metadata/dist/README.md
+++ b/metadata/dist/README.md
@@ -74,9 +74,15 @@ and connects them. (Nested collections such as `optionGroup.options` link on the
 those three.) Skip it and you get an instance whose AWaRe and ATC option-group sets are empty and whose program
 rules carry no actions, with nothing in either import summary to say so.
 
-The toolkit's own importer does this for you — `Import-NeoIPCMetadataPackage -ConnectReferences` — and
-`Test-NeoIPCMetadataImport` is the authoritative check that the collections actually linked. A second `status=OK`
-is **not** that proof; on 2.42+ the second pass reports OK and still drops them (above).
+The toolkit's own importer does this for you — pass `-ConnectReferences`, and name the target explicitly so the
+call cannot fall back to a default host:
+
+```pwsh
+Import-NeoIPCMetadata -Hostname dhis2.example.org -Path <package>.json -ConnectReferences
+```
+
+`Test-NeoIPCMetadataImport` is then the authoritative check that the collections actually linked. A second
+`status=OK` is **not** that proof; on 2.42+ the second pass reports OK and still drops them (above).
 
 After importing, verify rather than assume: read the option-group sets back and check their member counts. That
 advice is essential on 2.42+, where the drop is silent and sticky, and cheap everywhere else.

--- a/scripts/Build-NeoIPCMetadataDistribution.ps1
+++ b/scripts/Build-NeoIPCMetadataDistribution.ps1
@@ -54,7 +54,10 @@ if (-not (Test-Path -LiteralPath $OutputDirectory)) { New-Item -ItemType Directo
 
 # --- Alpha manifest policy (the values; the module only provides the mechanism) -------------------------------------
 # DHIS2Version is pinned to the NeoIPC DHIS2 deployment version (the dhis2/core image tag in the deployment's
-# compose file). The version is the required -Version param (no default — the caller always decides): CI passes the
+# compose file), which doubles as the lowest release the packages are actually exercised against. It names a
+# verified release rather than the lowest that could theoretically work: 2.40.3.2 carries a confirmed defect
+# fixed in 2.40.4, and no release below 2.40.12.0 is tested, so the stamp follows what is tested.
+# The version is the required -Version param (no default — the caller always decides): CI passes the
 # metadata release version on a metadata-v* release build, else the metadata/VERSION file (the metadata product's
 # source of truth).
 # healthArea tagging, DHIS2Build and the WHO sharing/group conventions are deferred to the standards-package design
@@ -62,7 +65,7 @@ if (-not (Test-Path -LiteralPath $OutputDirectory)) { New-Item -ItemType Directo
 $packageCode = 'NEOIPC_CORE'
 $packageType = 'TRK'
 $packageVersion = $Version
-$dhis2Version = '2.40.3.2'
+$dhis2Version = '2.40.12.0'
 $locale = 'en'
 
 function New-AlphaManifest([string]$NameSuffix, [string]$Description) {


### PR DESCRIPTION
Give the toolkit a README that orients a newcomer, and state the metadata package's real limits

The landing page was one sentence and a licensing table — the first thing anyone
sees on GitHub, and it explained nothing. It now says what the repository is and
who it is for, what each directory holds, how the five products are versioned and
released, and what the tooling needs, linking out to the deeper documents rather
than restating them. Contribution and translation routes are named, since the
protocol and report text are translated by volunteers who never touch git.

The metadata package is now described honestly rather than optimistically. It is
alpha, it does not yet follow the WHO packaging conventions, and it is verified
only against the 2.40 and 2.41 lines; on 2.42 and 2.43 an import intermittently
drops the members of owned ordered collections while reporting success.

Its import instructions also gain something they were missing entirely: the
package must be applied twice. DHIS2 does not link an object's owned reference
collections to objects created in the same payload, so a single import leaves
option-group sets and program-rule actions empty and still reports status=OK.
Following the previous instructions produced a silently incomplete instance.

The declared DHIS2 version in the generated manifest follows what is actually
verified rather than a release known to be defective.
