### PR TITLE
Bring the report catalogues up to the settled spelling

### DIFF
--- a/po/reports.af.po
+++ b/po/reports.af.po
@@ -5,6 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
 "PO-Revision-Date: 2026-07-29 17:29+0000\n"
 "Language-Team: Afrikaans <https://hosted.weblate.org/projects/neoipc/neoipc-reports/af/>\n"
 "Language: af\n"
@@ -283,10 +284,10 @@ msgstr ""
 msgid "Sum of patient days"
 msgstr ""
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr ""
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -385,10 +386,10 @@ msgstr ""
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr ""
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr ""
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -610,7 +611,7 @@ msgstr ""
 #. type: Hash Value: tbl-abr-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -670,7 +671,7 @@ msgstr ""
 #. type: Hash Value: tbl-agent-per-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -709,58 +710,58 @@ msgstr ""
 msgid "Infectious agents detected in nosocomial infections"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic Exposure Density Rate"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Substance-days"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -820,7 +821,7 @@ msgstr ""
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No device-associated infection data available for this report settings."
+msgid "No device-associated infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
@@ -880,7 +881,7 @@ msgstr ""
 #. type: Hash Value: tbl-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -916,7 +917,7 @@ msgstr ""
 #. type: Hash Value: tbl-infectious-agent-detection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -964,7 +965,7 @@ msgstr ""
 #. type: Hash Value: tbl-organism-resistance-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1024,7 +1025,7 @@ msgstr ""
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
+msgid "No antibiotic resistance diagnostics data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
@@ -1061,12 +1062,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates any
@@ -1108,7 +1103,7 @@ msgstr ""
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No risk/protective factor data available for this report settings."
+msgid "No risk/protective factor data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
@@ -1121,12 +1116,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
@@ -1147,12 +1136,6 @@ msgstr ""
 msgid "Ventilatory support"
 msgstr ""
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr ""
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, no-wrap
@@ -1162,7 +1145,7 @@ msgstr ""
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No secondary BSI data available for this report settings."
+msgid "No secondary BSI data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
@@ -1303,10 +1286,10 @@ msgstr ""
 msgid "Surgical procedures by category"
 msgstr ""
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr ""
 
 #. type: Hash Value: total
@@ -1522,7 +1505,7 @@ msgstr ""
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr ""
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1936,13 +1919,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2206,13 +2189,13 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2230,7 +2213,7 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec metric_label
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2491,13 +2474,13 @@ msgstr ""
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated for your department's infants."
@@ -2638,7 +2621,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, no-wrap
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2720,9 +2703,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2738,10 +2721,10 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
+msgid "`r sR$methods$antibiotic_utilization`\n"
 msgstr ""
 
 #. type: Plain text
@@ -3230,7 +3213,7 @@ msgstr ""
 msgid "Presence of Risk and Protective Factors"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in all infants."
@@ -3269,7 +3252,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, no-wrap
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr ""
 
 #. type: Plain text
@@ -3573,7 +3556,7 @@ msgstr ""
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 31 description
@@ -3597,31 +3580,31 @@ msgstr ""
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr ""
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr ""
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr ""
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 39 description
@@ -3720,8 +3703,8 @@ msgstr ""
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3818,7 +3801,7 @@ msgstr ""
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 
 #. type: Plain text
@@ -4377,7 +4360,7 @@ msgstr ""
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
 #, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr ""
 
 #. type: Plain text

--- a/po/reports.de.po
+++ b/po/reports.de.po
@@ -3,10 +3,12 @@
 # This file is distributed under the Creative Commons Attribution 4.0 International license
 #
 # Brar Piening <brar.piening@charite.de>, 2025.
+# Brar Piening <brar@gmx.de>, 2026.
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
-"PO-Revision-Date: 2026-07-29 17:27+0000\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
+"PO-Revision-Date: 2026-07-31 15:01+0000\n"
 "Language-Team: German <https://hosted.weblate.org/projects/neoipc/neoipc-reports/de/>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -285,11 +287,11 @@ msgstr "Dies ist eine spezielle Analyse, die"
 msgid "Sum of patient days"
 msgstr "Summe der Patiententage"
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Antibiotics"
-msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr "Antibiotika"
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -388,10 +390,10 @@ msgstr "Chirurgische Eingriffe nach Kategorie"
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr ""
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr ""
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -613,8 +615,9 @@ msgstr "%s: Die Gesamtzahl der antibiotikaresistenten Erreger bei allen Infektio
 
 #. type: Hash Value: tbl-abr-infection-rate no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No resistant pathogen infection data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Daten zu Infektionen mit resistenten Erregern vor."
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -674,8 +677,9 @@ msgstr "%s: Die Gesamtzahl der Infektionserreger in allen Infektionen."
 
 #. type: Hash Value: tbl-agent-per-infection-rate no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No infectious agent data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Daten zu Infektionserregern vor."
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -715,64 +719,64 @@ msgstr "Anzahl der bei Infektionen nachgewiesenen Infektionserreger"
 msgid "Infectious agents detected in nosocomial infections"
 msgstr "Bei nosokomialen Infektionen nachgewiesene Infektionserreger"
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Risk Density Rate"
 msgid "Antibiotic Exposure Density Rate"
 msgstr "Risikofaktor-Anwendungsrate"
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number of device-associated infections in all infants."
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr "%s: Die Gesamtzahl der Device-assoziierten Infektionen bei allen Kindern."
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No infection data available for this report settings."
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Infektionsdaten vor."
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The Risk Density Rate calculated across all infants from all departments in the reference data."
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr "%s: Die Risikofaktor-Anwendungsrate, berechnet für alle Kinder aus allen Abteilungen in den Referenzdaten."
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Risk Density Rates of the departments in the reference data. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Risk Density Rate."
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr "%s, %s, %s: Die Quartile (%s, %s und %s Quantile) der Risikofaktor-Anwendungsraten der Abteilungen in den Referenzdaten. Diese Quartile werden nur angezeigt, wenn die Anzahl der Abteilungen, die zum Nenner beitragen, größer oder gleich fünf ist und wenn die mittlere Anzahl der Device-Tag gemäß der gepoolten Risikofaktor-Anwendungsrate größer oder gleich eins ist."
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Substance"
 msgid "Substance-days"
 msgstr "Substanz"
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -834,8 +838,9 @@ msgstr "Beatmungsassoziierte Pneumonie"
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No device-associated infection data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No device-associated infection data available for this report settings."
+msgid "No device-associated infection data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Daten zu deviceassoziierten Infektionen vor."
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
@@ -897,8 +902,9 @@ msgstr "Anzahl der Infektionen"
 
 #. type: Hash Value: tbl-incidence-density-rates no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No infection data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Infektionsdaten vor."
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -935,8 +941,9 @@ msgstr "%s: Die Gesamtzahl der Infektionen, bei denen mindestens ein Infektionse
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No infectious agent detection data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Daten zum Nachweis von Infektionserregern vor."
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -987,7 +994,7 @@ msgstr "%s: Die Gesamtzahl der Infektionen bei allen Kindern."
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No antibiotic resistance diagnostics data available for this report settings."
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Daten zur Antibiotikaresistenzdiagnostik vor."
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1051,8 +1058,9 @@ msgstr "%s: Die Gesamtzahl der antibiotikaresistenten Krankheitserreger, für di
 
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No antibiotic resistance diagnostics data available for this report settings."
+msgid "No antibiotic resistance diagnostics data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Daten zur Antibiotikaresistenzdiagnostik vor."
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
@@ -1091,12 +1099,6 @@ msgstr "Anzahl der Krankheitserreger mit dokumentierten Tests auf Antibiotikares
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
 msgstr "Diagnostik von Antibiotikaresistenzen"
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
-msgstr "Access"
 
 #. type: Hash Value: tbl-risk-density-rates any
 #: reports/common.yaml:1
@@ -1137,8 +1139,9 @@ msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No risk/protective factor data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No risk/protective factor data available for this report settings."
+msgid "No risk/protective factor data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Daten zu Risikofaktoren und Schutzfaktoren vor."
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
@@ -1154,12 +1157,6 @@ msgstr "%s: Die Risikofaktor-Anwendungsrate, berechnet für alle Kinder aus alle
 #| msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Risk Density Rates of the departments in the reference data. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Risk Density Rate."
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
 msgstr "%s, %s, %s: Die Quartile (%s, %s und %s Quantile) der Risikofaktor-Anwendungsraten der Abteilungen in den Referenzdaten. Diese Quartile werden nur angezeigt, wenn die Anzahl der Abteilungen, die zum Nenner beitragen, größer oder gleich fünf ist und wenn die mittlere Anzahl der Device-Tag gemäß der gepoolten Risikofaktor-Anwendungsrate größer oder gleich eins ist."
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
-msgstr "Reserve"
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
 #: reports/common.yaml:1
@@ -1180,12 +1177,6 @@ msgstr "Gefäßkatheter"
 msgid "Ventilatory support"
 msgstr "Atemunterstützung"
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr "Watch"
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, no-wrap
@@ -1194,8 +1185,9 @@ msgstr "%s: Die Gesamtzahl der Infektionen, bei denen mindestens ein Infektionse
 
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No secondary BSI data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No secondary BSI data available for this report settings."
+msgid "No secondary BSI data available for these report settings."
 msgstr "Für diese Berichtseinstellungen liegen keine Daten zu sekundären Blutstrominfektionen vor."
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
@@ -1338,10 +1330,11 @@ msgstr "Anzahl der Prozeduren"
 msgid "Surgical procedures by category"
 msgstr "Chirurgische Eingriffe nach Kategorie"
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
-#, no-wrap
-msgid "Not yet categorised"
+#, fuzzy, no-wrap
+#| msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr "Noch nicht kategorisiert"
 
 #. type: Hash Value: total
@@ -1420,7 +1413,7 @@ msgstr "Surveillance"
 #: reports/Partner-Report/_quarto-en.yml:1
 #, no-wrap
 msgid "Partner Report"
-msgstr "Referenz-Auswertung"
+msgstr "Partner-Auswertung"
 
 #. type: Hash Value: title
 #: reports/Partner-Report/_quarto-en.yml:1
@@ -1557,7 +1550,7 @@ msgstr ""
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr ""
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1979,13 +1972,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2258,13 +2251,13 @@ msgstr "Beatmungsassoziierte Pneumonie"
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2283,7 +2276,7 @@ msgstr ""
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Necrotising Enterocolitis"
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr "Nekrotisierende Enterokolitis"
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2550,14 +2543,14 @@ msgstr "%s: Die Gesamtzahl der Tage, an denen der Risiko-/Schutzfaktor bei den K
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr "Anzahl der Infektionen, bei denen ein Infektionserreger nachgewiesen wurde."
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number of surgical procedures performed in your department's infants."
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr "%s: Die Gesamtzahl der chirurgischen Eingriffe, die bei allen Kindern durchgeführt wurden."
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The Risk Density Rate calculated for your department's infants.\n"
@@ -2704,7 +2697,7 @@ msgstr "Die Epidemiologie der Infektionserreger, die nosokomiale Infektionen in 
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, fuzzy, no-wrap
 #| msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections, representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr "Insgesamt wurden `r dR$numberOfInfectiousAgents` Infektionserreger in den `r dR$numberOfInfectionsWithAgent` Infektionen nachgewiesen, bei denen mindestens ein Erreger entweder aus der Primärinfektion und/oder der daraus resultierenden sekundären Blutbahninfektion gemeldet wurde (@tbl-agent-per-infection-rate). Diese `r dR$numberOfInfectionsWithAgent` diagnostisch positiven Infektionen von insgesamt `r dR$overallNumberOfInfections` Infektionen entsprechen einer Infektionserreger-Erkennungsrate von `r dR$infectiousAgentDetectionRate` pro 100 Infektionen (@tbl-infectious-agent-detection-rate).\n"
 
 #. type: Plain text
@@ -2796,9 +2789,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr "Die Prüfung der Empfindlichkeit gegenüber Antibiotika (AST) ist sowohl für die Behandlung einzelner Patienten als auch für die Überwachung auf Bevölkerungsebene von grundlegender Bedeutung. @tbl-resistance-test-rate gibt die Rate an, mit der aus Infektionen isolierte Krankheitserreger auf bestimmte relevante Antibiotikaresistenzen getestet werden. Dieser Abschnitt bewertet die *Vollständigkeit* der Testung; @tbl-abr-infection-rate zeigt die tatsächlich nachgewiesenen resistenten Erreger. Hohe Testraten gewährleisten zuverlässige Daten für Antibiotika-Stewardship-Programme und ermöglichen eine genaue Einschätzung von Resistenztrends. Niedrigere Raten können auf Lücken in der diagnostischen Kapazität oder in den Protokollen hinweisen, was Ihre Fähigkeit einschränken könnte, neu auftretende Resistenzmuster zu erkennen und darauf zu reagieren.\n"
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2816,11 +2809,12 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr "Chirurgische Eingriffe stellen einen wesentlichen Risikofaktor für nosokomiale Infektionen auf neonatologischen Intensivstationen dar. @tbl-surgical-procedure-rates zeigt die Raten verschiedener chirurgischer Eingriffe, die in Ihrer Abteilung durchgeführt werden, normiert auf 100 Aufnahmen. Ein Verständnis Ihres chirurgischen Behandlungsspektrums ist unerlässlich, um Infektionsraten zu interpretieren und geeignete Protokolle zur Prävention von Wundinfektionen umzusetzen. Ein Vergleich mit Referenzdaten hilft dabei, die chirurgische Arbeitslast Ihrer Abteilung und die damit verbundenen Infektionsrisiken einzuordnen.\n"
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
-msgstr ""
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
+#, fuzzy, no-wrap
+#| msgid "Antibiotics"
+msgid "`r sR$methods$antibiotic_utilization`\n"
+msgstr "Antibiotika"
 
 #. type: Plain text
 #: reports/Partner-Report/content/_tbl-intro-secondary-bsi.Rmd:1
@@ -3310,7 +3304,7 @@ msgstr "Dieser Bericht enthält Daten von neonatologischen Abteilungen in einem 
 msgid "Presence of Risk and Protective Factors"
 msgstr "Risiko- und Schutzfaktoren"
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number of infections in all infants."
@@ -3352,7 +3346,7 @@ msgstr "Da der Prozess zwar durch verschiedene Instrumente unterstützt wird, je
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, fuzzy, no-wrap
 #| msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In @tbl-incidence-density-rates, the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr "Nosokomiale Infektionen stellen den primären Endpunkt der NeoIPC-Surveillance dar. In @tbl-incidence-density-rates werden die Inzidenzdichten von Sepsis/BSI, Pneumonie und nekrotisierender Enterokolitis sowie der kombinierte Endpunkt „schwere Infektion” angezeigt. Insgesamt wurden `r dR$numberOfSevereInfections` schwere Infektionen bei `r dR$numberOfPatients` Neonaten registriert, was einer durchschnittlichen Anzahl von `r dR$averageSevereInfectionsPerPatient` Infektionen pro Patient entspricht.\n"
 
 #. type: Plain text
@@ -3663,8 +3657,9 @@ msgstr "Das Aufnahmedatum im Aufnahme-Formular (%s) unterscheidet sich vom Aufna
 
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
-#, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+#, fuzzy, no-wrap
+#| msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr "Die Sepsis trat innerhalb der ersten zwei Tage des Krankenhausaufenthalts eines überwiesenen oder (wieder-)aufgenommenen Patienten auf (der Tag des Krankenhausaufenthalts ist %i). Siehe @sec-problem-details-20."
 
 #. type: Hash Value: problems 31 description
@@ -3687,32 +3682,37 @@ msgstr "Die Pneumonie trat innerhalb der ersten drei Lebenstage auf (der Lebenst
 
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
-#, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+#, fuzzy, no-wrap
+#| msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr "Die Pneumonie trat innerhalb der ersten zwei Tage des Krankenhausaufenthalts eines überwiesenen oder (wieder-)aufgenommenen Patienten auf (der Tag des Krankenhausaufenthalts ist %i). Siehe @sec-problem-details-20."
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
-#, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+#, fuzzy, no-wrap
+#| msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr "Der im Nekrotisierende Enterokolitis-Formular gespeicherte Lebenstag (%i) stimmt nicht mit dem berechneten Wert (%i) überein. Siehe @sec-problem-details-17."
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
-#, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+#, fuzzy, no-wrap
+#| msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr "Der im Nekrotisierende Enterokolitis-Formular gespeicherte Tag des Auftretens nach Aufnahme (%i) stimmt nicht mit dem berechneten Wert (%i) überein. Siehe @sec-problem-details-18."
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
-#, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+#, fuzzy, no-wrap
+#| msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr "Die Nekrotisierende Enterokolitis trat innerhalb der ersten drei Lebenstage auf (der Lebenstag ist %i). Siehe @sec-problem-details-19."
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
-#, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+#, fuzzy, no-wrap
+#| msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr "Die Nekrotisierende Enterokolitis trat innerhalb der ersten zwei Tage des Krankenhausaufenthalts eines überwiesenen oder (wieder-)aufgenommenen Patienten auf (der Tag des Krankenhausaufenthalts ist %i). Siehe @sec-problem-details-20."
 
 #. type: Hash Value: problems 39 description
@@ -3807,12 +3807,20 @@ msgstr "Chirurgischer-Eingriff-Ereignis mit dem Eingriffsdatum"
 
 #. type: Plain text
 #: reports/Validation-Report/en/_problems_intro.Rmd:8
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
+#| "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
+#| "Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
+#| "At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+#| "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
+#| "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
+#| "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3866,9 +3874,7 @@ msgstr ""
 #: reports/Validation-Report/en/_solution_0015.Rmd:2
 #, no-wrap
 msgid "\\newpage\n"
-msgstr ""
-"\\n"
-"ewpage\n"
+msgstr "\\newpage\n"
 
 #. type: Title ##
 #: reports/Validation-Report/en/_problems_intro.Rmd:24
@@ -3924,11 +3930,15 @@ msgstr "Dieses Problem taucht typischerweise auf, wenn jemand die eingegebenen D
 
 #. type: Plain text
 #: reports/Validation-Report/en/_problem_detail_0001.Rmd:8
-#, no-wrap
+#, fuzzy, no-wrap
+#| msgid ""
+#| "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
+#| "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
+#| "However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 "Übrig bleibt dann eine Patientenakte ohne Patientenregistrierung, die im System wie eine Datenwaise existiert.\n"
 "Diese Patientenakten werden nicht in der Liste der registrierten Patienten angezeigt und ihre Daten können auch nicht in Auswertungen aufgeführt werden, da ihnen die meisten für die Analyse erforderlichen Informationen fehlen.\n"
@@ -4556,8 +4566,9 @@ msgstr "Bitte löschen Sie die Formulare für alle Infektionen, die keine nosoko
 
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
-#, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+#, fuzzy, no-wrap
+#| msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr "Die Infektion trat innerhalb der ersten zwei Tage des Krankenhausaufenthalts eines überwiesenen oder (wieder-)aufgenommenen Patienten auf {#sec-problem-details-20}"
 
 #. type: Plain text
@@ -5087,6 +5098,18 @@ msgstr ""
 #, no-wrap
 msgid "![The Next and Previous buttons in the event timeline of the Tracked Entity Instance Dashboard](img/fig-event-timeline-full.png){#fig-event-timeline-full fig-alt=\"A screenshot of the Tracked Entity Instance Dashboard with the Next and Previous buttons in the event timeline highlighted\"}\n"
 msgstr "![Die Schaltflächen \"Next\" und \"Previous\" in der Ereignis-Zeitleiste des Tracked Entity Instance Dashboards](img/fig-event-timeline-full.png){#fig-event-timeline-full fig-alt=\"Ein Screenshot des Tracked Entity Instance Dashboards, in dem die Schaltflächen \\\"Next\\\" und \\\"Previous\\\" in der Ereignis-Zeitleiste hervorgehoben sind\"}\n"
+
+#, no-wrap
+#~ msgid "Access"
+#~ msgstr "Access"
+
+#, no-wrap
+#~ msgid "Reserve"
+#~ msgstr "Reserve"
+
+#, no-wrap
+#~ msgid "Watch"
+#~ msgstr "Watch"
 
 #, no-wrap
 #~ msgid "The following summary presents key surveillance metrics for this report:\n"

--- a/po/reports.el.po
+++ b/po/reports.el.po
@@ -5,6 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
 "PO-Revision-Date: 2026-07-29 17:28+0000\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/neoipc/neoipc-reports/el/>\n"
 "Language: el\n"
@@ -283,10 +284,10 @@ msgstr ""
 msgid "Sum of patient days"
 msgstr ""
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr ""
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -385,10 +386,10 @@ msgstr ""
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr ""
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr ""
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -610,7 +611,7 @@ msgstr ""
 #. type: Hash Value: tbl-abr-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -670,7 +671,7 @@ msgstr ""
 #. type: Hash Value: tbl-agent-per-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -709,58 +710,58 @@ msgstr ""
 msgid "Infectious agents detected in nosocomial infections"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic Exposure Density Rate"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Substance-days"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -820,7 +821,7 @@ msgstr ""
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No device-associated infection data available for this report settings."
+msgid "No device-associated infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
@@ -880,7 +881,7 @@ msgstr ""
 #. type: Hash Value: tbl-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -916,7 +917,7 @@ msgstr ""
 #. type: Hash Value: tbl-infectious-agent-detection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -964,7 +965,7 @@ msgstr ""
 #. type: Hash Value: tbl-organism-resistance-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1024,7 +1025,7 @@ msgstr ""
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
+msgid "No antibiotic resistance diagnostics data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
@@ -1061,12 +1062,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates any
@@ -1108,7 +1103,7 @@ msgstr ""
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No risk/protective factor data available for this report settings."
+msgid "No risk/protective factor data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
@@ -1121,12 +1116,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
@@ -1147,12 +1136,6 @@ msgstr ""
 msgid "Ventilatory support"
 msgstr ""
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr ""
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, no-wrap
@@ -1162,7 +1145,7 @@ msgstr ""
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No secondary BSI data available for this report settings."
+msgid "No secondary BSI data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
@@ -1303,10 +1286,10 @@ msgstr ""
 msgid "Surgical procedures by category"
 msgstr ""
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr ""
 
 #. type: Hash Value: total
@@ -1522,7 +1505,7 @@ msgstr ""
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr ""
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1936,13 +1919,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2206,13 +2189,13 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2230,7 +2213,7 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec metric_label
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2491,13 +2474,13 @@ msgstr ""
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated for your department's infants."
@@ -2638,7 +2621,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, no-wrap
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2720,9 +2703,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2738,10 +2721,10 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
+msgid "`r sR$methods$antibiotic_utilization`\n"
 msgstr ""
 
 #. type: Plain text
@@ -3230,7 +3213,7 @@ msgstr ""
 msgid "Presence of Risk and Protective Factors"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in all infants."
@@ -3269,7 +3252,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, no-wrap
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr ""
 
 #. type: Plain text
@@ -3573,7 +3556,7 @@ msgstr ""
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 31 description
@@ -3597,31 +3580,31 @@ msgstr ""
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr ""
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr ""
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr ""
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 39 description
@@ -3720,8 +3703,8 @@ msgstr ""
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3818,7 +3801,7 @@ msgstr ""
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 
 #. type: Plain text
@@ -4377,7 +4360,7 @@ msgstr ""
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
 #, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr ""
 
 #. type: Plain text

--- a/po/reports.es.po
+++ b/po/reports.es.po
@@ -6,6 +6,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
 "PO-Revision-Date: 2026-07-29 17:27+0000\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/neoipc/neoipc-reports/es/>\n"
 "Language: es\n"
@@ -284,10 +285,11 @@ msgstr "Este es un análisis especial que"
 msgid "Sum of patient days"
 msgstr "Suma de días de hospitalización"
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
-#, no-wrap
-msgid "Antibiotic Utilisation"
+#, fuzzy, no-wrap
+#| msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr "Utilización de antibióticos"
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -386,10 +388,10 @@ msgstr "Procedimientos quirúrgicos por categoría"
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr "La tasa de agentes por infección mide la frecuencia con la que se detectan patógenos específicos en relación con el número de infecciones en las que se identificó algún agente infeccioso. Es normal que los valores superen el 100 % e indican infecciones polimicrobianas. Las dificultades diagnósticas específicas de los recién nacidos —entre ellas, el bajo volumen sanguíneo, que reduce la sensibilidad de los cultivos, y el elevado riesgo de contaminación— pueden influir en los patrones de detección."
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr "El uso de antibióticos se registra por sustancia individual, agrupadas por subgrupo farmacológico de la clasificación ATC. La tasa de densidad de exposición mide los días-sustancia por cada 100 días-paciente. Los días de tratamiento con antibióticos se cuentan desde la primera dosis hasta la última dosis de un tratamiento, ambas incluidas. Cada sustancia se cuenta por separado; un paciente que reciba dos antibióticos el mismo día contribuye con un día al recuento de cada sustancia. Debido a los tratamientos combinados, la suma de las tasas de cada sustancia puede superar la tasa total de exposición a antibióticos que figura en la tabla de factores de riesgo y de protección."
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -612,7 +614,7 @@ msgstr "%s: Número total de patógenos resistentes a los antibióticos en todas
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The resistant pathogen infection rate calculated across all infants from all departments."
-msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr "No hay datos disponibles sobre infecciones por patógenos resistentes en los entornos objeto de este informe."
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -672,8 +674,9 @@ msgstr "%s: Número total de agentes infecciosos en todas las infecciones."
 
 #. type: Hash Value: tbl-agent-per-infection-rate no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No infectious agent data available for this report settings."
+#, fuzzy, no-wrap
+#| msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr "No hay datos disponibles sobre agentes infecciosos para los ajustes de este informe."
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -713,63 +716,63 @@ msgstr "Número de agentes infecciosos detectados en infecciones"
 msgid "Infectious agents detected in nosocomial infections"
 msgstr "Agentes infecciosos detectados en infecciones nosocomiales"
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr "ATC: Clasificación Anatómica, Terapéutica y Química (OMS). Las sustancias se agrupan por subgrupos farmacológicos (5.º nivel ATC). Para más detalles, véase %s."
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr "Clasificación AWaRe de la OMS (Acceso, Vigilancia, Reserva). Véase %s."
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Risk Density Rate"
 msgid "Antibiotic Exposure Density Rate"
 msgstr "Tasa de densidad de riesgo"
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number of device-associated infections in all infants."
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr "%s: Número agregado de infecciones asociadas a dispositivos en todos los lactantes."
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr "No se dispone de datos sobre el uso de antibióticos para los entornos objeto de este informe."
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The Risk Density Rate calculated across all infants from all departments in the reference data."
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr "%s: La tasa de densidad de riesgo calculada para todos los bebés de todos los departamentos en los datos de referencia."
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Risk Density Rates of the departments in the reference data. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Risk Density Rate."
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr "%s, %s, %s: Los cuartiles (%s, %s y %s cuantiles) de las tasas de densidad de riesgo de los departamentos en los datos de referencia. Estos cuartiles solo se muestran cuando el número de departamentos que contribuyen al denominador es mayor o igual a cinco, y cuando el número medio de días de dispositivo es mayor o igual a uno según la tasa de densidad de riesgo agrupada."
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 msgid "Substance-days"
 msgstr "Días de substancia"
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr "Uso de antibióticos por subgrupo farmacológico y sustancia"
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -832,7 +835,7 @@ msgstr "Neumonía asociada al soporte ventilatorio"
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
-msgid "No device-associated infection data available for this report settings."
+msgid "No device-associated infection data available for these report settings."
 msgstr "No hay datos disponibles sobre infecciones asociadas a dispositivos para los parámetros de este informe."
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
@@ -896,7 +899,7 @@ msgstr "Número de infecciones"
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr "No hay datos sobre infecciones disponibles para los parámetros de este informe."
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -935,7 +938,7 @@ msgstr "%s: Número agregado de infecciones en las que se registró al menos un 
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr "No hay datos disponibles sobre la detección de agentes infecciosos para los entornos de este informe."
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -986,7 +989,7 @@ msgstr "%s: Número total de infecciones en todos los bebés."
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr "No se dispone de datos sobre la resistencia específica de ningún organismo para los parámetros de este informe."
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1051,7 +1054,7 @@ msgstr "%s: El número agregado de patógenos resistentes a los antibióticos qu
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
+msgid "No antibiotic resistance diagnostics data available for these report settings."
 msgstr "No hay datos de diagnóstico sobre la resistencia a los antibióticos disponibles para los parámetros de este informe."
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
@@ -1090,12 +1093,6 @@ msgstr "Número de patógenos con pruebas registradas de resistencia a los antib
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
 msgstr "Diagnóstico de la resistencia a los antibióticos"
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
-msgstr "Acceso"
 
 #. type: Hash Value: tbl-risk-density-rates any
 #: reports/common.yaml:1
@@ -1137,7 +1134,7 @@ msgstr "Se registra un día de «cuidado canguro» cuando el paciente ha recibid
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
-msgid "No risk/protective factor data available for this report settings."
+msgid "No risk/protective factor data available for these report settings."
 msgstr "No hay datos disponibles sobre factores de riesgo o de protección para los entornos objeto de este informe."
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
@@ -1153,12 +1150,6 @@ msgstr "%s: La tasa de densidad de riesgo calculada para todos los bebés de tod
 #| msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Risk Density Rates of the departments in the reference data. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Risk Density Rate."
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
 msgstr "%s, %s, %s: Los cuartiles (%s, %s y %s cuantiles) de las tasas de densidad de riesgo de los departamentos en los datos de referencia. Estos cuartiles solo se muestran cuando el número de departamentos que contribuyen al denominador es mayor o igual a cinco, y cuando el número medio de días de dispositivo es mayor o igual a uno según la tasa de densidad de riesgo agrupada."
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
-msgstr "Reserva"
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
 #: reports/common.yaml:1
@@ -1179,12 +1170,6 @@ msgstr "Catéter vascular"
 msgid "Ventilatory support"
 msgstr "Asistencia respiratoria"
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr "Ver"
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
@@ -1195,7 +1180,7 @@ msgstr "%s: Número agregado de infecciones en las que se registró al menos un 
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
-msgid "No secondary BSI data available for this report settings."
+msgid "No secondary BSI data available for these report settings."
 msgstr "No hay datos secundarios de BSI disponibles para los parámetros de este informe."
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
@@ -1342,10 +1327,11 @@ msgstr "Número de procedimientos"
 msgid "Surgical procedures by category"
 msgstr "Procedimientos quirúrgicos por categoría"
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
-#, no-wrap
-msgid "Not yet categorised"
+#, fuzzy, no-wrap
+#| msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr "Aún sin clasificar"
 
 #. type: Hash Value: total
@@ -1565,7 +1551,7 @@ msgstr "La resistencia elevada a la colistina (COLR) constituye un motivo de gra
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr "Las tasas elevadas de Staphylococcus aureus resistente a la meticilina (SARM) podrían justificar una revisión de las prácticas de cribado, descolonización y aislamiento de contactos."
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1979,13 +1965,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2258,13 +2244,13 @@ msgstr "Neumonía asociada al soporte ventilatorio"
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2283,7 +2269,7 @@ msgstr ""
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Necrotising Enterocolitis"
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr "Enterocolitis necrotizante"
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2554,14 +2540,14 @@ msgstr "%s: El número total de días en que el factor de riesgo/protección est
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr "%s: El porcentaje de infecciones en tu departamento en las que se detectó este agente infeccioso."
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number surgical procedures performed in all infants."
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr "%s: Número total de procedimientos quirúrgicos realizados en todos los bebés."
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The Risk Density Rate calculated for your unit's infants."
@@ -2719,7 +2705,7 @@ msgstr "La epidemiología de los agentes infecciosos que causan infecciones noso
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, fuzzy, no-wrap
 #| msgid "In total, `r dR$numberOfInfectiousAgents` infectious agents were detected in the `r dR$numberOfInfectionsWithAgent` infections that were reported to have yielded at least one agent from either the primary infection and/or the secondary bloodstream infection resulting from it (@tbl-agent-per-infection-rate). These `r dR$numberOfInfectionsWithAgent` diagnostic-positive infections out of `r dR$overallNumberOfInfections` overall infections represent an Infectious Agent Detection Rate of `r dR$infectiousAgentDetectionRate` per 100 infections (@tbl-infectious-agent-detection-rate).\n"
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr "En total, se detectaron `r dR$numberOfInfectiousAgents` agentes infecciosos en las `r dR$numberOfInfectionsWithAgent` infecciones que, según se informó, habían producido al menos un agente, ya fuera de la infección primaria o de la infección secundaria del torrente sanguíneo resultante de ella (@tbl-agent-per-infection-rate). Estas `r dR$numberOfInfectionsWithAgent` infecciones con diagnóstico positivo de un total de `r dR$overallNumberOfInfections` infecciones representan una tasa de detección de agentes infecciosos del `r dR$infectiousAgentDetectionRate` por cada 100 infecciones (@tbl-infectious-agent-detection-rate).\n"
 
 #. type: Plain text
@@ -2801,9 +2787,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2819,11 +2805,12 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
-msgstr ""
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
+#, fuzzy, no-wrap
+#| msgid "Antibiotic Utilisation"
+msgid "`r sR$methods$antibiotic_utilization`\n"
+msgstr "Utilización de antibióticos"
 
 #. type: Plain text
 #: reports/Partner-Report/content/_tbl-intro-secondary-bsi.Rmd:1
@@ -3329,7 +3316,7 @@ msgstr "Este informe presenta datos de unidades neonatales de un solo país. Est
 msgid "Presence of Risk and Protective Factors"
 msgstr "Factores de riesgo y de protección"
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number of infections in all infants."
@@ -3371,7 +3358,7 @@ msgstr "Dado que el proceso, aunque cuenta con el apoyo de diversas herramientas
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, fuzzy, no-wrap
 #| msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In @tbl-incidence-density-rates, the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr "Las infecciones nosocomiales representan el criterio de valoración principal de la vigilancia del NeoIPC. En @tbl-incidence-density-rates se muestran las densidades de incidencia de sepsis/BSI, neumonía y enterocolitis necrotizante, así como el criterio de valoración combinado «infección grave». En total, se registraron `r dR$numberOfSevereInfections` infecciones graves en `r dR$numberOfPatients` lactantes, lo que supone una media de `r dR$averageSevereInfectionsPerPatient` infecciones por paciente.\n"
 
 #. type: Plain text
@@ -3687,7 +3674,7 @@ msgstr ""
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 31 description
@@ -3711,31 +3698,31 @@ msgstr ""
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr ""
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr ""
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr ""
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 39 description
@@ -3838,8 +3825,8 @@ msgstr "Tasa de procedimientos quirúrgicos"
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3936,7 +3923,7 @@ msgstr ""
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 
 #. type: Plain text
@@ -4497,7 +4484,7 @@ msgstr ""
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
 #, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr ""
 
 #. type: Plain text
@@ -4967,6 +4954,18 @@ msgstr ""
 #, no-wrap
 msgid "![The Next and Previous buttons in the event timeline of the Tracked Entity Instance Dashboard](img/fig-event-timeline-full.png){#fig-event-timeline-full fig-alt=\"A screenshot of the Tracked Entity Instance Dashboard with the Next and Previous buttons in the event timeline highlighted\"}\n"
 msgstr ""
+
+#, no-wrap
+#~ msgid "Access"
+#~ msgstr "Acceso"
+
+#, no-wrap
+#~ msgid "Reserve"
+#~ msgstr "Reserva"
+
+#, no-wrap
+#~ msgid "Watch"
+#~ msgstr "Ver"
 
 #, no-wrap
 #~ msgid "Device-associated infections can be found in @tbl-device-associated-incidence-density-rates.\n"

--- a/po/reports.et.po
+++ b/po/reports.et.po
@@ -5,6 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
 "PO-Revision-Date: 2026-07-29 17:28+0000\n"
 "Language-Team: Estonian <https://hosted.weblate.org/projects/neoipc/neoipc-reports/et/>\n"
 "Language: et\n"
@@ -283,10 +284,10 @@ msgstr ""
 msgid "Sum of patient days"
 msgstr ""
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr ""
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -385,10 +386,10 @@ msgstr ""
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr ""
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr ""
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -610,7 +611,7 @@ msgstr ""
 #. type: Hash Value: tbl-abr-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -670,7 +671,7 @@ msgstr ""
 #. type: Hash Value: tbl-agent-per-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -709,58 +710,58 @@ msgstr ""
 msgid "Infectious agents detected in nosocomial infections"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic Exposure Density Rate"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Substance-days"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -820,7 +821,7 @@ msgstr ""
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No device-associated infection data available for this report settings."
+msgid "No device-associated infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
@@ -880,7 +881,7 @@ msgstr ""
 #. type: Hash Value: tbl-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -916,7 +917,7 @@ msgstr ""
 #. type: Hash Value: tbl-infectious-agent-detection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -964,7 +965,7 @@ msgstr ""
 #. type: Hash Value: tbl-organism-resistance-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1024,7 +1025,7 @@ msgstr ""
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
+msgid "No antibiotic resistance diagnostics data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
@@ -1061,12 +1062,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates any
@@ -1108,7 +1103,7 @@ msgstr ""
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No risk/protective factor data available for this report settings."
+msgid "No risk/protective factor data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
@@ -1121,12 +1116,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
@@ -1147,12 +1136,6 @@ msgstr ""
 msgid "Ventilatory support"
 msgstr ""
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr ""
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, no-wrap
@@ -1162,7 +1145,7 @@ msgstr ""
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No secondary BSI data available for this report settings."
+msgid "No secondary BSI data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
@@ -1303,10 +1286,10 @@ msgstr ""
 msgid "Surgical procedures by category"
 msgstr ""
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr ""
 
 #. type: Hash Value: total
@@ -1522,7 +1505,7 @@ msgstr ""
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr ""
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1936,13 +1919,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2206,13 +2189,13 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2230,7 +2213,7 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec metric_label
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2491,13 +2474,13 @@ msgstr ""
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated for your department's infants."
@@ -2638,7 +2621,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, no-wrap
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2720,9 +2703,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2738,10 +2721,10 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
+msgid "`r sR$methods$antibiotic_utilization`\n"
 msgstr ""
 
 #. type: Plain text
@@ -3230,7 +3213,7 @@ msgstr ""
 msgid "Presence of Risk and Protective Factors"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in all infants."
@@ -3269,7 +3252,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, no-wrap
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr ""
 
 #. type: Plain text
@@ -3573,7 +3556,7 @@ msgstr ""
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 31 description
@@ -3597,31 +3580,31 @@ msgstr ""
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr ""
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr ""
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr ""
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 39 description
@@ -3720,8 +3703,8 @@ msgstr ""
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3818,7 +3801,7 @@ msgstr ""
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 
 #. type: Plain text
@@ -4377,7 +4360,7 @@ msgstr ""
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
 #, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr ""
 
 #. type: Plain text

--- a/po/reports.fr.po
+++ b/po/reports.fr.po
@@ -5,6 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
 "PO-Revision-Date: 2026-07-29 17:28+0000\n"
 "Language-Team: French <https://hosted.weblate.org/projects/neoipc/neoipc-reports/fr/>\n"
 "Language: fr\n"
@@ -283,10 +284,10 @@ msgstr ""
 msgid "Sum of patient days"
 msgstr ""
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr ""
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -385,10 +386,10 @@ msgstr ""
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr ""
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr ""
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -610,7 +611,7 @@ msgstr ""
 #. type: Hash Value: tbl-abr-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -670,7 +671,7 @@ msgstr ""
 #. type: Hash Value: tbl-agent-per-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -709,58 +710,58 @@ msgstr ""
 msgid "Infectious agents detected in nosocomial infections"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic Exposure Density Rate"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Substance-days"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -820,7 +821,7 @@ msgstr ""
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No device-associated infection data available for this report settings."
+msgid "No device-associated infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
@@ -880,7 +881,7 @@ msgstr ""
 #. type: Hash Value: tbl-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -916,7 +917,7 @@ msgstr ""
 #. type: Hash Value: tbl-infectious-agent-detection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -964,7 +965,7 @@ msgstr ""
 #. type: Hash Value: tbl-organism-resistance-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1024,7 +1025,7 @@ msgstr ""
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
+msgid "No antibiotic resistance diagnostics data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
@@ -1061,12 +1062,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates any
@@ -1108,7 +1103,7 @@ msgstr ""
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No risk/protective factor data available for this report settings."
+msgid "No risk/protective factor data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
@@ -1121,12 +1116,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
@@ -1147,12 +1136,6 @@ msgstr ""
 msgid "Ventilatory support"
 msgstr ""
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr ""
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, no-wrap
@@ -1162,7 +1145,7 @@ msgstr ""
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No secondary BSI data available for this report settings."
+msgid "No secondary BSI data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
@@ -1303,10 +1286,10 @@ msgstr ""
 msgid "Surgical procedures by category"
 msgstr ""
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr ""
 
 #. type: Hash Value: total
@@ -1522,7 +1505,7 @@ msgstr ""
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr ""
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1936,13 +1919,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2206,13 +2189,13 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2230,7 +2213,7 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec metric_label
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2491,13 +2474,13 @@ msgstr ""
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated for your department's infants."
@@ -2638,7 +2621,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, no-wrap
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2720,9 +2703,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2738,10 +2721,10 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
+msgid "`r sR$methods$antibiotic_utilization`\n"
 msgstr ""
 
 #. type: Plain text
@@ -3230,7 +3213,7 @@ msgstr ""
 msgid "Presence of Risk and Protective Factors"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in all infants."
@@ -3269,7 +3252,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, no-wrap
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr ""
 
 #. type: Plain text
@@ -3573,7 +3556,7 @@ msgstr ""
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 31 description
@@ -3597,31 +3580,31 @@ msgstr ""
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr ""
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr ""
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr ""
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 39 description
@@ -3720,8 +3703,8 @@ msgstr ""
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3818,7 +3801,7 @@ msgstr ""
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 
 #. type: Plain text
@@ -4377,7 +4360,7 @@ msgstr ""
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
 #, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr ""
 
 #. type: Plain text

--- a/po/reports.it.po
+++ b/po/reports.it.po
@@ -5,6 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
 "PO-Revision-Date: 2026-07-29 17:27+0000\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/neoipc/neoipc-reports/it/>\n"
 "Language: it\n"
@@ -290,11 +291,11 @@ msgstr "Questa è un'analisi speciale che"
 msgid "Sum of patient days"
 msgstr "Somma dei giorni di degenza:\n"
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Antibiotics"
-msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr "Antibiotici"
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -399,10 +400,10 @@ msgstr "Procedure chirurgiche per categoria"
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr ""
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr ""
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -626,7 +627,7 @@ msgstr "%s: Numero complessivo di agenti patogeni resistenti agli antibiotici in
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The resistant pathogen infection rate calculated across all infants from all departments."
-msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr "%s: tasso di infezione da agenti patogeni resistenti calcolato su tutti i neonati di tutti i reparti."
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -688,7 +689,7 @@ msgstr "%s: Numero complessivo di agenti infettivi in tutte le infezioni."
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr "Numero di infezioni con agente"
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -728,63 +729,63 @@ msgstr "Numero di agenti infettivi rilevati nelle infezioni"
 msgid "Infectious agents detected in nosocomial infections"
 msgstr "Agenti infettivi rilevati nelle infezioni nosocomiali"
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Risk Density Rate"
 msgid "Antibiotic Exposure Density Rate"
 msgstr "Tasso di densità di rischio"
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number of device-associated infections in all infants."
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr "%s: Numero complessivo di infezioni associate al dispositivo in tutti i neonati."
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr "Numero di infezioni con agente"
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The Risk Density Rate calculated across all infants from all departments in the reference data."
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr "%s: tasso di densità di rischio calcolato su tutti i neonati di tutti i reparti nei dati di riferimento."
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Risk Density Rates of the departments in the reference data. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Risk Density Rate."
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr "%s, %s, %s: I quartili (quantili %s, %s e %s) dei tassi di densità di rischio dei reparti nei dati di riferimento. Questi quartili vengono visualizzati solo quando il numero di reparti che contribuiscono al denominatore è maggiore o uguale a cinque e quando il numero mediano di giorni di utilizzo del dispositivo è maggiore o uguale a uno secondo il tasso di densità di rischio aggregato."
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Substance-days"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -846,9 +847,10 @@ msgstr "Polmonite associata a supporto ventilatorio"
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No device-associated infection data available for this report settings."
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "No of infections with agent"
+msgid "No device-associated infection data available for these report settings."
+msgstr "Numero di infezioni con agente"
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
 #: reports/common.yaml:1
@@ -911,7 +913,7 @@ msgstr "Numero di infezioni"
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr "Numero di infezioni con agente"
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -950,7 +952,7 @@ msgstr "%s: Numero complessivo di infezioni in cui è stato registrato almeno un
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr "Numero di infezioni con agente"
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -1001,7 +1003,7 @@ msgstr "%s: Numero complessivo di infezioni in tutti i neonati."
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
 #| msgid "No of infections with agent"
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr "Numero di infezioni con agente"
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1065,9 +1067,10 @@ msgstr "%s: Numero complessivo di agenti patogeni resistenti agli antibiotici co
 
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "No of infections with agent"
+msgid "No antibiotic resistance diagnostics data available for these report settings."
+msgstr "Numero di infezioni con agente"
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
 #: reports/common.yaml:1
@@ -1105,12 +1108,6 @@ msgstr "Numero di agenti patogeni con test di resistenza agli antibiotici regist
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
 msgstr "Diagnostica della resistenza agli antibiotici"
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
-msgstr "Accesso"
 
 #. type: Hash Value: tbl-risk-density-rates any
 #: reports/common.yaml:1
@@ -1151,9 +1148,10 @@ msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No risk/protective factor data available for this report settings."
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "No of infections with agent"
+msgid "No risk/protective factor data available for these report settings."
+msgstr "Numero di infezioni con agente"
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
 #: reports/common.yaml:1
@@ -1168,12 +1166,6 @@ msgstr "%s: tasso di densità di rischio calcolato su tutti i neonati di tutti i
 #| msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Risk Density Rates of the departments in the reference data. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Risk Density Rate."
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
 msgstr "%s, %s, %s: I quartili (quantili %s, %s e %s) dei tassi di densità di rischio dei reparti nei dati di riferimento. Questi quartili vengono visualizzati solo quando il numero di reparti che contribuiscono al denominatore è maggiore o uguale a cinque e quando il numero mediano di giorni di utilizzo del dispositivo è maggiore o uguale a uno secondo il tasso di densità di rischio aggregato."
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
-msgstr "Riserva"
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
 #: reports/common.yaml:1
@@ -1194,12 +1186,6 @@ msgstr "Catetere vascolare"
 msgid "Ventilatory support"
 msgstr "Supporto ventilatorio"
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr "Sorveglianza"
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, fuzzy, no-wrap
@@ -1209,9 +1195,10 @@ msgstr "%s: Numero complessivo di infezioni in cui è stato registrato almeno un
 
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
-#, no-wrap
-msgid "No secondary BSI data available for this report settings."
-msgstr ""
+#, fuzzy, no-wrap
+#| msgid "No of infections with agent"
+msgid "No secondary BSI data available for these report settings."
+msgstr "Numero di infezioni con agente"
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
 #: reports/common.yaml:1
@@ -1357,10 +1344,11 @@ msgstr "Numero di procedure"
 msgid "Surgical procedures by category"
 msgstr "Procedure chirurgiche per categoria"
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
-#, no-wrap
-msgid "Not yet categorised"
+#, fuzzy, no-wrap
+#| msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr "Non ancora categorizzato"
 
 #. type: Hash Value: total
@@ -1580,7 +1568,7 @@ msgstr ""
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr ""
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1994,13 +1982,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2273,13 +2261,13 @@ msgstr "Polmonite associata a supporto ventilatorio"
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2298,7 +2286,7 @@ msgstr ""
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "Necrotising Enterocolitis"
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr "Enterocolite necrotizzante"
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2569,14 +2557,14 @@ msgstr "%s: Numero complessivo di giorni in cui il fattore di rischio/protezione
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr "Numero di infezioni in cui è stato rilevato un agente infettivo"
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number surgical procedures performed in all infants."
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr "%s: numero complessivo di interventi chirurgici eseguiti su tutti i neonati."
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The Risk Density Rate calculated for your department's infants.\n"
@@ -2733,7 +2721,7 @@ msgstr "L'epidemiologia degli agenti infettivi che causano infezioni nosocomiali
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, fuzzy, no-wrap
 #| msgid "In total, `r dR$numberOfInfectiousAgents` infectious agents were detected in the `r dR$numberOfInfectionsWithAgent` infections that were reported to have yielded at least one agent from either the primary infection and/or the secondary bloodstream infection resulting from it (@tbl-agent-per-infection-rate). These `r dR$numberOfInfectionsWithAgent` diagnostic-positive infections out of `r dR$overallNumberOfInfections` overall infections represent an Infectious Agent Detection Rate of `r dR$infectiousAgentDetectionRate` per 100 infections (@tbl-infectious-agent-detection-rate).\n"
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr "In totale, sono stati rilevati `r dR$numberOfInfectiousAgents` agenti infettivi nelle `r dR$numberOfInfectionsWithAgent` infezioni che sono state segnalate come aventi prodotto almeno un agente dall'infezione primaria e/o dall'infezione secondaria del flusso sanguigno da essa derivante (@tbl-agent-per-infection-rate). Queste `r dR$numberOfInfectionsWithAgent` infezioni diagnosticate positive su un totale di `r dR$overallNumberOfInfections` infezioni rappresentano un tasso di rilevamento degli agenti infettivi pari al `r dR$infectiousAgentDetectionRate` per 100 infezioni (@tbl-infectious-agent-detection-rate).\n"
 
 #. type: Plain text
@@ -2815,9 +2803,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2833,11 +2821,12 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
-msgstr ""
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
+#, fuzzy, no-wrap
+#| msgid "Antibiotics"
+msgid "`r sR$methods$antibiotic_utilization`\n"
+msgstr "Antibiotici"
 
 #. type: Plain text
 #: reports/Partner-Report/content/_tbl-intro-secondary-bsi.Rmd:1
@@ -3345,7 +3334,7 @@ msgstr "Il presente rapporto presenta dati provenienti da unità neonatali di un
 msgid "Presence of Risk and Protective Factors"
 msgstr "Fattori di rischio e di protezione"
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, fuzzy, no-wrap
 #| msgid "%s: The aggregated number of infections in all infants."
@@ -3387,7 +3376,7 @@ msgstr "Poiché il processo, sebbene supportato da vari strumenti, si basa sulla
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, fuzzy, no-wrap
 #| msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In @tbl-incidence-density-rates, the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr "Le infezioni nosocomiali rappresentano l'endpoint primario della sorveglianza NeoIPC. Nella @tbl-incidence-density-rates sono riportate le densità di incidenza di sepsi/BSI, polmonite e enterocolite necrotizzante, nonché l'endpoint combinato \"infezione grave\". Complessivamente sono state registrate `r dR$numberOfSevereInfections` infezioni gravi in `r dR$numberOfPatients` neonati, con un numero medio di `r dR$averageSevereInfectionsPerPatient` infezioni per paziente.\n"
 
 #. type: Plain text
@@ -3703,7 +3692,7 @@ msgstr ""
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 31 description
@@ -3727,31 +3716,31 @@ msgstr ""
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr ""
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr ""
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr ""
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 39 description
@@ -3854,8 +3843,8 @@ msgstr "Tasso di procedure chirurgiche"
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3952,7 +3941,7 @@ msgstr ""
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 
 #. type: Plain text
@@ -4513,7 +4502,7 @@ msgstr ""
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
 #, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr ""
 
 #. type: Plain text
@@ -4983,6 +4972,18 @@ msgstr ""
 #, no-wrap
 msgid "![The Next and Previous buttons in the event timeline of the Tracked Entity Instance Dashboard](img/fig-event-timeline-full.png){#fig-event-timeline-full fig-alt=\"A screenshot of the Tracked Entity Instance Dashboard with the Next and Previous buttons in the event timeline highlighted\"}\n"
 msgstr ""
+
+#, no-wrap
+#~ msgid "Access"
+#~ msgstr "Accesso"
+
+#, no-wrap
+#~ msgid "Reserve"
+#~ msgstr "Riserva"
+
+#, no-wrap
+#~ msgid "Watch"
+#~ msgstr "Sorveglianza"
 
 #, no-wrap
 #~ msgid "Device-associated infections can be found in @tbl-device-associated-incidence-density-rates.\n"

--- a/po/reports.ne.po
+++ b/po/reports.ne.po
@@ -5,6 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
 "PO-Revision-Date: 2026-07-29 17:28+0000\n"
 "Language-Team: Nepali <https://hosted.weblate.org/projects/neoipc/neoipc-reports/ne/>\n"
 "Language: ne\n"
@@ -283,10 +284,10 @@ msgstr ""
 msgid "Sum of patient days"
 msgstr ""
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr ""
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -385,10 +386,10 @@ msgstr ""
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr ""
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr ""
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -610,7 +611,7 @@ msgstr ""
 #. type: Hash Value: tbl-abr-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -670,7 +671,7 @@ msgstr ""
 #. type: Hash Value: tbl-agent-per-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -709,58 +710,58 @@ msgstr ""
 msgid "Infectious agents detected in nosocomial infections"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic Exposure Density Rate"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Substance-days"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -820,7 +821,7 @@ msgstr ""
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No device-associated infection data available for this report settings."
+msgid "No device-associated infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
@@ -880,7 +881,7 @@ msgstr ""
 #. type: Hash Value: tbl-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -916,7 +917,7 @@ msgstr ""
 #. type: Hash Value: tbl-infectious-agent-detection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -964,7 +965,7 @@ msgstr ""
 #. type: Hash Value: tbl-organism-resistance-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1024,7 +1025,7 @@ msgstr ""
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
+msgid "No antibiotic resistance diagnostics data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
@@ -1061,12 +1062,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates any
@@ -1108,7 +1103,7 @@ msgstr ""
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No risk/protective factor data available for this report settings."
+msgid "No risk/protective factor data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
@@ -1121,12 +1116,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
@@ -1147,12 +1136,6 @@ msgstr ""
 msgid "Ventilatory support"
 msgstr ""
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr ""
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, no-wrap
@@ -1162,7 +1145,7 @@ msgstr ""
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No secondary BSI data available for this report settings."
+msgid "No secondary BSI data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
@@ -1303,10 +1286,10 @@ msgstr ""
 msgid "Surgical procedures by category"
 msgstr ""
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr ""
 
 #. type: Hash Value: total
@@ -1522,7 +1505,7 @@ msgstr ""
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr ""
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1936,13 +1919,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2206,13 +2189,13 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2230,7 +2213,7 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec metric_label
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2491,13 +2474,13 @@ msgstr ""
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated for your department's infants."
@@ -2638,7 +2621,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, no-wrap
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2720,9 +2703,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2738,10 +2721,10 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
+msgid "`r sR$methods$antibiotic_utilization`\n"
 msgstr ""
 
 #. type: Plain text
@@ -3230,7 +3213,7 @@ msgstr ""
 msgid "Presence of Risk and Protective Factors"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in all infants."
@@ -3269,7 +3252,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, no-wrap
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr ""
 
 #. type: Plain text
@@ -3573,7 +3556,7 @@ msgstr ""
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 31 description
@@ -3597,31 +3580,31 @@ msgstr ""
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr ""
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr ""
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr ""
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 39 description
@@ -3720,8 +3703,8 @@ msgstr ""
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3818,7 +3801,7 @@ msgstr ""
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 
 #. type: Plain text
@@ -4377,7 +4360,7 @@ msgstr ""
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
 #, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr ""
 
 #. type: Plain text

--- a/po/reports.tr.po
+++ b/po/reports.tr.po
@@ -5,6 +5,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: NeoIPC-Support@charite.de\n"
+"POT-Creation-Date: 2026-07-31 17:48+0200\n"
 "PO-Revision-Date: 2026-07-29 17:29+0000\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/neoipc/neoipc-reports/tr/>\n"
 "Language: tr\n"
@@ -283,10 +284,10 @@ msgstr ""
 msgid "Sum of patient days"
 msgstr ""
 
-#. type: Hash Value: headings antibiotic_utilisation
+#. type: Hash Value: headings antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic Utilisation"
+msgid "Antibiotic Utilization"
 msgstr ""
 
 #. type: Hash Value: headings antimicrobial_susceptibility_testing
@@ -385,10 +386,10 @@ msgstr ""
 msgid "The agent-per-infection rate measures how frequently specific pathogens are detected relative to the number of infections in which any infectious agent was identified. Values above 100% are expected and indicate polymicrobial infections. Diagnostic challenges specific to neonates — including low blood volume reducing culture sensitivity and elevated contamination risk — may influence detection patterns."
 msgstr ""
 
-#. type: Hash Value: methods antibiotic_utilisation
+#. type: Hash Value: methods antibiotic_utilization
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
+msgid "Antibiotic utilization is reported per individual substance, grouped by ATC pharmacological subgroup. The exposure density rate measures substance-days per 100 patient-days. Antibiotic days are counted from the first dose to the last dose of a therapy inclusive. Each substance is counted separately; a patient receiving two antibiotics on the same day contributes one day to each substance's tally. Because of combination therapy, the sum of individual substance rates can exceed the total antibiotic exposure rate shown in the risk and protective factors table."
 msgstr ""
 
 #. type: Hash Value: methods ci_quartile_auto_note
@@ -610,7 +611,7 @@ msgstr ""
 #. type: Hash Value: tbl-abr-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No resistant pathogen infection data available for this report settings."
+msgid "No resistant pathogen infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-abr-infection-rate pooled_footnote
@@ -670,7 +671,7 @@ msgstr ""
 #. type: Hash Value: tbl-agent-per-infection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent data available for this report settings."
+msgid "No infectious agent data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-agent-per-infection-rate pooled_footnote
@@ -709,58 +710,58 @@ msgstr ""
 msgid "Infectious agents detected in nosocomial infections"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation atc_footnote
+#. type: Hash Value: tbl-antibiotic-utilization atc_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "ATC: Anatomical Therapeutic Chemical classification (WHO). Substances are grouped by pharmacological subgroup (ATC 5th level). See %s for details."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation aware_column_footnote
+#. type: Hash Value: tbl-antibiotic-utilization aware_column_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "WHO AWaRe classification (Access, Watch, Reserve). See %s."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation exposure_density_rate
+#. type: Hash Value: tbl-antibiotic-utilization exposure_density_rate
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic Exposure Density Rate"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded across all infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation no_data
+#. type: Hash Value: tbl-antibiotic-utilization no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic utilisation data available for this report settings."
+msgid "No antibiotic utilization data available for these report settings."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation pooled_footnote
+#. type: Hash Value: tbl-antibiotic-utilization pooled_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated across all infants from all departments in the reference data."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation quartile_footnote
+#. type: Hash Value: tbl-antibiotic-utilization quartile_footnote
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Antibiotic Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of substance-days is greater than or equal to one according to the pooled rate."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation substance_days
+#. type: Hash Value: tbl-antibiotic-utilization substance_days
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Substance-days"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation tbl-cap
+#. type: Hash Value: tbl-antibiotic-utilization tbl-cap
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Antibiotic utilisation by pharmacological subgroup and substance"
+msgid "Antibiotic utilization by pharmacological subgroup and substance"
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates cvc
@@ -820,7 +821,7 @@ msgstr ""
 #. type: Hash Value: tbl-device-associated-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No device-associated infection data available for this report settings."
+msgid "No device-associated infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-device-associated-incidence-density-rates pooled_footnote
@@ -880,7 +881,7 @@ msgstr ""
 #. type: Hash Value: tbl-incidence-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infection data available for this report settings."
+msgid "No infection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-incidence-density-rates pooled_footnote
@@ -916,7 +917,7 @@ msgstr ""
 #. type: Hash Value: tbl-infectious-agent-detection-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No infectious agent detection data available for this report settings."
+msgid "No infectious agent detection data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-infectious-agent-detection-rate pooled_footnote
@@ -964,7 +965,7 @@ msgstr ""
 #. type: Hash Value: tbl-organism-resistance-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No organism-specific resistance data available for this report settings."
+msgid "No organism-specific resistance data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-organism-resistance-rate pooled_footnote
@@ -1024,7 +1025,7 @@ msgstr ""
 #. type: Hash Value: tbl-resistance-test-rate no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No antibiotic resistance diagnostics data available for this report settings."
+msgid "No antibiotic resistance diagnostics data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-resistance-test-rate pooled_footnote
@@ -1061,12 +1062,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "Antibiotic resistance diagnostics"
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates access
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Access"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates any
@@ -1108,7 +1103,7 @@ msgstr ""
 #. type: Hash Value: tbl-risk-density-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No risk/protective factor data available for this report settings."
+msgid "No risk/protective factor data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates pooled_footnote
@@ -1121,12 +1116,6 @@ msgstr ""
 #: reports/common.yaml:1
 #, no-wrap
 msgid "%s, %s, %s: The quartiles (%s, %s and %s quantiles) of the Exposure Density Rates of the departments in the reference data. Q₂ represents the median. These quartiles are only displayed when the number of departments contributing to the denominator is greater than or equal to five, and when the median number of device days is greater than or equal to one according to the pooled Exposure Density Rate."
-msgstr ""
-
-#. type: Hash Value: tbl-risk-density-rates reserve
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Reserve"
 msgstr ""
 
 #. type: Hash Value: tbl-risk-density-rates tbl-cap
@@ -1147,12 +1136,6 @@ msgstr ""
 msgid "Ventilatory support"
 msgstr ""
 
-#. type: Hash Value: tbl-risk-density-rates watch
-#: reports/common.yaml:1
-#, no-wrap
-msgid "Watch"
-msgstr ""
-
 #. type: Hash Value: tbl-secondary-bsi-rates n_footnote
 #: reports/common.yaml:1
 #, no-wrap
@@ -1162,7 +1145,7 @@ msgstr ""
 #. type: Hash Value: tbl-secondary-bsi-rates no_data
 #: reports/common.yaml:1
 #, no-wrap
-msgid "No secondary BSI data available for this report settings."
+msgid "No secondary BSI data available for these report settings."
 msgstr ""
 
 #. type: Hash Value: tbl-secondary-bsi-rates pooled_footnote
@@ -1303,10 +1286,10 @@ msgstr ""
 msgid "Surgical procedures by category"
 msgstr ""
 
-#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorised
+#. type: Hash Value: tbl-surgical-procedure-rates to_be_categorized
 #: reports/common.yaml:1
 #, no-wrap
-msgid "Not yet categorised"
+msgid "Not yet categorized"
 msgstr ""
 
 #. type: Hash Value: total
@@ -1522,7 +1505,7 @@ msgstr ""
 #. type: Hash Value: outlier abr_gram_positive_mrsa_high
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonisation, and contact isolation practices."
+msgid "Elevated methicillin-resistant Staphylococcus aureus (MRSA) rates may warrant review of screening, decolonization, and contact isolation practices."
 msgstr ""
 
 #. type: Hash Value: outlier abr_gram_positive_vre_high
@@ -1936,13 +1919,13 @@ msgstr ""
 #. type: Hash Value: outlier nec_interpretation_high_despite_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
+msgid "The necrotizing enterocolitis rate is above the reference range despite high human milk feeding and probiotic use. Other contributing factors may warrant assessment."
 msgstr ""
 
 #. type: Hash Value: outlier nec_interpretation_high_low_microbiome
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
+msgid "The necrotizing enterocolitis rate is above the reference range in a context where human milk feeding or probiotic use is below it. Microbiome-supportive strategies may be a relevant consideration."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_bsi action_elevated
@@ -2206,13 +2189,13 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec action_elevated
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotising enterocolitis risk."
+msgid "Strengthening lactation support, donor milk availability, or feeding pathways may help reduce necrotizing enterocolitis risk."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_narrowed
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "Case mix, feeding advancement protocols, and necrotising enterocolitis diagnostic criteria may warrant review."
+msgid "Case mix, feeding advancement protocols, and necrotizing enterocolitis diagnostic criteria may warrant review."
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec action_elevated_secondary
@@ -2230,7 +2213,7 @@ msgstr ""
 #. type: Hash Value: outlier pairing_nec metric_label
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "necrotising enterocolitis rate"
+msgid "necrotizing enterocolitis rate"
 msgstr ""
 
 #. type: Hash Value: outlier pairing_nec primary_paired_label
@@ -2491,13 +2474,13 @@ msgstr ""
 msgid "%s: The percentage of infections in your department where this infectious agent was detected."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in your department's infants."
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation rate_footnote
+#. type: Hash Value: tbl-antibiotic-utilization rate_footnote
 #: reports/Partner-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The Antibiotic Exposure Density Rate calculated for your department's infants."
@@ -2638,7 +2621,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Partner-Report/content/_infectious-agents.Rmd:3
 #, no-wrap
-msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotising enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
+msgid "In your data, `r dR$own$numberOfInfectiousAgents` infectious agents were detected in `r dR$own$numberOfInfectionsWithAgent` infections out of `r dR$own$overallNumberOfInfections` total infections (including sepsis/BSI, pneumonia, necrotizing enterocolitis, and surgical site infections), representing an infectious agent detection rate of `r dR$own$infectiousAgentDetectionRate` per 100 infections. The following tables provide detailed information on pathogen distribution and antimicrobial resistance patterns.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2720,9 +2703,9 @@ msgid "Antimicrobial susceptibility testing (AST) is fundamental to both individ
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_tbl-intro-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "@tbl-antibiotic-utilisation details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
+msgid "@tbl-antibiotic-utilization details antibiotic exposure at the level of individual substances, grouped by ATC pharmacological subgroup. Bold rows show the aggregated rate for each subgroup; indented rows show the rate for each substance within that subgroup. Comparing substance-level patterns with the reference data can help identify opportunities for antibiotic stewardship.\n"
 msgstr ""
 
 #. type: Plain text
@@ -2738,10 +2721,10 @@ msgid "@tbl-surgical-procedure-rates presents rates of various surgical procedur
 msgstr ""
 
 #. type: Plain text
-#: reports/Partner-Report/content/_methods-antibiotic-utilisation.Rmd:1
-#: reports/Reference-Report/content/_methods-antibiotic-utilisation.Rmd:1
+#: reports/Partner-Report/content/_methods-antibiotic-utilization.Rmd:1
+#: reports/Reference-Report/content/_methods-antibiotic-utilization.Rmd:1
 #, no-wrap
-msgid "`r sR$methods$antibiotic_utilisation`\n"
+msgid "`r sR$methods$antibiotic_utilization`\n"
 msgstr ""
 
 #. type: Plain text
@@ -3230,7 +3213,7 @@ msgstr ""
 msgid "Presence of Risk and Protective Factors"
 msgstr ""
 
-#. type: Hash Value: tbl-antibiotic-utilisation n_footnote
+#. type: Hash Value: tbl-antibiotic-utilization n_footnote
 #: reports/Reference-Report/content/_sR.yaml:1
 #, no-wrap
 msgid "%s: The aggregated number of substance-days recorded in all infants."
@@ -3269,7 +3252,7 @@ msgstr ""
 #. type: Plain text
 #: reports/Reference-Report/content/_nosocomial_infections.Rmd:2
 #, no-wrap
-msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotising enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
+msgid "Nosocomial infections represent the primary endpoint of NeoIPC surveillance. In`r dR$refIDRTable` the incidence densities of sepsis/BSI, pneumonia and necrotizing enterocolitis, as well as the combined endpoint 'severe infection', are displayed. Overall `r dR$numberOfSevereInfections` severe infections were recorded in `r dR$numberOfPatients` infants resulting in an average number of `r dR$averageSevereInfectionsPerPatient` infections per patient.\n"
 msgstr ""
 
 #. type: Plain text
@@ -3573,7 +3556,7 @@ msgstr ""
 #. type: Hash Value: problems 30 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The sepsis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The sepsis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 31 description
@@ -3597,31 +3580,31 @@ msgstr ""
 #. type: Hash Value: problems 34 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The pneumonia occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The pneumonia occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 35 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of life stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
+msgid "The day of life stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-17."
 msgstr ""
 
 #. type: Hash Value: problems 36 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The day of occurrence after admission stored in the necrotising enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
+msgid "The day of occurrence after admission stored in the necrotizing enterocolitis form (%i) does not match the calculated value (%i). See @sec-problem-details-18."
 msgstr ""
 
 #. type: Hash Value: problems 37 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
+msgid "The necrotizing enterocolitis occurred within the first 3 days of life (day of life is %i). See @sec-problem-details-19."
 msgstr ""
 
 #. type: Hash Value: problems 38 description
 #: reports/Validation-Report/content/_sR.yaml:1
 #, no-wrap
-msgid "The necrotising enterocolitis occurred within the first two days of hospitalisation of a referred or (re-)admitted patient (day of hospitalisation is %i). See @sec-problem-details-20."
+msgid "The necrotizing enterocolitis occurred within the first two days of hospitalization of a referred or (re-)admitted patient (day of hospitalization is %i). See @sec-problem-details-20."
 msgstr ""
 
 #. type: Hash Value: problems 39 description
@@ -3720,8 +3703,8 @@ msgstr ""
 msgid ""
 "To ensure that all partners can base their decisions on valid data, we strive for the highest possible data quality for the individual analyses and reference reports of the NeoIPC surveillance.\n"
 "Wherever possible, we try to check the validity of the data as soon as it is entered and, if necessary, ask the person entering the data to make corrections.\n"
-"Unfortunately, our surveillance platform cannot recognise all possible problems at the time of entry.\n"
-"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarise them in this report and send it to our partners with a request for correction.\n"
+"Unfortunately, our surveillance platform cannot recognize all possible problems at the time of entry.\n"
+"At regular intervals, especially before reference reports are created, we therefore try to identify these problems using special database queries, summarize them in this report and send it to our partners with a request for correction.\n"
 "To make the correction as efficient as possible, the report in @sec-problems contains a link for each patient record in which a problem has been identified, which leads directly to the Tracked Entity Instance Dashboard of the patient record in question.\n"
 "In addition, @sec-problem-details details the issues encountered so that you can understand the potential impact and ways to avoid the problem in the future.\n"
 "In @sec-solutions we have also outlined the various steps that can be taken to resolve the issue.\n"
@@ -3818,7 +3801,7 @@ msgstr ""
 msgid ""
 "What remains is a patient record without patient enrolment, which exists in the system as a data orphan.\n"
 "These patient records will not appear in the list of registered patients and their data cannot be listed in any reports, as most of the information required for analysis is missing.\n"
-"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognise that this ID is already being used by a different patient and will reject the entry.\n"
+"However, if you try to enter a new patient with the same NeoIPC Patient ID, the system will recognize that this ID is already being used by a different patient and will reject the entry.\n"
 msgstr ""
 
 #. type: Plain text
@@ -4377,7 +4360,7 @@ msgstr ""
 #. type: Title ###
 #: reports/Validation-Report/en/_problem_detail_0020.Rmd:1
 #, no-wrap
-msgid "The Infection Occurred Within the First Two Days of Hospitalisation of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
+msgid "The Infection Occurred Within the First Two Days of Hospitalization of a Referred or (Re-)Admitted Patient {#sec-problem-details-20}"
 msgstr ""
 
 #. type: Plain text


### PR DESCRIPTION
German, Spanish and Italian follow the report template after the house-spelling
settlement in #122.

Thirty-one strings across the three languages stopped being translated because
their source text changed and the units no longer exist. Nothing was demoted to
needing editing and nothing was emptied, so no translator's work is lost here.

Merge this with "Rebase and merge". A squash gives these commits a different
patch identity, after which Weblate cannot recognise its own work as already
merged and replays it into a conflict across every component at once.
