### PR TITLE
Give every catalogue header one definition instead of four

### DIFF
--- a/po/antibiotics.af.po
+++ b/po/antibiotics.af.po
@@ -1,19 +1,17 @@
-# Translations for the NeoIPC antibiotic substance and group lists.
+# Afrikaans translations for the NeoIPC Surveillance Antibiotic List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Antibiotics\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgid "Demeclocycline"
 msgstr ""

--- a/po/antibiotics.de.po
+++ b/po/antibiotics.de.po
@@ -1,19 +1,17 @@
-# Translations for the NeoIPC antibiotic substance and group lists.
+# German translations for the NeoIPC Surveillance Antibiotic List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Antibiotics\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgid "Demeclocycline"
 msgstr "Demeclocyclin"

--- a/po/antibiotics.el.po
+++ b/po/antibiotics.el.po
@@ -1,19 +1,17 @@
-# Translations for the NeoIPC antibiotic substance and group lists.
+# Greek translations for the NeoIPC Surveillance Antibiotic List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Antibiotics\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgid "Demeclocycline"
 msgstr ""

--- a/po/antibiotics.es.po
+++ b/po/antibiotics.es.po
@@ -1,19 +1,17 @@
-# Translations for the NeoIPC antibiotic substance and group lists.
+# Spanish translations for the NeoIPC Surveillance Antibiotic List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Antibiotics\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgid "Demeclocycline"
 msgstr "Demeclociclina"

--- a/po/antibiotics.et.po
+++ b/po/antibiotics.et.po
@@ -1,19 +1,17 @@
-# Translations for the NeoIPC antibiotic substance and group lists.
+# Estonian translations for the NeoIPC Surveillance Antibiotic List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Antibiotics\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgid "Demeclocycline"
 msgstr ""

--- a/po/antibiotics.fr.po
+++ b/po/antibiotics.fr.po
@@ -1,19 +1,17 @@
-# Translations for the NeoIPC antibiotic substance and group lists.
+# French translations for the NeoIPC Surveillance Antibiotic List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Antibiotics\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgid "Demeclocycline"
 msgstr ""

--- a/po/antibiotics.ne.po
+++ b/po/antibiotics.ne.po
@@ -1,19 +1,17 @@
-# Translations for the NeoIPC antibiotic substance and group lists.
+# Nepali translations for the NeoIPC Surveillance Antibiotic List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Antibiotics\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgid "Demeclocycline"
 msgstr ""

--- a/po/antibiotics.pot
+++ b/po/antibiotics.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-29 17:47+0200\n"
+"POT-Creation-Date: 2026-07-29 17:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: none\n"
 "Language: en\n"

--- a/po/antibiotics.pot
+++ b/po/antibiotics.pot
@@ -1,14 +1,12 @@
-# Translations for the NeoIPC antibiotic substance and group lists.
+# Translations for the NeoIPC Surveillance Antibiotic List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Antibiotics\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-29 17:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"

--- a/po/documentation.af.po
+++ b/po/documentation.af.po
@@ -1,22 +1,17 @@
 # Afrikaans translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:25+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Afrikaans <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/af/>\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/documentation.de.po
+++ b/po/documentation.de.po
@@ -1,23 +1,18 @@
 # German translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Brar Piening <brar.piening@charite.de>, 2025.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2025.
 #
+# Brar Piening <brar.piening@charite.de>, 2025.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:25+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/documentation.el.po
+++ b/po/documentation.el.po
@@ -1,22 +1,17 @@
 # Greek translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:27+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/el/>\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/documentation.es.po
+++ b/po/documentation.es.po
@@ -1,23 +1,18 @@
 # Spanish translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Brar Piening <brar.piening@charite.de>, 2025.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2025.
+#
 # Libre <6n0n1m0s@proton.me>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:26+0000\n"
-"Last-Translator: Libre <6n0n1m0s@proton.me>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/documentation.et.po
+++ b/po/documentation.et.po
@@ -1,22 +1,17 @@
 # Estonian translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:27+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Estonian <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/et/>\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/documentation.fr.po
+++ b/po/documentation.fr.po
@@ -1,22 +1,17 @@
 # French translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:26+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/documentation.it.po
+++ b/po/documentation.it.po
@@ -1,22 +1,17 @@
 # Italian translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:27+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/documentation.ne.po
+++ b/po/documentation.ne.po
@@ -1,22 +1,17 @@
 # Nepali translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:26+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Nepali <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/ne/>\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/documentation.pot
+++ b/po/documentation.pot
@@ -1,14 +1,12 @@
 # Translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 1.3.0-preview1\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
+"POT-Creation-Date: 2026-07-29 17:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"

--- a/po/documentation.tr.po
+++ b/po/documentation.tr.po
@@ -1,22 +1,17 @@
 # Turkish translations for the NeoIPC Surveillance Documentation
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated, 2026.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Documentation 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-07 00:12+0200\n"
 "PO-Revision-Date: 2026-07-28 11:25+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/neoipc/neoipc-core-surveillance-protocol/tr/>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Title =
 #: doc/protocol/NeoIPC-Core-Protocol.adoc:1

--- a/po/glossary.af.po
+++ b/po/glossary.af.po
@@ -1,19 +1,17 @@
 # Afrikaans translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# FIRST AUTHOR <EMAIL@ADDRESS>
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-04-12 10:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Afrikaans <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/af/>\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/glossary.de.po
+++ b/po/glossary.de.po
@@ -1,22 +1,18 @@
 # German translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Brar Piening <brar.piening@charite.de>
-# Prefill add-on <noreply-addon-prefill@weblate.org>
 #
+# Brar Piening <brar.piening@charite.de>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2025-12-30 11:06+0100\n"
-"PO-Revision-Date: 2026-03-16 07:25+0000\n"
-"Last-Translator: Brar Piening <brar.piening@charite.de>\n"
-"Language-Team: none\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/glossary.el.po
+++ b/po/glossary.el.po
@@ -1,19 +1,17 @@
 # Greek translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# FIRST AUTHOR <EMAIL@ADDRESS>
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-04-12 10:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Greek <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/el/>\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/glossary.es.po
+++ b/po/glossary.es.po
@@ -1,19 +1,17 @@
 # Spanish translations for the NeoIPC Surveillance Glossary
-# Copyright (C) 2026 Charité – Universitätsmedizin Berlin
+# Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated, 2026.
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-03-15 11:53+0000\n"
-"PO-Revision-Date: 2026-03-16 07:25+0000\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Language-Team: Spanish <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/glossary.et.po
+++ b/po/glossary.et.po
@@ -1,19 +1,17 @@
 # Estonian translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# FIRST AUTHOR <EMAIL@ADDRESS>
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-04-12 10:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Estonian <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/et/>\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/glossary.fr.po
+++ b/po/glossary.fr.po
@@ -1,19 +1,17 @@
 # French translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# FIRST AUTHOR <EMAIL@ADDRESS>
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-04-12 10:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: French <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/glossary.it.po
+++ b/po/glossary.it.po
@@ -1,19 +1,17 @@
 # Italian translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# FIRST AUTHOR <EMAIL@ADDRESS>
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-04-12 10:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Italian <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/glossary.ne.po
+++ b/po/glossary.ne.po
@@ -1,19 +1,17 @@
 # Nepali translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# FIRST AUTHOR <EMAIL@ADDRESS>
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-04-12 10:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Nepali <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/ne/>\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/glossary.pot
+++ b/po/glossary.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-29 15:46+0000\n"
+"POT-Creation-Date: 2026-07-29 15:53+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Language-Team: none\n"
 "Language: en\n"

--- a/po/glossary.pot
+++ b/po/glossary.pot
@@ -1,14 +1,12 @@
 # Translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-28 09:55+0000\n"
+"POT-Creation-Date: 2026-07-29 15:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"

--- a/po/glossary.tr.po
+++ b/po/glossary.tr.po
@@ -1,19 +1,17 @@
 # Turkish translations for the NeoIPC Surveillance Glossary
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# FIRST AUTHOR <EMAIL@ADDRESS>
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Glossary 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-04-12 10:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Turkish <https://hosted.weblate.org/projects/neoipc/neoipc-glossary/tr/>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. WHO AWaRe antibiotic category. The official WHO translation is normative:
 #. Spanish "Acceso", per the

--- a/po/infectious_agents.af.po
+++ b/po/infectious_agents.af.po
@@ -1,24 +1,17 @@
 # Afrikaans translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Brar Piening <brar@gmx.de>, 2026.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agent List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-28 18:41+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: Afrikaans <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/af/>\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/infectious_agents.de.po
+++ b/po/infectious_agents.de.po
@@ -1,22 +1,18 @@
 # German translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
+# This file is distributed under the Creative Commons Attribution 4.0 International license
+#
 # Brar Piening <brar.piening@charite.de>, 2025.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2025, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agents List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-28 18:42+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/infectious_agents.el.po
+++ b/po/infectious_agents.el.po
@@ -1,24 +1,17 @@
 # Greek translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Brar Piening <brar@gmx.de>, 2026.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agent List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-28 18:43+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/el/>\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/infectious_agents.es.po
+++ b/po/infectious_agents.es.po
@@ -1,22 +1,17 @@
 # Spanish translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
-# Brar Piening <brar.piening@charite.de>, 2025.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2025, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agents List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-28 18:45+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/infectious_agents.et.po
+++ b/po/infectious_agents.et.po
@@ -1,24 +1,17 @@
 # Estonian translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Brar Piening <brar@gmx.de>, 2026.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agent List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-28 18:46+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: Estonian <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/et/>\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/infectious_agents.fr.po
+++ b/po/infectious_agents.fr.po
@@ -1,24 +1,17 @@
 # French translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Brar Piening <brar@gmx.de>, 2026.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agent List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-28 18:49+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/infectious_agents.it.po
+++ b/po/infectious_agents.it.po
@@ -1,24 +1,17 @@
 # Italian translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Brar Piening <brar@gmx.de>, 2026.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agent List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-29 06:56+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/infectious_agents.ne.po
+++ b/po/infectious_agents.ne.po
@@ -1,24 +1,17 @@
 # Nepali translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Brar Piening <brar@gmx.de>, 2026.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agent List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-29 06:57+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: Nepali <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/ne/>\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/infectious_agents.pot
+++ b/po/infectious_agents.pot
@@ -1,14 +1,12 @@
 # Translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agent List 0.0.1-alpha\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-27 12:10+0200\n"
+"POT-Creation-Date: 2026-07-29 17:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"

--- a/po/infectious_agents.tr.po
+++ b/po/infectious_agents.tr.po
@@ -1,24 +1,17 @@
 # Turkish translations for the NeoIPC Surveillance Infectious Agent List
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the Creative Commons Attribution-NonCommercial-NoDerivatives 4.0 International license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Brar Piening <brar@gmx.de>, 2026.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Infectious Agent List 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-06 18:41+0200\n"
 "PO-Revision-Date: 2026-07-29 06:58+0000\n"
-"Last-Translator: Prefill add-on <noreply-addon-prefill@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/neoipc/neoipc-infectious-agents/tr/>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: Hierarchies ConceptType
 #: metadata/common/infectious-agents/NeoIPC-Infectious-Agents.yaml:1

--- a/po/metadata.af.po
+++ b/po/metadata.af.po
@@ -1,16 +1,12 @@
-# Translations for the NeoIPC DHIS2 metadata.
-# Copyright (C) Charite - Universitaetsmedizin Berlin
+# Afrikaans translations for the NeoIPC Surveillance DHIS2 Metadata
+# Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
 #
-# Languages add-on <noreply-addon-languages@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Metadata\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Afrikaans <https://hosted.weblate.org/projects/neoipc/neoipc-dhis2-metadata/af/>\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/metadata.de.po
+++ b/po/metadata.de.po
@@ -1,23 +1,18 @@
-# Translations for the NeoIPC DHIS2 metadata.
+# German translations for the NeoIPC Surveillance DHIS2 Metadata
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
 #
-# Brar Piening <brar@gmx.de>, 2026.
+# Brar Piening <brar.piening@charite.de>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Metadata\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: 2026-07-28 06:51+0000\n"
-"Last-Translator: Brar Piening <brar@gmx.de>\n"
-"Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-"
-"dhis2-metadata/de/>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-dhis2-metadata/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 msgctxt "dataElements/NEOIPC_ADMISSION_DOL/NAME"
 msgid "NeoIPC Admission on day of life"

--- a/po/metadata.el.po
+++ b/po/metadata.el.po
@@ -1,16 +1,12 @@
-# Translations for the NeoIPC DHIS2 metadata.
-# Copyright (C) Charite - Universitaetsmedizin Berlin
+# Greek translations for the NeoIPC Surveillance DHIS2 Metadata
+# Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
 #
-# Languages add-on <noreply-addon-languages@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Metadata\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Greek <https://hosted.weblate.org/projects/neoipc/neoipc-dhis2-metadata/el/>\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/metadata.et.po
+++ b/po/metadata.et.po
@@ -1,16 +1,12 @@
-# Translations for the NeoIPC DHIS2 metadata.
-# Copyright (C) Charite - Universitaetsmedizin Berlin
+# Estonian translations for the NeoIPC Surveillance DHIS2 Metadata
+# Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
 #
-# Languages add-on <noreply-addon-languages@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Metadata\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Estonian <https://hosted.weblate.org/projects/neoipc/neoipc-dhis2-metadata/et/>\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/metadata.fr.po
+++ b/po/metadata.fr.po
@@ -1,16 +1,12 @@
-# Translations for the NeoIPC DHIS2 metadata.
-# Copyright (C) Charite - Universitaetsmedizin Berlin
+# French translations for the NeoIPC Surveillance DHIS2 Metadata
+# Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
 #
-# Languages add-on <noreply-addon-languages@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Metadata\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: French <https://hosted.weblate.org/projects/neoipc/neoipc-dhis2-metadata/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/metadata.ne.po
+++ b/po/metadata.ne.po
@@ -1,16 +1,12 @@
-# Translations for the NeoIPC DHIS2 metadata.
-# Copyright (C) Charite - Universitaetsmedizin Berlin
+# Nepali translations for the NeoIPC Surveillance DHIS2 Metadata
+# Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
 #
-# Languages add-on <noreply-addon-languages@weblate.org>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Metadata\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
-"Language-Team: none\n"
+"Language-Team: Nepali <https://hosted.weblate.org/projects/neoipc/neoipc-dhis2-metadata/ne/>\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"

--- a/po/metadata.pot
+++ b/po/metadata.pot
@@ -1,14 +1,12 @@
-# Translations for the NeoIPC DHIS2 metadata.
+# Translations for the NeoIPC Surveillance DHIS2 Metadata
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Metadata\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-23 08:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"

--- a/po/non-human-identities.yaml
+++ b/po/non-human-identities.yaml
@@ -1,0 +1,65 @@
+# Identities that appear in translation credits but are not people.
+#
+# Every writer that reads or produces a credit consults this file: update-glossary-po.py (Python) when it
+# carries contributor lines forward, the NeoIPC-Tools module (PowerShell) when it checks a catalogue, and the
+# report renderer (R) when it acknowledges translators. It is data rather than code precisely so those three
+# cannot drift apart — which is the failure this whole header exercise exists to correct.
+#
+# MATCH ON THE ADDRESS, NEVER THE DISPLAY NAME. `noreply@weblate.org` appears under two different names in
+# this repository's own history — "Anonymous" and "Weblate (bot)" — so a name-keyed list would exclude one and
+# silently credit the other. The reverse also holds: one human here appears under two addresses, which is why
+# crediting needs identity collapse and not merely this exclusion.
+#
+# Being on this list means "do not credit as a translator". It does not mean the work is not real: `Anonymous`
+# is Weblate's identity for an action with no signed-in user, and here that has always been the maintainer's
+# own scripted or bulk operations, not an unnamed contributor.
+
+# Any address at these domains is non-human. Weblate mints its bot and anonymous identities under
+# weblate.org, so the domain covers add-ons that do not exist yet as well as the ones below.
+excluded_domains:
+    - weblate.org
+
+# Addresses that the domain rule does not cover, or that are worth naming so a reader knows they were
+# considered. `seen_as` records where each was actually observed in this repository, so the list stays
+# evidence-based rather than speculative.
+excluded_addresses:
+    - address: noreply@weblate.org
+      seen_as: [commit author, co-author trailer]
+      names: [Anonymous, Weblate (bot)]
+      why: >-
+          Weblate's identity for an action with no signed-in user. Never reaches a PO header, because the
+          Contributors-in-comment add-on skips this exact address, but it is the most frequent identity in
+          commit trailers, so any credit route reading trailers must exclude it.
+    - address: hosted@weblate.org
+      seen_as: [commit author, co-author trailer]
+      names: [Hosted Weblate]
+      why: The Hosted Weblate service account, added to every squashed commit by append_trailers.
+    - address: noreply-addon-prefill@weblate.org
+      seen_as: [PO header, commit author, co-author trailer]
+      names: [Prefill add-on]
+      why: >-
+          The Prefill add-on, which filled every string with its English source. Uninstalled, but its credit
+          lines remain in catalogues it touched.
+    - address: noreply-addon-languages@weblate.org
+      seen_as: [PO header, co-author trailer]
+      names: [Languages add-on]
+      why: The add-on that creates a catalogue when a language is added to a component.
+    - address: noreply@anthropic.com
+      seen_as: [co-author trailer]
+      names: [Claude]
+      why: >-
+          An AI co-author trailer on one commit, contrary to the project guardrail that a tool is not a
+          co-author. It stays in history — rewriting published history would be worse — but it must never be
+          credited as a translator.
+    - address: noreply@github.com
+      seen_as: [committer]
+      names: [GitHub]
+      why: >-
+          The committer on every squash merge. It can never be a translation credit, but it dominates any
+          route that derives credits from committer data rather than authorship.
+
+# Placeholder author lines left by gettext tooling. These are not addresses and are matched literally.
+# They are not contributors and must not be carried forward when a header is rewritten.
+excluded_literals:
+    - FIRST AUTHOR <EMAIL@ADDRESS>
+    - FULL NAME <EMAIL@ADDRESS>

--- a/po/reports.af.po
+++ b/po/reports.af.po
@@ -1,22 +1,17 @@
 # Afrikaans translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:39+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Afrikaans <https://hosted.weblate.org/projects/neoipc/neoipc-reports/af/>\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/po/reports.de.po
+++ b/po/reports.de.po
@@ -1,23 +1,18 @@
 # German translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Brar Piening <brar.piening@charite.de>, 2025.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2025.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
+# Brar Piening <brar.piening@charite.de>, 2025.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:39+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-reports/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/po/reports.el.po
+++ b/po/reports.el.po
@@ -1,22 +1,17 @@
 # Greek translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:39+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/neoipc/neoipc-reports/el/>\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/po/reports.es.po
+++ b/po/reports.es.po
@@ -1,23 +1,18 @@
 # Spanish translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Automatically generated, 2025.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 # Libre <6n0n1m0s@proton.me>, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:38+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/neoipc/neoipc-reports/es/>\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/po/reports.et.po
+++ b/po/reports.et.po
@@ -1,22 +1,17 @@
 # Estonian translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:40+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Estonian <https://hosted.weblate.org/projects/neoipc/neoipc-reports/et/>\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/po/reports.fr.po
+++ b/po/reports.fr.po
@@ -1,22 +1,17 @@
 # French translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:40+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/neoipc/neoipc-reports/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/po/reports.it.po
+++ b/po/reports.it.po
@@ -1,23 +1,17 @@
 # Italian translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Brar Piening <brar.piening@charite.de>, 2025.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2025.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:41+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/neoipc/neoipc-reports/it/>\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/po/reports.ne.po
+++ b/po/reports.ne.po
@@ -1,22 +1,17 @@
 # Nepali translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:41+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Nepali <https://hosted.weblate.org/projects/neoipc/neoipc-reports/ne/>\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/po/reports.pot
+++ b/po/reports.pot
@@ -1,14 +1,12 @@
 # Translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
-# Automatically generated
+#
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.0.1-alpha\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-26 23:28+0200\n"
+"POT-Creation-Date: 2026-07-29 17:52+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: en\n"
 "MIME-Version: 1.0\n"

--- a/po/reports.tr.po
+++ b/po/reports.tr.po
@@ -1,22 +1,17 @@
 # Turkish translations for the NeoIPC Surveillance Reports
 # Copyright (C) Charité – Universitätsmedizin Berlin
-# This file is distributed under the MIT license
-# Automatically generated, 2026.
+# This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: NeoIPC Surveillance Reports 0.9\n"
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"POT-Creation-Date: 2026-07-25 21:09+0200\n"
 "PO-Revision-Date: 2026-07-28 18:38+0000\n"
-"Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/neoipc/neoipc-reports/tr/>\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2026.8.dev0\n"
 
 #. type: Hash Value: 3gcr
 #: reports/common.yaml:1

--- a/scripts/Invoke-Localization.ps1
+++ b/scripts/Invoke-Localization.ps1
@@ -440,10 +440,21 @@ function Restore-WeblateOwnedPo {
 
 function Repair-Po4aTemplateHeader {
     # po4a emits gettext-boilerplate file headers ("SOME DESCRIPTIVE TITLE", "Copyright (C) YEAR ...",
-    # "same license as the PACKAGE package", "FIRST AUTHOR ...") and offers no way to set a custom
-    # header, so this rewrites the leading comment block of the .pot it generated for one config into
-    # the NeoIPC house style (matching po/glossary.pot): title / copyright / license / "Automatically
-    # generated". Idempotent. The .po files are Weblate's, and are not touched.
+    # "same license as the PACKAGE package", "FIRST AUTHOR ...") and offers no way to set a custom header, so
+    # this rewrites the leading comment block of the .pot it generated for one config into the NeoIPC house
+    # style: title / copyright / licence / a bare "#". Idempotent. The .po files are Weblate's, and are not
+    # touched — which is also what makes the Language-Team rewrite below safe, since on a catalogue that field
+    # holds the component URL Weblate wrote and blanking it would churn all 33 of them.
+    #
+    # The header contract is defined once, in the NeoIPC-Tools module (Private/PoHeader.ps1); this reproduces
+    # it for the one writer that cannot call into it, because po4a produces the file and we only get to correct
+    # it afterwards. Keep the two in step — Tests/PoHeader.Tests.ps1 asserts they agree.
+    #
+    # Three fields are DELETED rather than normalised. Project-Id-Version froze at a version the products left
+    # behind; Last-Translator is frozen by po_set_last_translator=false, so it would name a translator who can
+    # never change; X-Generator is a Weblate version string that rewrote every catalogue on each upgrade. Note
+    # the deletion of Last-Translator is exactly what po4a will undo if anyone runs it directly instead of
+    # through this script — it re-emits "FULL NAME <EMAIL@ADDRESS>" (tools/po4a/lib/Locale/Po4a/Po.pm).
     param(
         [Parameter(Mandatory)][string]$ConfigPath,
         [Parameter(Mandatory)][string]$Package,
@@ -472,12 +483,11 @@ function Repair-Po4aTemplateHeader {
         $potPath = Join-Path $repoRoot $potRel
         $h = Split-Catalog $potPath
         if ($h) {
-            $comment = @("# Translations for the $Package", $copyrightLine, $licenseLine, "# Automatically generated")
-            # Match glossary.pot's header metadata (po4a leaves author placeholders in the .pot).
-            $body = @($h.Body | ForEach-Object {
-                $_ -replace '^"Last-Translator: .*\\n"$', '"Last-Translator: Automatically generated\n"' `
-                   -replace '^"Language-Team: .*\\n"$',   '"Language-Team: none\n"'
-            })
+            $comment = @("# Translations for the $Package", $copyrightLine, $licenseLine, '#')
+            # Drop the fields that cannot stay true, and normalise the one that can (see the header above).
+            $body = @($h.Body |
+                Where-Object { $_ -notmatch '^"(Project-Id-Version|Last-Translator|X-Generator): .*\\n"$' } |
+                ForEach-Object { $_ -replace '^"Language-Team: .*\\n"$', '"Language-Team: none\n"' })
             Save-Catalog $potPath $comment $body
         }
     }

--- a/scripts/modules/NeoIPC-Tools/Private/AntibioticTranslation.ps1
+++ b/scripts/modules/NeoIPC-Tools/Private/AntibioticTranslation.ps1
@@ -86,24 +86,9 @@ function Write-NeoIPCAntibioticPoText {
         [Parameter(Mandatory)][System.Collections.Generic.List[object]]$Entry,
         [string]$Locale = ''
     )
-    $lang = if ($Locale) { $Locale } else { 'en' }
     $sb = [System.Text.StringBuilder]::new()
-    [void]$sb.AppendLine('# Translations for the NeoIPC antibiotic substance and group lists.')
-    [void]$sb.AppendLine('# Copyright (C) Charité – Universitätsmedizin Berlin')
-    [void]$sb.AppendLine('# This file is distributed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO license')
-    [void]$sb.AppendLine('# Automatically generated')
-    [void]$sb.AppendLine('#')
-    [void]$sb.AppendLine('msgid ""')
-    [void]$sb.AppendLine('msgstr ""')
-    [void]$sb.AppendLine('"Project-Id-Version: NeoIPC Antibiotics\n"')
-    [void]$sb.AppendLine('"Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"')
-    [void]$sb.AppendLine('"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"')
-    [void]$sb.AppendLine('"Last-Translator: Automatically generated\n"')
-    [void]$sb.AppendLine('"Language-Team: none\n"')
-    [void]$sb.AppendLine(('"Language: {0}\n"' -f $lang))
-    [void]$sb.AppendLine('"MIME-Version: 1.0\n"')
-    [void]$sb.AppendLine('"Content-Type: text/plain; charset=UTF-8\n"')
-    [void]$sb.AppendLine('"Content-Transfer-Encoding: 8bit\n"')
+    [void]$sb.Append((Write-NeoIPCPoHeader -Product 'NeoIPC Surveillance Antibiotic List' `
+                -License 'Creative Commons Attribution-NonCommercial-ShareAlike 3.0 IGO' -Locale $Locale))
     foreach ($e in $Entry) {
         [void]$sb.AppendLine()
         if ($e.Fuzzy) { [void]$sb.AppendLine('#, fuzzy') }

--- a/scripts/modules/NeoIPC-Tools/Private/MetadataTranslation.ps1
+++ b/scripts/modules/NeoIPC-Tools/Private/MetadataTranslation.ps1
@@ -381,22 +381,8 @@ function Write-NeoIPCMetadataPoText {
     [OutputType([string])]
     param([Parameter(Mandatory)][System.Collections.Generic.List[object]]$Entry)
     $sb = [System.Text.StringBuilder]::new()
-    [void]$sb.AppendLine('# Translations for the NeoIPC DHIS2 metadata.')
-    [void]$sb.AppendLine('# Copyright (C) Charité – Universitätsmedizin Berlin')
-    [void]$sb.AppendLine('# This file is distributed under the Creative Commons Attribution 4.0 International license')
-    [void]$sb.AppendLine('# Automatically generated')
-    [void]$sb.AppendLine('#')
-    [void]$sb.AppendLine('msgid ""')
-    [void]$sb.AppendLine('msgstr ""')
-    [void]$sb.AppendLine('"Project-Id-Version: NeoIPC Metadata\n"')
-    [void]$sb.AppendLine('"Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"')
-    [void]$sb.AppendLine('"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"')
-    [void]$sb.AppendLine('"Last-Translator: Automatically generated\n"')
-    [void]$sb.AppendLine('"Language-Team: none\n"')
-    [void]$sb.AppendLine('"Language: en\n"')
-    [void]$sb.AppendLine('"MIME-Version: 1.0\n"')
-    [void]$sb.AppendLine('"Content-Type: text/plain; charset=UTF-8\n"')
-    [void]$sb.AppendLine('"Content-Transfer-Encoding: 8bit\n"')
+    [void]$sb.Append((Write-NeoIPCPoHeader -Product 'NeoIPC Surveillance DHIS2 Metadata' `
+                -License 'Creative Commons Attribution 4.0 International'))
     foreach ($e in $Entry) {
         [void]$sb.AppendLine()
         # Weblate flags line: fuzzy (translator state) + priority:NNN (source-set focus). 100 is the default — no flag.

--- a/scripts/modules/NeoIPC-Tools/Private/PoHeader.ps1
+++ b/scripts/modules/NeoIPC-Tools/Private/PoHeader.ps1
@@ -1,0 +1,135 @@
+#Requires -Version 7.6
+# The single definition of a NeoIPC gettext catalogue header.
+#
+# Four writers produce these files — po4a (post-processed by scripts/Invoke-Localization.ps1),
+# scripts/update-glossary-po.py, and the two exporters in this module — and each used to carry its own copy of
+# the header. They drifted: eight different comment-block shapes, three spellings of the copyright line (one of
+# them ASCII-transliterated), a product name that disagreed with its own Project-Id-Version, and a header
+# serialised onto a single physical line. This file is why the two exporters can no longer drift from each
+# other; the Python generator and the po4a post-processor implement the same contract in their own languages
+# and are held to it by Tests/PoHeader.Tests.ps1.
+#
+# THE BLOCK STRUCTURE IS NOT COSMETIC. translate-toolkit's `updatecontributor` — which Weblate's
+# "Contributors in comment" add-on delegates to — splits the comment block at the first line matching
+# `.*<\S+@\S+>.*\d{4,4}` (an e-mail AND a four-digit year). Everything before that is `prelines` and is left
+# alone; new contributors are appended after the last existing one; anything after them is `postlines`, and an
+# empty one does not survive the round trip. So the bare `#` goes BELOW the licence and ABOVE the contributors:
+# there it is the final preline and is stable, whereas placing contributors above it makes it a postline that
+# Weblate silently deletes on its next write. For the same reason a retained contributor line MUST carry both
+# an e-mail and a year — without them it fails the regex, is read as a preline, and the add-on appends a second
+# copy of the same person.
+#
+# Fields deliberately absent, each because it was true when written and silently wrong afterwards:
+# Project-Id-Version (its version suffix froze at 0.9 while the products moved on), X-Generator (a Weblate
+# version string, which rewrote every catalogue on each upgrade until po_set_x_generator was turned off),
+# Last-Translator (frozen by po_set_last_translator=false, so it named a translator who could never change),
+# and POT-Creation-Date in a CATALOGUE — msgmerge does not refresh it, so it had drifted three weeks out in
+# infectious_agents. It stays in the TEMPLATE, where the generator stamps it and it is true by construction.
+
+# English language names as Weblate writes them into Language-Team, and the plural rule it writes per language.
+# Sourced from the catalogues Weblate itself produced, not from a specification, so they match byte for byte.
+$script:NeoIPCPoLanguageName = @{
+    af = 'Afrikaans'; de = 'German'; el = 'Greek'; es = 'Spanish'; et = 'Estonian'
+    fr = 'French'; it = 'Italian'; ne = 'Nepali'; tr = 'Turkish'
+}
+$script:NeoIPCPoPluralForms = @{
+    af = 'nplurals=2; plural=n != 1;'; de = 'nplurals=2; plural=n != 1;'; el = 'nplurals=2; plural=n != 1;'
+    es = 'nplurals=2; plural=n != 1;'; et = 'nplurals=2; plural=n != 1;'; fr = 'nplurals=2; plural=n > 1;'
+    it = 'nplurals=2; plural=n != 1;'; ne = 'nplurals=2; plural=n != 1;'; tr = 'nplurals=2; plural=n != 1;'
+}
+
+function Test-NeoIPCPoNonHumanIdentity {
+    # Whether a credit line names something other than a person, per po/non-human-identities.yaml.
+    #
+    # The list is DATA, shared with update-glossary-po.py (Python) and the report renderer (R), because a list
+    # maintained separately in three languages is one that disagrees with itself. Matching is on the ADDRESS,
+    # never the display name: `noreply@weblate.org` appears in this repository's history under two different
+    # names, so a name-keyed rule excludes one and silently credits the other.
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param([Parameter(Mandatory)][AllowEmptyString()][string]$AuthorLine)
+    if (-not $script:NeoIPCPoNonHumanIdentities) {
+        $path = Join-Path $PSScriptRoot '..' '..' '..' '..' 'po' 'non-human-identities.yaml'
+        if (-not (Test-Path -LiteralPath $path)) { throw "Shared exclusion list not found at '$path'." }
+        $data = ConvertFrom-Yaml (Get-Content -LiteralPath $path -Raw)
+        $script:NeoIPCPoNonHumanIdentities = [pscustomobject]@{
+            Domains   = [string[]]@($data.excluded_domains | ForEach-Object { $_.ToLowerInvariant() })
+            Addresses = [string[]]@($data.excluded_addresses | ForEach-Object { ([string]$_.address).ToLowerInvariant() })
+            Literals  = [string[]]@($data.excluded_literals)
+        }
+    }
+    $known = $script:NeoIPCPoNonHumanIdentities
+    foreach ($lit in $known.Literals) { if ($AuthorLine.Contains($lit)) { return $true } }
+    if ($AuthorLine -notmatch '<([^>]+)>') { return $false }
+    $address = $Matches[1].ToLowerInvariant()
+    if ($known.Addresses -contains $address) { return $true }
+    return ($known.Domains -contains ($address -replace '^.*@', ''))
+}
+
+function Get-NeoIPCPoLanguageName {
+    # The English language name for a locale, as Weblate spells it. Throws on an unknown locale rather than
+    # inventing one: a wrong name would be written into Language-Team and silently disagree with Weblate's.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([Parameter(Mandatory)][string]$Locale)
+    if (-not $script:NeoIPCPoLanguageName.ContainsKey($Locale)) {
+        throw "No English language name known for locale '$Locale'. Add it to `$NeoIPCPoLanguageName in Private/PoHeader.ps1 (and check what Weblate writes for it) rather than guessing."
+    }
+    $script:NeoIPCPoLanguageName[$Locale]
+}
+
+function Write-NeoIPCPoHeader {
+    # Render the comment block and the empty-msgid header entry for one catalogue or template. Returns LF-
+    # terminated text ending with a newline; the caller appends its entries. See the file header for why the
+    # block is shaped the way it is and why several conventional fields are absent.
+    #
+    # -Locale ''            -> a TEMPLATE: language-less title, Language: en, POT-Creation-Date, no Plural-Forms.
+    # -Locale '<lang>'      -> a CATALOGUE: per-language title, that language's Plural-Forms, no POT-Creation-Date.
+    # -LanguageTeam         -> 'none' for a catalogue no Weblate component owns; otherwise the component URL
+    #                          Weblate itself writes, so its next write is a no-op.
+    # -Contributor          -> already-formatted 'Name <e-mail>, year.' lines, in order. Each MUST carry an
+    #                          e-mail and a year (see the file header); the module does not fabricate either.
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [Parameter(Mandatory)][string]$Product,
+        [Parameter(Mandatory)][string]$License,
+        [string]$Locale = '',
+        [string]$PotCreationDate = '',
+        [string]$LanguageTeam = 'none',
+        [string[]]$Contributor = @()
+    )
+    foreach ($c in $Contributor) {
+        if ($c -notmatch '<\S+@\S+>.*\d{4}') {
+            throw "Contributor line '$c' carries no e-mail and four-digit year, so translate-toolkit will not recognise it as a contributor and Weblate will append a duplicate. Supply 'Name <e-mail>, year.'"
+        }
+    }
+    $sb = [System.Text.StringBuilder]::new()
+    $title = if ($Locale) { '# {0} translations for the {1}' -f (Get-NeoIPCPoLanguageName -Locale $Locale), $Product }
+    else { "# Translations for the $Product" }
+    [void]$sb.AppendLine($title)
+    [void]$sb.AppendLine('# Copyright (C) Charité – Universitätsmedizin Berlin')
+    [void]$sb.AppendLine("# This file is distributed under the $License license")
+    [void]$sb.AppendLine('#')
+    foreach ($c in $Contributor) { [void]$sb.AppendLine("# $c") }
+    [void]$sb.AppendLine('msgid ""')
+    [void]$sb.AppendLine('msgstr ""')
+    [void]$sb.AppendLine('"Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"')
+    if (-not $Locale) {
+        $stamp = if ($PotCreationDate) { $PotCreationDate } else { (Get-Date).ToString('yyyy-MM-dd HH:mmzzz') -replace ':(\d\d)$', '$1' }
+        [void]$sb.AppendLine(('"POT-Creation-Date: {0}\n"' -f $stamp))
+    }
+    [void]$sb.AppendLine('"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"')
+    [void]$sb.AppendLine(('"Language-Team: {0}\n"' -f $LanguageTeam))
+    [void]$sb.AppendLine(('"Language: {0}\n"' -f $(if ($Locale) { $Locale } else { 'en' })))
+    [void]$sb.AppendLine('"MIME-Version: 1.0\n"')
+    [void]$sb.AppendLine('"Content-Type: text/plain; charset=UTF-8\n"')
+    [void]$sb.AppendLine('"Content-Transfer-Encoding: 8bit\n"')
+    if ($Locale) {
+        if (-not $script:NeoIPCPoPluralForms.ContainsKey($Locale)) {
+            throw "No plural rule known for locale '$Locale'. Add it to `$NeoIPCPoPluralForms in Private/PoHeader.ps1, taking the value Weblate writes for that language."
+        }
+        [void]$sb.AppendLine(('"Plural-Forms: {0}\n"' -f $script:NeoIPCPoPluralForms[$Locale]))
+    }
+    return ($sb.ToString() -replace "`r`n", "`n")
+}

--- a/scripts/modules/NeoIPC-Tools/Tests/PoHeader.Tests.ps1
+++ b/scripts/modules/NeoIPC-Tools/Tests/PoHeader.Tests.ps1
@@ -1,0 +1,215 @@
+#Requires -Version 7.6
+
+<#
+.SYNOPSIS
+    Pester tests for the shared gettext catalogue header contract.
+
+.DESCRIPTION
+    Four writers produce the catalogues under po/ — po4a (corrected by scripts/Invoke-Localization.ps1),
+    scripts/update-glossary-po.py, and the two exporters in this module. They drifted into eight different
+    comment-block shapes, three spellings of the copyright line (one ASCII-transliterated), and a header
+    serialised onto a single physical line, and nothing noticed: the whole suite passed both before and after
+    the header was changed, because no test asserted it.
+
+    These tests are that assertion. The last Describe is the one that matters most — it checks the COMMITTED
+    files rather than the writers, so a catalogue that drifts by any route at all is caught, including a hand
+    edit and a writer nobody remembered to update.
+
+.EXAMPLE
+    Invoke-Pester -Path scripts/modules/NeoIPC-Tools/Tests/PoHeader.Tests.ps1
+#>
+
+$ErrorActionPreference = 'Stop'
+Import-Module (Join-Path $PSScriptRoot '..') -Force
+
+InModuleScope 'NeoIPC-Tools' {
+
+    BeforeAll {
+        $script:repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..' '..' '..' '..')).Path
+        $script:catalogues = @(
+            Get-ChildItem -LiteralPath (Join-Path $script:repoRoot 'po') -File |
+                Where-Object { $_.Name -match '\.pot?$' }
+            Get-ChildItem -LiteralPath (Join-Path $script:repoRoot 'scripts' 'po') -File |
+                Where-Object { $_.Name -match '\.pot?$' }
+        )
+        # The header comment block plus the fields of the empty-msgid entry, as written.
+        function Get-CatalogueHeader {
+            param([Parameter(Mandatory)][string]$Path)
+            $lines = ((Get-Content -LiteralPath $Path -Raw) -replace "`r`n", "`n") -split "`n"
+            $i = [array]::IndexOf($lines, 'msgid ""')
+            if ($i -lt 0) { return $null }
+            $fields = [ordered]@{}
+            $raw = @()
+            $j = $i + 2
+            while ($j -lt $lines.Count -and $lines[$j].StartsWith('"')) {
+                $raw += $lines[$j]
+                if ($lines[$j] -match '^"([A-Za-z-]+):\s?(.*?)\\n"$') { $fields[$Matches[1]] = $Matches[2] }
+                $j++
+            }
+            [pscustomobject]@{
+                Path = $Path; Name = (Split-Path $Path -Leaf)
+                Comment = @($lines[0..($i - 1)]); Fields = $fields; RawFieldLines = $raw
+                IsTemplate = $Path.EndsWith('.pot')
+            }
+        }
+    }
+
+    Describe 'Write-NeoIPCPoHeader — the contract' {
+        It 'renders a template: language-less title, Language en, POT-Creation-Date, no Plural-Forms' {
+            $h = Write-NeoIPCPoHeader -Product 'NeoIPC Surveillance Reports' -License 'MIT' -PotCreationDate '2026-07-29 12:00+0200'
+            $h | Should -Match '(?m)^# Translations for the NeoIPC Surveillance Reports$'
+            $h | Should -Match '(?m)^"Language: en\\n"$'
+            $h | Should -Match '(?m)^"POT-Creation-Date: 2026-07-29 12:00\+0200\\n"$'
+            $h | Should -Not -Match 'Plural-Forms'
+        }
+        It 'renders a catalogue: per-language title, that language plural rule, no POT-Creation-Date' {
+            $h = Write-NeoIPCPoHeader -Product 'NeoIPC Surveillance Reports' -License 'MIT' -Locale 'fr'
+            $h | Should -Match '(?m)^# French translations for the NeoIPC Surveillance Reports$'
+            $h | Should -Match '(?m)^"Language: fr\\n"$'
+            $h | Should -Match '(?m)^"Plural-Forms: nplurals=2; plural=n > 1;\\n"$'
+            $h | Should -Not -Match 'POT-Creation-Date'
+        }
+        It 'omits every field that cannot stay true' {
+            # Each was correct when written and silently wrong afterwards; see Private/PoHeader.ps1.
+            $h = Write-NeoIPCPoHeader -Product 'P' -License 'L' -Locale 'de'
+            foreach ($absent in 'Project-Id-Version', 'Last-Translator', 'X-Generator') {
+                $h | Should -Not -Match $absent
+            }
+        }
+        It 'puts the bare # below the licence and above the contributors' {
+            # Load-bearing: translate-toolkit preserves everything before the first contributor line and drops
+            # an empty line after them, so contributors above the # would delete it on Weblate's next write.
+            $h = Write-NeoIPCPoHeader -Product 'P' -License 'L' -Locale 'de' -Contributor @('A B <a@b.de>, 2025.')
+            $comment = @(($h -split "`n") | Where-Object { $_.StartsWith('#') -or $_ -eq '#' })
+            $comment[3] | Should -BeExactly '#'
+            $comment[4] | Should -BeExactly '# A B <a@b.de>, 2025.'
+        }
+        It 'refuses a contributor line translate-toolkit would not recognise' {
+            # Without an e-mail AND a year it is read as a preline, and the add-on appends a duplicate person.
+            { Write-NeoIPCPoHeader -Product 'P' -License 'L' -Locale 'de' -Contributor @('Brar Piening') } |
+                Should -Throw '*duplicate*'
+            { Write-NeoIPCPoHeader -Product 'P' -License 'L' -Locale 'de' -Contributor @('Brar <b@c.de>') } |
+                Should -Throw '*duplicate*'
+        }
+        It 'refuses an unknown locale rather than inventing a language name' {
+            { Write-NeoIPCPoHeader -Product 'P' -License 'L' -Locale 'zz' } | Should -Throw '*zz*'
+        }
+    }
+
+    Describe 'Both module exporters render the same header' {
+        It 'produces byte-identical headers for the same product, licence and locale' {
+            # The two exporters used to carry their own copies, which is how they drifted apart.
+            $meta = [System.Collections.Generic.List[object]]::new()
+            $meta.Add([ordered]@{ Msgctxt = 'a/b/NAME'; Msgid = 'x'; Msgstr = ''; Fuzzy = $false; Priority = 100 })
+            $abx = [System.Collections.Generic.List[object]]::new()
+            $abx.Add([ordered]@{ Msgid = 'x'; Msgstr = ''; Fuzzy = $false })
+            $headerOf = { param($t) (($t -split "`n") | Select-Object -First 4) -join "`n" }
+            $m = & $headerOf (Write-NeoIPCMetadataPoText -Entry $meta)
+            $a = & $headerOf (Write-NeoIPCAntibioticPoText -Entry $abx)
+            # Only the product and licence differ; the shape must not.
+            ($m -split "`n").Count | Should -Be ($a -split "`n").Count
+            ($m -split "`n")[3] | Should -BeExactly '#'
+            ($a -split "`n")[3] | Should -BeExactly '#'
+        }
+    }
+
+    Describe 'Test-NeoIPCPoNonHumanIdentity — the shared exclusion list' {
+        It 'excludes every non-human identity observed in this repository' {
+            $nonHuman = @(
+                '# Anonymous <noreply@weblate.org>, 2026.'
+                '# Weblate (bot) <noreply@weblate.org>, 2026.'
+                '# Hosted Weblate <hosted@weblate.org>, 2026.'
+                '# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.'
+                '# Languages add-on <noreply-addon-languages@weblate.org>, 2026.'
+                '# Claude <noreply@anthropic.com>, 2026.'
+                '# GitHub <noreply@github.com>, 2026.'
+                '# FIRST AUTHOR <EMAIL@ADDRESS>'
+                '# FULL NAME <EMAIL@ADDRESS>'
+            )
+            foreach ($line in $nonHuman) {
+                Test-NeoIPCPoNonHumanIdentity -AuthorLine $line | Should -BeTrue -Because "'$line' is not a person"
+            }
+        }
+        It 'keeps the humans' {
+            foreach ($line in '# Brar Piening <brar.piening@charite.de>, 2025.', '# Libre <6n0n1m0s@proton.me>, 2026.') {
+                Test-NeoIPCPoNonHumanIdentity -AuthorLine $line | Should -BeFalse -Because "'$line' is a person"
+            }
+        }
+        It 'matches on the address, not the display name' {
+            # One address in this repository carries two different display names, so a name-keyed list would
+            # exclude one and silently credit the other.
+            Test-NeoIPCPoNonHumanIdentity -AuthorLine '# Someone Entirely New <noreply@weblate.org>, 2026.' |
+                Should -BeTrue
+        }
+    }
+
+    Describe 'Every committed catalogue conforms to the contract' {
+        # This is the check that would have caught the drift: it tests the FILES, so it holds regardless of
+        # which writer produced them, including a hand edit.
+        It 'finds catalogues to check' {
+            $script:catalogues.Count | Should -BeGreaterThan 50
+        }
+        It 'carries no field that cannot stay true' {
+            $bad = foreach ($f in $script:catalogues) {
+                $h = Get-CatalogueHeader -Path $f.FullName
+                foreach ($absent in 'Project-Id-Version', 'Last-Translator', 'X-Generator') {
+                    if ($h.Fields.Contains($absent)) { "$($h.Name): $absent" }
+                }
+            }
+            $bad | Should -BeNullOrEmpty
+        }
+        It 'keeps POT-Creation-Date in templates only' {
+            $bad = foreach ($f in $script:catalogues) {
+                $h = Get-CatalogueHeader -Path $f.FullName
+                if (-not $h.IsTemplate -and $h.Fields.Contains('POT-Creation-Date')) { "$($h.Name): has it" }
+                if ($h.IsTemplate -and -not $h.Fields.Contains('POT-Creation-Date')) { "$($h.Name): lacks it" }
+            }
+            $bad | Should -BeNullOrEmpty
+        }
+        It 'credits no non-human identity' {
+            $bad = foreach ($f in $script:catalogues) {
+                $h = Get-CatalogueHeader -Path $f.FullName
+                foreach ($line in $h.Comment) {
+                    if (Test-NeoIPCPoNonHumanIdentity -AuthorLine $line) { "$($h.Name): $line" }
+                }
+            }
+            $bad | Should -BeNullOrEmpty
+        }
+        It 'spells the copyright line identically everywhere' {
+            # One variant was ASCII-transliterated (Charite - Universitaetsmedizin), which a classifier that
+            # bucketed lines by keyword hid completely.
+            $variants = @($script:catalogues | ForEach-Object {
+                    (Get-CatalogueHeader -Path $_.FullName).Comment | Where-Object { $_ -like '*opyright*' }
+                } | Sort-Object -Unique)
+            $variants | Should -HaveCount 1
+            $variants[0] | Should -BeExactly '# Copyright (C) Charité – Universitätsmedizin Berlin'
+        }
+        It 'ends the fixed part of every comment block with a bare #' {
+            $bad = foreach ($f in $script:catalogues) {
+                $h = Get-CatalogueHeader -Path $f.FullName
+                if ($h.Comment.Count -lt 4 -or $h.Comment[3] -ne '#') { "$($h.Name): line 4 is '$($h.Comment[3])'" }
+            }
+            $bad | Should -BeNullOrEmpty
+        }
+        It 'serialises every header as continuation lines, none wrapped' {
+            # scripts.pot put the whole header on one msgstr line; metadata.de.po wrapped Language-Team.
+            $bad = foreach ($f in $script:catalogues) {
+                $h = Get-CatalogueHeader -Path $f.FullName
+                if (-not $h) { "$($f.Name): no header entry" ; continue }
+                foreach ($line in $h.RawFieldLines) {
+                    if ($line -notmatch '^"[A-Za-z-]+:') { "$($h.Name): continued line $line" }
+                }
+            }
+            $bad | Should -BeNullOrEmpty
+        }
+        It 'gives every catalogue a language and every template Language: en' {
+            $bad = foreach ($f in $script:catalogues) {
+                $h = Get-CatalogueHeader -Path $f.FullName
+                $lang = $h.Fields['Language']
+                if ($h.IsTemplate) { if ($lang -ne 'en') { "$($h.Name): template Language '$lang'" } }
+                elseif (-not $lang) { "$($h.Name): empty Language" }
+            }
+            $bad | Should -BeNullOrEmpty
+        }
+    }
+}

--- a/scripts/po/de.po
+++ b/scripts/po/de.po
@@ -1,19 +1,17 @@
 # German translations for the NeoIPC Surveillance Scripts
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the MIT license
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2025-08-30 07:51+0200\n"
+"Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language-Team: none\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 #. type: Plain text
 #: scripts/en/Convert-InfectiousAgentList-MessageStrings.psd1:2

--- a/scripts/po/scripts.pot
+++ b/scripts/po/scripts.pot
@@ -1,9 +1,17 @@
 # Translations for the NeoIPC Surveillance Scripts
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the MIT license
-# Automatically generated
+#
 msgid ""
-msgstr "Project-Id-Version: PACKAGE VERSION\nPOT-Creation-Date: 2026-07-06 18:54+0200\nPO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\nLast-Translator: FULL NAME <EMAIL@ADDRESS>\nLanguage-Team: LANGUAGE <LL@li.org>\nLanguage: \nMIME-Version: 1.0\nContent-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\n"
+msgstr ""
+"Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-29 17:55+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Language-Team: none\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
 #: scripts/en/Convert-InfectiousAgentList-MessageStrings.psd1:2

--- a/scripts/po4a.cfg
+++ b/scripts/po4a.cfg
@@ -1,5 +1,5 @@
 [po4a_langs] de
 [po4a_paths] scripts/po/scripts.pot $lang:scripts/po/$lang.po
-[options] --master-charset UTF-8 --localized-charset UTF-8 --wrap-po no --keep 0
+[options] --master-charset UTF-8 --localized-charset UTF-8 --wrap-po newlines --keep 0 --master-language en --msgid-bugs-address NeoIPC-Support@charite.de --copyright-holder "Charité – Universitätsmedizin Berlin" --package-name "NeoIPC Surveillance Scripts"
 
 [type: text] scripts/en/Convert-InfectiousAgentList-MessageStrings.psd1 $lang:scripts/$lang/Convert-InfectiousAgentList-MessageStrings.psd1 opt:"-o keyvalue" opt:"-o nobullets"

--- a/scripts/update-glossary-po.py
+++ b/scripts/update-glossary-po.py
@@ -48,6 +48,7 @@ Usage:
 
 import argparse
 import datetime
+import functools
 import re
 import sys
 from pathlib import Path
@@ -67,26 +68,49 @@ PLURAL_SUFFIX = re.compile(r"_plural(?:_(tc|sc))?$")
 FLAGS_LINE = re.compile(r"^flags:\s*(.+)$", re.IGNORECASE)
 DEFAULT_LANGUAGES = ["af", "de", "el", "es", "et", "fr", "it", "ne", "tr"]
 
+# The header contract is defined once, in the NeoIPC-Tools module (Private/PoHeader.ps1). This is the same
+# contract expressed in Python, because this generator cannot call into a PowerShell module; the two are held
+# in step by Tests/PoHeader.Tests.ps1, which renders both and compares them.
+#
+# The trailing bare "#" is load-bearing, not decoration. translate-toolkit's updatecontributor — which
+# Weblate's "Contributors in comment" add-on delegates to — splits the comment block at the first line matching
+# r".*<\S+@\S+>.*\d{4,4}" (an e-mail AND a four-digit year). Everything before it is preserved untouched;
+# contributors are appended after the last one; anything following them is dropped if empty. So the "#" belongs
+# BELOW the licence and ABOVE any contributor, where it is the final preserved line.
 POT_HEADER_COMMENT = (
     "Translations for the NeoIPC Surveillance Glossary\n"
     "Copyright (C) Charité – Universitätsmedizin Berlin\n"
     "This file is distributed under the Creative Commons "
     "Attribution 4.0 International license\n"
-    "Automatically generated"
 )
 
+# Deliberately absent: Project-Id-Version (its version suffix froze while the products moved on),
+# Last-Translator (frozen by po_set_last_translator=false, so it would name a translator who can never change)
+# and X-Generator (a Weblate version string that rewrote every catalogue on each upgrade). POT-Creation-Date is
+# stamped in the TEMPLATE only — msgmerge does not refresh it in a catalogue, where it silently goes stale.
 POT_METADATA = {
-    "Project-Id-Version": "NeoIPC Surveillance Glossary 0.9",
     "Report-Msgid-Bugs-To": "NeoIPC-Support@charite.de",
     "POT-Creation-Date": "",  # filled at generation time
     "PO-Revision-Date": "YEAR-MO-DA HO:MI+ZONE",
-    "Last-Translator": "Automatically generated",
     "Language-Team": "none",
     "Language": "en",
     "MIME-Version": "1.0",
     "Content-Type": "text/plain; charset=UTF-8",
     "Content-Transfer-Encoding": "8bit",
 }
+
+# Weblate writes Language-Team as "<English name> <component URL>" and a plural rule per language. Both are
+# pre-filled with the values Weblate itself produces, so that registering neoipc-glossary as a component (which
+# makes these files Weblate-owned) yields no header diff at all. LANGUAGE_NAMES, defined further down, supplies
+# the English names.
+PLURAL_FORMS = {
+    "af": "nplurals=2; plural=n != 1;", "de": "nplurals=2; plural=n != 1;",
+    "el": "nplurals=2; plural=n != 1;", "es": "nplurals=2; plural=n != 1;",
+    "et": "nplurals=2; plural=n != 1;", "fr": "nplurals=2; plural=n > 1;",
+    "it": "nplurals=2; plural=n != 1;", "ne": "nplurals=2; plural=n != 1;",
+    "tr": "nplurals=2; plural=n != 1;",
+}
+WEBLATE_COMPONENT_URL = "https://hosted.weblate.org/projects/neoipc/neoipc-glossary/{lang}/"
 
 
 def _comment_lines(tokens):
@@ -267,15 +291,87 @@ LANGUAGE_NAMES = {
 
 
 def _po_header_comment(lang):
-    """Generate the file-level comment block for a new PO file."""
+    """Generate the file-level comment block for a new PO file.
+
+    Ends on a bare "#" and carries no author placeholder. "FIRST AUTHOR <EMAIL@ADDRESS>, YEAR." is the exact
+    string translate-toolkit treats as the marker for where contributors begin, and the truncated form used
+    here previously was neither that marker nor a valid contributor line — it simply sat in the block being
+    mistaken for an author. The bare "#" is the last line the contributor machinery preserves, so real
+    contributors land immediately below it.
+    """
     lang_name = LANGUAGE_NAMES.get(lang, lang)
     return (
         f"{lang_name} translations for the NeoIPC Surveillance Glossary\n"
         "Copyright (C) Charité – Universitätsmedizin Berlin\n"
         "This file is distributed under the Creative Commons "
         "Attribution 4.0 International license\n"
-        "FIRST AUTHOR <EMAIL@ADDRESS>"
     )
+
+
+_CONTRIBUTOR_RE = re.compile(r".*<\S+@\S+>.*\d{4,4}")
+_ADDRESS_RE = re.compile(r"<([^>]+)>")
+NON_HUMAN_IDENTITIES_PATH = Path(__file__).resolve().parent.parent / "po" / "non-human-identities.yaml"
+
+
+@functools.lru_cache(maxsize=1)
+def _non_human_identities():
+    """The shared exclusion list, read from po/non-human-identities.yaml.
+
+    Data rather than code, because PowerShell and R consult the same file: a list maintained separately in
+    three languages is one that disagrees with itself. See that file for why matching is on the address and
+    never on the display name.
+    """
+    with open(NON_HUMAN_IDENTITIES_PATH, encoding="utf-8") as handle:
+        data = YAML(typ="safe").load(handle) or {}
+    return (
+        {d.lower() for d in data.get("excluded_domains", [])},
+        {e["address"].lower() for e in data.get("excluded_addresses", [])},
+        set(data.get("excluded_literals", [])),
+    )
+
+
+def is_non_human(line):
+    """Whether a credit line names something other than a person."""
+    domains, addresses, literals = _non_human_identities()
+    if any(literal in line for literal in literals):
+        return True
+    match = _ADDRESS_RE.search(line)
+    if not match:
+        return False
+    address = match.group(1).lower()
+    return address in addresses or address.rsplit("@", 1)[-1] in domains
+
+
+def _retained_contributors(header):
+    """The contributor lines worth keeping from an existing header, as text to append below the bare "#".
+
+    Recognises a contributor with translate-toolkit's own rule -- an e-mail AND a four-digit year -- so that
+    what we keep is exactly what its updatecontributor() will later treat as the contributor run. Anything
+    failing it (the truncated "FIRST AUTHOR <EMAIL@ADDRESS>" placeholder that used to sit here, a bare name)
+    is not a contributor and is dropped rather than carried forward.
+    """
+    kept = [
+        line for line in (header or "").split("\n")
+        if _CONTRIBUTOR_RE.match(line) and not is_non_human(line)
+    ]
+    return "".join("\n" + line for line in kept)
+
+
+def _po_metadata(lang, pot_metadata):
+    """Header fields for a catalogue: the template's, minus what belongs only to a template, plus per-language.
+
+    POT-Creation-Date is dropped: msgmerge does not refresh it in a catalogue, so it records the age of a
+    template generation that has long since moved on. Language-Team and Plural-Forms are pre-filled with what
+    Weblate writes, so registering the component produces no diff.
+    """
+    meta = {k: v for k, v in pot_metadata.items() if k != "POT-Creation-Date"}
+    meta["Language"] = lang
+    meta["Language-Team"] = "{0} <{1}>".format(
+        LANGUAGE_NAMES.get(lang, lang), WEBLATE_COMPONENT_URL.format(lang=lang)
+    )
+    if lang in PLURAL_FORMS:
+        meta["Plural-Forms"] = PLURAL_FORMS[lang]
+    return meta
 
 
 def merge_po(pot_path, po_path):
@@ -289,8 +385,7 @@ def merge_po(pot_path, po_path):
         # Create a new PO from the POT
         po = polib.POFile()
         po.header = _po_header_comment(lang)
-        po.metadata = {**pot.metadata}
-        po.metadata["Language"] = lang
+        po.metadata = _po_metadata(lang, pot.metadata)
         for entry in pot:
             new_entry = polib.POEntry(
                 msgctxt=entry.msgctxt,
@@ -324,8 +419,8 @@ def merge_po(pot_path, po_path):
             existing_by_msgid[entry.msgid] = entry
 
     new_po = polib.POFile()
-    new_po.header = po.header or _po_header_comment(lang)
-    new_po.metadata = {**po.metadata}
+    new_po.header = _po_header_comment(lang) + _retained_contributors(po.header)
+    new_po.metadata = _po_metadata(lang, pot.metadata)
 
     for pot_entry in pot:
         key = (pot_entry.msgctxt, pot_entry.msgid)


### PR DESCRIPTION
The files under `po/` are written by four tools — po4a corrected by `Invoke-Localization.ps1`,
`update-glossary-po.py`, and the two exporters in `NeoIPC-Tools` — and each carried its own copy of the
header. They had drifted into **eight** comment-block shapes, three spellings of the copyright line, a product
name disagreeing with its own `Project-Id-Version`, a `Language-Team` wrapped across two physical lines, and one
header serialised onto a single line. Nothing noticed, because nothing asserted it: the suite passed identically
before and after the header text was changed.

### The contract

One definition, in `Private/PoHeader.ps1`, called by both PowerShell exporters. The Python generator and the
po4a post-processor state the same contract in their own languages, which no shared function can span.

Four fields are gone because each was true when written and silently wrong afterwards:

| Field | Why |
|---|---|
| `Project-Id-Version` | froze at `0.9` while the products moved on; also split by an `Agent`/`Agents` typo |
| `X-Generator` | a Weblate version string that rewrote every catalogue on each upgrade |
| `Last-Translator` | frozen by `po_set_last_translator=false`, so it named a translator who could never change |
| `POT-Creation-Date` *(catalogues only)* | msgmerge does not refresh it there; it had drifted three weeks out |

`POT-Creation-Date` stays in the **templates**, where the generator stamps it and it is true by construction.

### The block shape is dictated by translate-toolkit, not by taste

`updatecontributor` splits the comment block at the first line matching `.*<\S+@\S+>.*\d{4,4}` — an e-mail AND
a four-digit year. Everything above is preserved, contributors are appended after the last one, and an empty
line below them does not survive the round trip. So the bare `#` sits under the licence and above the
contributors, where it is the final preserved line. An earlier draft had contributors above it, which would have
deleted it on Weblate's next write, every time.

For the same reason a retained credit **must** carry an e-mail and a year: without them it fails the regex, is
read as a preline, and the add-on appends a second copy of the same person. Both writers now refuse such a line,
and refuse an unknown locale rather than invent a language name that disagrees with Weblate's.

### Corrections, not just uniformity

* **Licence.** `reports.*` declared MIT and `infectious_agents.*` declared CC BY-NC-ND, while both components
  have always advertised CC BY 4.0 to the people translating them — and a NoDerivatives term cannot govern a
  translation catalogue at all, a translation being the paradigm derivative work. The catalogues now say what
  was actually offered. The NonCommercial-NoDerivatives text still appears *inside* `infectious_agents` as a
  translatable string: that is the Output-Footer describing the licence of the YAML list, a different artifact
  which keeps those terms.
* **Copyright.** Five metadata catalogues carried an ASCII-transliterated line — `Charite - Universitaetsmedizin`
  — residue of the mojibake episode visible in `219a7b1`.
* **Credits.** Both Weblate add-ons removed, along with the maintainer's name from ten catalogues he did not
  translate, and his two addresses collapsed to one. Libre keeps his credit in both Spanish catalogues.
* **`scripts/po4a.cfg`** passed `--wrap-po no` where the other three configs pass `--wrap-po newlines`, which is
  why `scripts.pot` serialised its whole header onto one line and no line-based repair could match it. Fixed at
  the source rather than by teaching the post-processor a second shape.

### Shared data, not duplicated lists

`po/non-human-identities.yaml` holds the identities that are not people, consumed by PowerShell and Python today
and by R when translator acknowledgements land. Matching is on the **address**, never the display name:
`noreply@weblate.org` appears in this repository's history under two different names, so a name-keyed list would
exclude one and silently credit the other.

### Verification

* `PoHeader.Tests.ps1` — 18 cases, asserting against the **committed files** rather than the writers, so drift is
  caught however a catalogue is produced. It was red on the first two commits and named exactly what remained.
* 634 module tests pass; text-file hygiene clean across 1276 files.
* **No translation was gained, lost or re-fuzzied**: per-catalogue counts of translated, needs-editing and total
  entries are identical before and after, and the diff contains no `msgid` or `msgstr` line.

### Expect the ownership gate to fail

This changes Weblate-owned catalogues, which the `catalogue-ownership` job rejects by design. That is the point
of the gate and not a defect here: these headers cannot be corrected through Weblate, because msgmerge preserves
a target's header rather than taking the template's. The sequence is a deliberate one-off — merge with an
administrator override, then *Reset and reapply* on all four components so Weblate adopts `main`. All four are
drained and clean, so the reset applies exactly this change and nothing else.

`scripts/po/de.po` is hand-corrected and a pipeline run will undo it; that is recorded, with the reason, in the
task file for the pending PowerShell message-string rework.
