### PR TITLE
Ignore only grep's "no matches", not every way grep can fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,24 @@ jobs:
                 fi
 
                 offending=""
-                matched=$(printf '%s\n' "$changed" | grep -E "^($owned)$" || true)
+                # `|| true` would ignore EVERY non-zero status; the contract this gate wants is narrower and
+                # is stated in the loop below — grep's exit 1 means "no matches", which is how it says the
+                # input is clean, and anything ABOVE 1 is grep itself failing. Collapsing the two lets a
+                # filter that could not run read as "nothing owned was changed": measured under Actions'
+                # `bash -eo pipefail`, an unrunnable pattern took the old form to "PASSED, exit 0" on a
+                # changed catalogue it should have rejected. Not reachable while `$owned` is a literal that
+                # compiles — but "correct because today's pattern happens to compile" is a property of the
+                # input rather than of this gate, which is the same reasoning that closed the rename and
+                # word-splitting escapes above.
+                #
+                # `|| rc=$?` rather than a bare assignment: under `set -e` a failing command substitution
+                # ends the step before the status can be inspected at all.
+                rc=0
+                matched=$(printf '%s\n' "$changed" | grep -E "^($owned)$") || rc=$?
+                if [ "$rc" -gt 1 ]; then
+                  echo "::error::The ownership filter could not run (grep exit $rc) — the gate cannot vouch for this pull request."
+                  exit 1
+                fi
                 # `while IFS= read -r`, not `for f in $(…)`: the unquoted expansion word-splits on IFS, so a
                 # matching path containing a space arrives as two fragments, neither of which names a real
                 # file — `git log -- po/reports.de` returns nothing, the loop reads that as "no non-Weblate
@@ -112,7 +129,17 @@ jobs:
                   fi
                   # Not `grep -q`: it exits on the first hit, and SIGPIPE plus `pipefail` would then report
                   # the pipeline as failed, which reads here as "no offence found" and silently passes.
-                  others=$(printf '%s\n' "$committers" | grep -vFx "$weblate" || true)
+                  # Same narrowing as the filter above, and here the two statuses are load-bearing in
+                  # opposite directions: `grep -vFx` exits 1 when every committer IS Weblate — the clean
+                  # case, which must stay ignored — and 0 when a non-Weblate committer exists, which is the
+                  # offence. So this cannot become a bare `grep` with no `||` at all; 0 and 1 are both
+                  # expected answers and only 2 and above mean the filter failed.
+                  rc=0
+                  others=$(printf '%s\n' "$committers" | grep -vFx "$weblate") || rc=$?
+                  if [ "$rc" -gt 1 ]; then
+                    echo "::error::The committer filter could not run for $f (grep exit $rc) — the gate cannot vouch for this pull request."
+                    exit 1
+                  fi
                   if [ -n "$others" ]; then offending="${offending}${f}"$'\n'; fi
                 done <<< "$matched"
                 if [ -n "$offending" ]; then


### PR DESCRIPTION
Both grep invocations in the `catalogue-ownership` gate were wrapped in `|| true`, which ignores **every** non-zero status. The contract the gate wants is narrower, and the comment beside one of them already states it:

> Only the grep's own "no matches" status is ignored, since that is its way of saying the file is clean.

`|| true` is wider than that rule. Exit 1 is grep saying *no matches*; anything above 1 is grep failing — and collapsing the two lets a filter that could not run read as *nothing owned was changed*.

## Measured

Under Actions' real shell (`bash --noprofile --norc -eo pipefail`), on the gate's own construct with a changed catalogue present:

```
                       valid pattern            pattern that cannot compile
old form   REJECTED: po/reports.de.po      PASSED (nothing owned changed)   exit 0
new form   REJECTED: po/reports.de.po      ::error:: filter could not run (grep exit 2)  exit 1

valid pattern, no match:   both forms PASS, exit 0
```

Worth noting which patterns actually error, because the obvious guess is wrong — `\(` is a literal in ERE and exits 1, not 2:

```
^(a$   exit 2      a{1,   exit 1  (valid)
[abc   exit 2      a\     exit 2
```

## Why not simply drop the `|| true`

Because both low statuses are real answers, in opposite directions:

```
all committers are Weblate   grep -vFx exits 1   <- CLEAN, must stay ignored
mixed history                grep -vFx exits 0   <- an offence
no owned file changed        grep -E   exits 1   <- CLEAN, must stay ignored
```

So the statuses are compared rather than discarded: 0 and 1 expected, 2 and above fatal. `|| rc=$?` rather than a bare assignment, because under `set -e` a failing command substitution ends the step before any status can be inspected.

## Severity — stated plainly

**Not reachable with today's inputs.** The owned pattern is a literal in the workflow that compiles, and the committer filter passes `-F`, so it has no regex to be invalid. What remains is resource exhaustion or a broken `grep`. That is thinner than the word-splitting escape, which needed only someone to create a file.

The argument that does not rest on reachability is one this gate has already accepted twice, in its own comments: *"correct because today's filemask happens to yield space-free paths" is a property of the data, not of this gate.* "Correct because `$owned` happens to compile" is the same sentence about a different datum, and taking one while declining the other would apply the standard to whichever instance was found first.

## Scope

The identical construct exists in both repositories' copies of this gate, so this change is made in both. No behaviour changes for any input the gate sees today.
