### PR TITLE
Drop the bot credit the infectious-agents drain reintroduced

### DIFF
--- a/po/infectious_agents.af.po
+++ b/po/infectious_agents.af.po
@@ -2,7 +2,6 @@
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"

--- a/po/infectious_agents.de.po
+++ b/po/infectious_agents.de.po
@@ -3,7 +3,6 @@
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 # Brar Piening <brar.piening@charite.de>, 2025.
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"

--- a/po/infectious_agents.el.po
+++ b/po/infectious_agents.el.po
@@ -2,7 +2,6 @@
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"

--- a/po/infectious_agents.es.po
+++ b/po/infectious_agents.es.po
@@ -2,7 +2,6 @@
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"

--- a/po/infectious_agents.et.po
+++ b/po/infectious_agents.et.po
@@ -2,7 +2,6 @@
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"

--- a/po/infectious_agents.fr.po
+++ b/po/infectious_agents.fr.po
@@ -2,7 +2,6 @@
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"

--- a/po/infectious_agents.it.po
+++ b/po/infectious_agents.it.po
@@ -2,7 +2,6 @@
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"

--- a/po/infectious_agents.ne.po
+++ b/po/infectious_agents.ne.po
@@ -2,7 +2,6 @@
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"

--- a/po/infectious_agents.tr.po
+++ b/po/infectious_agents.tr.po
@@ -2,7 +2,6 @@
 # Copyright (C) Charité – Universitätsmedizin Berlin
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
-# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"


### PR DESCRIPTION
Removes the nine `# Prefill add-on <noreply-addon-prefill@weblate.org>, 2026.` lines that #116 brought
onto `main`. Nine deletions, nothing else — `git diff` contains exactly one distinct line, nine times.
`PoHeader.Tests.ps1` is green again (18/18).

### Why it could not be fixed on the drain branch

Weblate keeps its commits after pushing and rebases them onto `main`. Rewriting that branch gives them a
different patch identity, so git can no longer prove `main` contains them, and it replays them into a
conflict across every component at once. Correcting the header from the repository side *after* the drain
lands is the route that holds — the same one used when the catalogue headers were first brought onto one
definition.

### Why it happened, and why it is a one-off

The commit that added the lines is *authored by* the Prefill add-on. That add-on was uninstalled, but the
authorship of its changes stayed in Weblate's database; the Squash add-on groups pending changes by
author, so flushing them produced a commit under that identity, and *Contributors in comment* writes the
committing author into each touched header. Its bot filter skips only `noreply@weblate.org`.

The second commit on that same branch — authored by `Anonymous <noreply@weblate.org>` — added no credit
at all. That is the control: it shows the filter works for the address it knows, and that the contributor
list is appended per commit rather than recomputed from history. With the backlog now drained and the
add-on uninstalled, there is no second commit under that identity coming.

### `catalogue-ownership` will fail, and that is correct

This pull request edits Weblate-owned `.po` files from the repository side, which is exactly what that
gate exists to reject. The gate is right and should not be weakened; this is the narrow case it cannot
distinguish — a header correction that Weblate itself cannot make, because the offending value is what
Weblate writes. It needs an administrator override, and nothing else here does.

#112 makes the next occurrence self-detecting by running the header contract in CI, so this class stops
depending on someone reading a translation diff.
