### PR TITLE
Scope the POT-Creation-Date rule to the catalogues this repository writes

### DIFF
--- a/scripts/modules/NeoIPC-Tools/Private/PoHeader.ps1
+++ b/scripts/modules/NeoIPC-Tools/Private/PoHeader.ps1
@@ -27,8 +27,20 @@
 # Project-Id-Version (its version suffix froze at 0.9 while the products moved on), X-Generator (a Weblate
 # version string, which rewrote every catalogue on each upgrade until po_set_x_generator was turned off),
 # Last-Translator (frozen by po_set_last_translator=false, so it named a translator who could never change),
-# and POT-Creation-Date in a CATALOGUE — msgmerge does not refresh it, so it had drifted three weeks out in
-# infectious_agents. It stays in the TEMPLATE, where the generator stamps it and it is true by construction.
+# and POT-Creation-Date in a REPOSITORY-OWNED CATALOGUE — no writer here refreshes it, so it had drifted three
+# weeks out in infectious_agents. It stays in the TEMPLATE, where the generator stamps it and it is true by
+# construction.
+#
+# A WEBLATE-OWNED CATALOGUE is exempt from that last one, because the premise behind it does not hold there.
+# Weblate rewrites the field from the template whenever the template changes, and the values it wrote after
+# the anchor and spelling work match their template byte for byte in every catalogue and language — so the
+# field is refreshed rather than stale, which is the only property the exclusion was ever protecting. The
+# exemption is not a preference: Weblate offers no way to suppress the field. Its ten po_* file-format
+# parameters cover X-Generator, Last-Translator, Language-Team and msgid-bug address, and none of them
+# touches this, so the alternative was a second writer on files Weblate owns — the arrangement this whole
+# contract exists to prevent. The residue is that between a template change and the next drain the catalogues
+# name the older template; that corrects itself on the drain and is why the exemption is granted by ownership
+# rather than by asserting the two agree, which would block every source-string change until someone drained.
 
 # English language names as Weblate writes them into Language-Team, and the plural rule it writes per language.
 # Sourced from the catalogues Weblate itself produced, not from a specification, so they match byte for byte.
@@ -41,6 +53,17 @@ $script:NeoIPCPoPluralForms = @{
     es = 'nplurals=2; plural=n != 1;'; et = 'nplurals=2; plural=n != 1;'; fr = 'nplurals=2; plural=n > 1;'
     it = 'nplurals=2; plural=n != 1;'; ne = 'nplurals=2; plural=n != 1;'; tr = 'nplurals=2; plural=n != 1;'
 }
+
+# The catalogues registered as Weblate components, named by the stem their files share. Weblate is their only
+# writer, which is what makes the POT-Creation-Date exemption above safe to grant to exactly these and to
+# nothing else. po/antibiotics.*.po and scripts/po/*.po are deliberately absent: neither is on Weblate, both
+# stay repository-owned, and a generator run or a hand edit there is legitimate. The catalogue-ownership job
+# in .github/workflows/build.yml states the same list as a bash regex for a check that cannot run PowerShell;
+# registering a catalogue on Weblate means adding it in both places, and de-registering means removing it
+# from both.
+$script:NeoIPCWeblateOwnedCatalogue = @(
+    'documentation', 'glossary', 'infectious_agents', 'metadata', 'reports'
+)
 
 function Test-NeoIPCPoNonHumanIdentity {
     # Whether a credit line names something other than a person, per po/non-human-identities.yaml.

--- a/scripts/modules/NeoIPC-Tools/Tests/PoHeader.Tests.ps1
+++ b/scripts/modules/NeoIPC-Tools/Tests/PoHeader.Tests.ps1
@@ -168,13 +168,28 @@ InModuleScope 'NeoIPC-Tools' {
             }
             $bad | Should -BeNullOrEmpty
         }
-        It 'keeps POT-Creation-Date in templates only' {
+        It 'keeps POT-Creation-Date in templates and out of repository-owned catalogues' {
             $bad = foreach ($f in $script:catalogues) {
                 $h = Get-CatalogueHeader -Path $f.FullName
-                if (-not $h.IsTemplate -and $h.Fields.Contains('POT-Creation-Date')) { "$($h.Name): has it" }
-                if ($h.IsTemplate -and -not $h.Fields.Contains('POT-Creation-Date')) { "$($h.Name): lacks it" }
+                $has = $h.Fields.Contains('POT-Creation-Date')
+                if ($h.IsTemplate) {
+                    if (-not $has) { "$($h.Name): lacks it" }
+                    continue
+                }
+                # Weblate rewrites the field from the template on every template change, so in the catalogues
+                # it owns the field is refreshed rather than stale, and staleness is the whole reason the
+                # field is excluded elsewhere. Private/PoHeader.ps1 carries the argument and the list.
+                if (($h.Name -split '\.')[0] -in $script:NeoIPCWeblateOwnedCatalogue) { continue }
+                if ($has) { "$($h.Name): has it" }
             }
             $bad | Should -BeNullOrEmpty
+        }
+        It 'exempts only the catalogues Weblate writes' {
+            # The exemption is sound only where Weblate is the writer. A catalogue this repository writes that
+            # gained the field would be stale by the original argument, so it must stay subject to the rule --
+            # antibiotics because its licence bars it from Weblate, scripts/po because its mechanism does.
+            $script:NeoIPCWeblateOwnedCatalogue | Should -Not -Contain 'antibiotics'
+            $script:NeoIPCWeblateOwnedCatalogue | Should -Not -Contain 'de'
         }
         It 'credits no non-human identity' {
             $bad = foreach ($f in $script:catalogues) {


### PR DESCRIPTION
Every Weblate drain currently fails `build-docs` on one assertion, and no drain
can merge until this lands.

The header contract keeps `POT-Creation-Date` out of a catalogue because nothing
refreshes it there — it had drifted three weeks out in the infectious-agent
catalogue, and a field that is silently wrong is worse than an absent one. That
premise does not hold for a catalogue Weblate owns. Weblate rewrites the field
from the template whenever the template changes, and the values it wrote after
the anchor and spelling work match their template byte for byte in every
catalogue and language, so the field is refreshed rather than stale.

Exempting them is not a preference either. Weblate offers no way to suppress the
field: its file-format parameters reach `X-Generator`, `Last-Translator`,
`Language-Team` and the msgid-bug address, and none of them touches this one. The
alternative was a second writer on files Weblate owns, which is what the
ownership model exists to prevent.

The exemption is granted by ownership rather than by asserting that a catalogue
and its template agree, because the stronger form would block every
source-string change until someone drained.

It stays narrow, and that is verified rather than assumed. A repository-owned
catalogue that gains the field still fails, named in the failure; the original
assertion fails against a drained catalogue; and a second assertion pins the
antibiotic and PowerShell-message catalogues outside the exemption, so neither
can drift into it silently.

The owned-catalogue list now exists in two places — here and as a bash regex in
the `catalogue-ownership` job, which cannot run PowerShell. Both say so and name
each other. Deriving one from the other would mean making that job shell out,
and it is load-bearing enough that trading a rewrite risk against drift in a
five-entry list was the wrong bargain.
